### PR TITLE
Strict typing the internal structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,8 @@ codegen-units = 1
 panic = "abort"
 
 [dependencies]
-hex = "0.4.3"
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
-rand_core = {version = "0.6.4", features = ["getrandom"]}
 ureq = {version = "2.8.0", features = ["json"]}
 bip39 = "2.0.0"
 electrum-client = "0.19.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,7 @@ pub enum Error {
     BIP32(bitcoin::bip32::Error),
     BIP39(bip39::Error),
     Hash(bitcoin::hashes::FromSliceError),
+    Locktime(String),
 }
 
 impl From<electrum_client::Error> for Error {
@@ -137,5 +138,17 @@ impl From<bitcoin::hashes::FromSliceError> for Error {
 impl From<bip39::Error> for Error {
     fn from(value: bip39::Error) -> Self {
         Self::BIP39(value)
+    }
+}
+
+impl From<bitcoin::absolute::Error> for Error {
+    fn from(value: bitcoin::absolute::Error) -> Self {
+        Self::Locktime(value.to_string())
+    }
+}
+
+impl From<elements::locktime::Error> for Error {
+    fn from(value: elements::locktime::Error) -> Self {
+        Self::Locktime(value.to_string())
     }
 }

--- a/src/network/electrum.rs
+++ b/src/network/electrum.rs
@@ -4,9 +4,9 @@ use crate::error::Error;
 
 use super::Chain;
 
-pub const DEFAULT_TESTNET_NODE: &str = "electrum.bullbitcoin.com:60002";
+pub const DEFAULT_TESTNET_NODE: &str = "electrum.blockstream.info:60002";
 pub const DEFAULT_LIQUID_TESTNET_NODE: &str = "blockstream.info:465";
-pub const DEFAULT_MAINNET_NODE: &str = "electrum.bullbitcoin.com:50002";
+pub const DEFAULT_MAINNET_NODE: &str = "electrum.blockstream.info:50002";
 pub const DEFAULT_ELECTRUM_TIMEOUT: u8 = 10;
 
 #[derive(Debug, Clone)]

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -732,7 +732,7 @@ impl CreateSwapResponse {
         keypair: &ZKKeyPair,
         chain: Chain,
     ) -> Result<LBtcSwapScript, Error> {
-        self.validate_submarine(&preimage, &keypair, chain)?;
+        self.validate_reverse(&preimage, &keypair, chain)?;
         Ok(LBtcSwapScript::reverse_from_str(
             &self.get_redeem_script()?,
             &self.get_blinding_key()?,

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -35,7 +35,10 @@
 //! ```
 use crate::error::Error;
 use crate::network::Chain;
+use bitcoin::absolute::LockTime;
 use bitcoin::secp256k1::Keypair;
+use bitcoin::PublicKey;
+use bitcoin::ScriptBuf;
 use elements::secp256k1_zkp::Keypair as ZKKeyPair;
 use elements::secp256k1_zkp::Secp256k1 as ZKSecp256k1;
 use lightning_invoice::Bolt11Invoice;
@@ -747,13 +750,16 @@ impl CreateSwapResponse {
                 let boltz_sub_script =
                     BtcSwapScript::submarine_from_str(&self.get_redeem_script()?)?;
 
-                let constructed_sub_script = BtcSwapScript::new(
-                    SwapType::Submarine,
-                    &preimage.hash160.to_string(),
-                    &boltz_sub_script.receiver_pubkey,
-                    &self.get_timeout()?,
-                    &keypair.public_key().to_string(),
-                );
+                let constructed_sub_script = BtcSwapScript {
+                    swap_type: SwapType::Submarine,
+                    hashlock: preimage.hash160,
+                    receiver_pubkey: boltz_sub_script.receiver_pubkey,
+                    locktime: LockTime::from_height(self.get_timeout()?)?,
+                    sender_pubkey: bitcoin::PublicKey {
+                        compressed: true,
+                        inner: keypair.public_key(),
+                    },
+                };
                 let address = constructed_sub_script.to_address(chain)?;
                 if constructed_sub_script == boltz_sub_script
                     && address.to_string() == self.get_funding_address()?
@@ -771,7 +777,7 @@ impl CreateSwapResponse {
                     &self.get_redeem_script()?,
                     &blinding_key.clone(),
                 )?;
-                if &boltz_sub_script.hashlock != &preimage.hash160.to_string() {
+                if &boltz_sub_script.hashlock != &preimage.hash160 {
                     return Err(Error::Protocol(format!(
                         "Hash160 mismatch: {},{}",
                         boltz_sub_script.hashlock,
@@ -779,14 +785,17 @@ impl CreateSwapResponse {
                     )));
                 }
                 let secp = ZKSecp256k1::new();
-                let script = LBtcSwapScript::new(
-                    SwapType::Submarine,
-                    &preimage.hash160.to_string(),
-                    &boltz_sub_script.reciever_pubkey,
-                    self.get_timeout()?,
-                    &keypair.public_key().to_string(),
-                    &ZKKeyPair::from_seckey_str(&secp, &blinding_key)?.into(),
-                );
+                let script = LBtcSwapScript {
+                    swap_type: SwapType::Submarine,
+                    hashlock: preimage.hash160,
+                    reciever_pubkey: boltz_sub_script.reciever_pubkey,
+                    locktime: elements::LockTime::from_height(self.get_timeout()?)?,
+                    sender_pubkey: PublicKey {
+                        compressed: true,
+                        inner: keypair.public_key(),
+                    },
+                    blinding_key: ZKKeyPair::from_seckey_str(&secp, &blinding_key)?.into(),
+                };
 
                 let address = script.to_address(chain)?;
                 println!(
@@ -841,13 +850,16 @@ impl CreateSwapResponse {
             Chain::Bitcoin | Chain::BitcoinTestnet => {
                 let boltz_rev_script = BtcSwapScript::reverse_from_str(&self.get_redeem_script()?)?;
 
-                let constructed_rev_script = BtcSwapScript::new(
-                    SwapType::ReverseSubmarine,
-                    &preimage.hash160.to_string(),
-                    &keypair.public_key().to_string(),
-                    &(self.get_timeout()?),
-                    &boltz_rev_script.sender_pubkey,
-                );
+                let constructed_rev_script = BtcSwapScript {
+                    swap_type: SwapType::ReverseSubmarine,
+                    hashlock: preimage.hash160,
+                    receiver_pubkey: PublicKey {
+                        compressed: true,
+                        inner: keypair.public_key(),
+                    },
+                    locktime: LockTime::from_height(self.get_timeout()?)?,
+                    sender_pubkey: boltz_rev_script.sender_pubkey,
+                };
                 let address = constructed_rev_script.to_address(chain)?;
                 if constructed_rev_script == boltz_rev_script
                     && address.to_string() == self.get_lockup_address()?
@@ -864,14 +876,17 @@ impl CreateSwapResponse {
                     &blinding_key.clone(),
                 )?;
                 let secp = ZKSecp256k1::new();
-                let constructed_rev_script = LBtcSwapScript::new(
-                    SwapType::ReverseSubmarine,
-                    &preimage.hash160.to_string(),
-                    &keypair.public_key().to_string(),
-                    self.get_timeout()?,
-                    &boltz_rev_script.sender_pubkey,
-                    &ZKKeyPair::from_seckey_str(&secp, &blinding_key)?.into(),
-                );
+                let constructed_rev_script = LBtcSwapScript {
+                    swap_type: SwapType::ReverseSubmarine,
+                    hashlock: preimage.hash160,
+                    reciever_pubkey: PublicKey {
+                        compressed: true,
+                        inner: keypair.public_key(),
+                    },
+                    locktime: elements::LockTime::from_height(self.get_timeout()?)?,
+                    sender_pubkey: boltz_rev_script.sender_pubkey,
+                    blinding_key: ZKKeyPair::from_seckey_str(&secp, &blinding_key)?,
+                };
                 let address = constructed_rev_script.to_address(chain)?;
                 if constructed_rev_script == boltz_rev_script
                     && address.to_string() == self.get_lockup_address()?

--- a/tests/liquid.rs
+++ b/tests/liquid.rs
@@ -145,7 +145,7 @@ fn test_liquid_rsi() {
     println!("*******INVOICE****************");
     println!("{}", invoice.to_string());
     println!("timeoutBlockHeight: {}", response.get_timeout().unwrap());
-    println!("nLocktime: {}", boltz_script_elements.timelock);
+    println!("nLocktime: {}", boltz_script_elements.locktime);
     println!("");
     println!("Once you have paid the invoice, press enter to continue the tests.");
     println!("******************************");


### PR DESCRIPTION
This PR uses strict typing for all the internal SwapScript and SwapTx structures.

This also removes two redundant dependency, rand and hex. These are already available from the bitcoin library.