### PR TITLE
Add github CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,41 @@
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+name: build
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly 
+        features:
+          - default
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Generate cache key
+        run: echo "${{ matrix.rust }} ${{ matrix.features }}" | tee .cache_key
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('.cache_key') }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Set default toolchain
+        run: rustup default ${{ matrix.rust }}
+      - name: Set profile
+        run: rustup set profile minimal
+      - name: Update toolchain
+        run: rustup update
+      - name: Build
+        run: cargo build --features ${{ matrix.features }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+name: lint
+
+jobs:
+
+  fmt:
+    name: rust fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set default toolchain
+        run: rustup default nightly
+      - name: Set profile
+        run: rustup set profile minimal
+      - name: Add rustfmt
+        run: rustup component add rustfmt
+      - name: Add clippy
+        run: rustup component add clippy
+      - name: Update toolchain
+        run: rustup update
+      - name: Check fmt
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        #TODO: enable clippy when all clippy warnings are fixed.
+        #run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,42 @@
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+name: test
+
+jobs:
+  test_with_codecov:
+    name: Run tests with coverage reporting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set default toolchain
+        run: rustup default nightly
+      - name: Set profile
+        run: rustup set profile minimal
+
+      # Pin grcov to v0.8.2 because of build failure at 0.8.3
+      - name: Install grcov
+        run: cargo install grcov --force --version 0.8.2
+
+      # Tests are run with code coverage support
+      - name: Run cargo test
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+        run: cargo test -- --nocapture
+      - id: coverage
+        name: Generate coverage
+        uses: actions-rs/grcov@v0.1.5
+      
+      # Upload coverage report
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ${{ steps.coverage.outputs.report }}
+          directory: ./coverage/reports/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ lto = true
 codegen-units = 1
 panic = "abort"
 
-[build]
-profiler = true
-
 [dependencies]
 hex = "0.4.3"
 serde = { version = "1.0.0", features = ["derive"] }
@@ -33,3 +30,7 @@ electrum-client = "0.19.0"
 bitcoin = {version = "0.31.1", features = ["rand", "base64", "rand-std"]}
 elements = { version = "0.24.0", features = ["serde"] }
 lightning-invoice = "0.26.0"
+
+#Empty default feature set, (helpful to generalise in github actions)
+[features]
+default = []

--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -1035,7 +1035,7 @@ mod tests {
         let rs = "a91430dd7bf6e97514be2ec0d1368790f763184b7f848763210301798770066e9d93803ced62f169d06567683d26a180f87be736e1af00eaba116703fa0113b1752102c530b4583640ab3df5c75c5ce381c4b747af6bdd6c618db7e5248cb0adcf3a1868ac";
         let blinder = "89b7b9e32cb141787ae187f0d7db784eb114ea7e69da7be9bebafee3f3dbb64e";
         let exp_addr =
-            "vjU48EMUcaiFDvJxSdFoc9s7c94czG7cvawBkn82vt5gkE2Tjq9hXKqi3UyvPgrDgN1vi7V8mRvneTtT";
+            "tlq1qqdtkt2czrht3mjy7kwtauq0swtvr5tfxysvcekmrzraayu025wjl8537am2epmhzl40e27mpuxr2cp36emmmtudjquf5lruld437rz0tkqxu72j38yjz";
         let script = LBtcSwapScript::submarine_from_str(rs, blinder).unwrap();
         assert_eq!(
             script.to_address(Chain::LiquidTestnet).unwrap().to_string(),
@@ -1088,7 +1088,7 @@ mod tests {
 
         assert_eq!(address.to_string(), expected_address);
 
-        let mut liquid_swap_tx =
+        let liquid_swap_tx =
             LBtcSwapTx::new_claim(el_script, RETURN_ADDRESS.to_string(), network_config).unwrap();
         //let _ = liquid_swap_tx.fetch_utxo(&network_config).unwrap();
         println!("{:#?}", liquid_swap_tx);

--- a/src/util/secrets.rs
+++ b/src/util/secrets.rs
@@ -535,7 +535,7 @@ mod tests {
         };
         let file: RefundSwapFile = recovery.into();
         let base_path = "/tmp/boltz-rust";
-        file.write_to_file(base_path);
+        file.write_to_file(base_path).unwrap();
         let file_path = base_path.to_owned() + "/" + &file.file_name();
         let file_struct = RefundSwapFile::read_from_file(file_path);
         println!("Refund File: {:?}", file_struct);

--- a/tests/liquid.rs
+++ b/tests/liquid.rs
@@ -10,7 +10,7 @@ use boltz_client::{
         LBtcReverseRecovery, LBtcSubmarineRecovery, LiquidSwapKey, Preimage, RefundSwapFile,
         SwapKey,
     },
-    Keypair, Secp256k1, ZKKeyPair,
+    Keypair, ZKKeyPair,
 };
 pub mod test_utils;
 /// submarine swap integration


### PR DESCRIPTION
This PR adds github CI in the repo and fixes a test failure and some compiler warnings.

Note:
 - Clippy is disabled until all the clippy warnings are fixed.
 - Code coverage report is generated in CI. But requires maintainer's access to upload the report to codecov. Instructions here https://docs.codecov.com/docs/quick-start. Codecov would be an useful to measure test coverage which is important for low level bitcoin libs.  