### PR TITLE
Test Framework + Claim/Refund Integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ bitcoin = {version = "0.31.1", features = ["rand", "base64", "rand-std"]}
 elements = { version = "0.24.0", features = ["serde"] }
 lightning-invoice = "0.26.0"
 
+[dev-dependencies]
+bitcoind = {version = "0.34.1", features = ["25_0"] }
+
 #Empty default feature set, (helpful to generalise in github actions)
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,6 @@ pub mod util;
 pub use bitcoin::secp256k1::{Keypair, Secp256k1};
 pub use elements::secp256k1_zkp::{Keypair as ZKKeyPair, Secp256k1 as ZKSecp256k1};
 pub use lightning_invoice::Bolt11Invoice;
+
+pub use swaps::bitcoin::{BtcSwapScript, BtcSwapTx};
+pub use swaps::boltz::{SwapTxKind, SwapType};

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -4,6 +4,7 @@ pub mod electrum;
 pub enum Chain {
     Bitcoin,
     BitcoinTestnet,
+    BitcoinRegtest,
     Liquid,
     LiquidTestnet,
 }

--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -237,12 +237,14 @@ impl BtcSwapScript {
         let script = self.to_script()?;
         let mut network = match network {
             Chain::Bitcoin => Network::Bitcoin,
-            _ => Network::Testnet,
+            Chain::BitcoinRegtest => Network::Regtest,
+            Chain::BitcoinTestnet => Network::Testnet,
+            _ => {
+                return Err(Error::Protocol(
+                    "Liquid chain used for Bitcoin operations".to_string(),
+                ))
+            }
         };
-        // Use regtest for integration tests
-        if cfg!(test) {
-            network = Network::Regtest;
-        }
         match self.swap_type {
             SwapType::Submarine => Ok(Address::p2shwsh(&script, network)),
             SwapType::ReverseSubmarine => Ok(Address::p2wsh(&script, network)),

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -746,7 +746,7 @@ impl CreateSwapResponse {
         chain: Chain,
     ) -> Result<(), Error> {
         match chain {
-            Chain::Bitcoin | Chain::BitcoinTestnet => {
+            Chain::Bitcoin | Chain::BitcoinTestnet | Chain::BitcoinRegtest => {
                 let boltz_sub_script =
                     BtcSwapScript::submarine_from_str(&self.get_redeem_script()?)?;
 
@@ -847,7 +847,7 @@ impl CreateSwapResponse {
             }
         }
         match chain {
-            Chain::Bitcoin | Chain::BitcoinTestnet => {
+            Chain::Bitcoin | Chain::BitcoinTestnet | Chain::BitcoinRegtest => {
                 let boltz_rev_script = BtcSwapScript::reverse_from_str(&self.get_redeem_script()?)?;
 
                 let constructed_rev_script = BtcSwapScript {

--- a/tests/regtest-claim.rs
+++ b/tests/regtest-claim.rs
@@ -1,0 +1,103 @@
+use bitcoin::absolute::LockTime;
+use bitcoin::key::rand::thread_rng;
+use bitcoin::key::{Keypair, PublicKey};
+use bitcoin::secp256k1::Secp256k1;
+use bitcoin::{Amount, OutPoint};
+use bitcoind::bitcoincore_rpc::json::ScanTxOutRequest;
+use bitcoind::bitcoincore_rpc::RpcApi;
+use boltz_client::network::Chain;
+use boltz_client::util::secrets::Preimage;
+use boltz_client::{BtcSwapScript, BtcSwapTx};
+use boltz_client::{SwapTxKind, SwapType};
+mod test_framework;
+use test_framework::TestFramework;
+
+#[test]
+fn test_reverse_claim_regtest() {
+    // Init test framework and get a test-wallet
+    let test_framework = TestFramework::init();
+
+    // Generate a random preimage and hash it.
+    let preimage = Preimage::new();
+
+    // Generate dummy receiver and sender's keypair
+    let secp = Secp256k1::new();
+    let recvr_keypair = Keypair::new(&secp, &mut thread_rng());
+    let sender_keypair = Keypair::new(&secp, &mut thread_rng());
+
+    // create a btc swap script.
+    let swap_script = BtcSwapScript {
+        swap_type: SwapType::ReverseSubmarine,
+        hashlock: preimage.hash160,
+        receiver_pubkey: PublicKey {
+            compressed: true,
+            inner: recvr_keypair.public_key(),
+        },
+        locktime: LockTime::from_height(200).unwrap(),
+        sender_pubkey: PublicKey {
+            compressed: true,
+            inner: sender_keypair.public_key(),
+        },
+    };
+
+    // Send coin the swapscript address and confirm tx
+    let swap_addrs = swap_script.to_address(Chain::BitcoinTestnet).unwrap();
+    let spk = swap_addrs.script_pubkey();
+    println!("spk: {}", spk);
+    test_framework.send_coins(&swap_addrs, Amount::from_sat(10000));
+    test_framework.generate_blocks(1);
+
+    let scan_request = ScanTxOutRequest::Single(format!("addr({})", swap_addrs));
+
+    let scan_result = test_framework
+        .as_ref()
+        .scan_tx_out_set_blocking(&[scan_request.clone()])
+        .unwrap();
+
+    assert_eq!(scan_result.unspents.len(), 1);
+    assert_eq!(scan_result.total_amount, Amount::from_sat(10000));
+
+    // Create a refund spending transaction from the swap
+    let utxo = scan_result
+        .unspents
+        .iter()
+        .map(|utxo| {
+            let outpoint = OutPoint::new(utxo.txid, utxo.vout);
+            (outpoint, utxo.amount.to_sat())
+        })
+        .last()
+        .expect("value expected");
+
+    let test_wallet = test_framework.get_test_wallet();
+    let refund_addrs = test_wallet
+        .get_new_address(None, None)
+        .unwrap()
+        .assume_checked();
+
+    let swap_tx = BtcSwapTx {
+        kind: SwapTxKind::Claim,
+        swap_script,
+        output_address: refund_addrs,
+        utxo,
+    };
+
+    let claim_tx = swap_tx.sign_claim(&recvr_keypair, &preimage, 1000).unwrap();
+
+    test_framework
+        .as_ref()
+        .send_raw_transaction(&claim_tx)
+        .unwrap();
+    test_framework.generate_blocks(1);
+
+    let scan_result = test_framework
+        .as_ref()
+        .scan_tx_out_set_blocking(&[scan_request])
+        .unwrap();
+
+    assert_eq!(scan_result.unspents.len(), 0);
+    assert_eq!(scan_result.total_amount, Amount::from_sat(0));
+
+    let test_balance = test_wallet.get_balance(None, None).unwrap();
+
+    assert_eq!(test_balance, Amount::from_sat(19000));
+}

--- a/tests/regtest-claim.rs
+++ b/tests/regtest-claim.rs
@@ -41,7 +41,7 @@ fn test_reverse_claim_regtest() {
     };
 
     // Send coin the swapscript address and confirm tx
-    let swap_addrs = swap_script.to_address(Chain::BitcoinTestnet).unwrap();
+    let swap_addrs = swap_script.to_address(Chain::BitcoinRegtest).unwrap();
     let spk = swap_addrs.script_pubkey();
     println!("spk: {}", spk);
     test_framework.send_coins(&swap_addrs, Amount::from_sat(10000));

--- a/tests/regtest-refund.rs
+++ b/tests/regtest-refund.rs
@@ -45,7 +45,7 @@ fn test_submarine_refund_regtest() {
     };
 
     // Send coin the swapscript address and confirm tx
-    let swap_addrs = swap_script.to_address(Chain::BitcoinTestnet).unwrap();
+    let swap_addrs = swap_script.to_address(Chain::BitcoinRegtest).unwrap();
     test_framework.send_coins(&swap_addrs, Amount::from_sat(10000));
     test_framework.generate_blocks(1);
 

--- a/tests/regtest-refund.rs
+++ b/tests/regtest-refund.rs
@@ -1,0 +1,107 @@
+use bitcoin::absolute::LockTime;
+use bitcoin::hashes::{hash160, Hash};
+use bitcoin::key::rand::rngs::OsRng;
+use bitcoin::key::rand::{thread_rng, RngCore};
+use bitcoin::key::{Keypair, PublicKey};
+use bitcoin::secp256k1::Secp256k1;
+use bitcoin::{Amount, OutPoint};
+use bitcoind::bitcoincore_rpc::json::ScanTxOutRequest;
+use bitcoind::bitcoincore_rpc::RpcApi;
+use boltz_client::network::Chain;
+use boltz_client::{BtcSwapScript, BtcSwapTx};
+use boltz_client::{SwapTxKind, SwapType};
+mod test_framework;
+use test_framework::TestFramework;
+
+#[test]
+fn test_submarine_refund_regtest() {
+    // Init test framework and get a test-wallet
+    let test_framework = TestFramework::init();
+
+    // Generate a random preimage and hash it.
+    let mut bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+
+    let hash160 = hash160::Hash::hash(&bytes);
+
+    // Generate dummy receiver and sender's keypair
+    let secp = Secp256k1::new();
+    let recvr_keypair = Keypair::new(&secp, &mut thread_rng());
+    let sender_keypair = Keypair::new(&secp, &mut thread_rng());
+
+    // create a btc swap script.
+    let swap_script = BtcSwapScript {
+        swap_type: SwapType::Submarine,
+        hashlock: hash160,
+        receiver_pubkey: PublicKey {
+            compressed: true,
+            inner: recvr_keypair.public_key(),
+        },
+        locktime: LockTime::from_height(200).unwrap(),
+        sender_pubkey: PublicKey {
+            compressed: true,
+            inner: sender_keypair.public_key(),
+        },
+    };
+
+    // Send coin the swapscript address and confirm tx
+    let swap_addrs = swap_script.to_address(Chain::BitcoinTestnet).unwrap();
+    test_framework.send_coins(&swap_addrs, Amount::from_sat(10000));
+    test_framework.generate_blocks(1);
+
+    let scan_request = ScanTxOutRequest::Single(format!("addr({})", swap_addrs));
+
+    let scan_result = test_framework
+        .as_ref()
+        .scan_tx_out_set_blocking(&[scan_request.clone()])
+        .unwrap();
+
+    assert_eq!(scan_result.unspents.len(), 1);
+    assert_eq!(scan_result.total_amount, Amount::from_sat(10000));
+
+    // Create a refund spending transaction from the swap
+    let utxo = scan_result
+        .unspents
+        .iter()
+        .map(|utxo| {
+            let outpoint = OutPoint::new(utxo.txid, utxo.vout);
+            (outpoint, utxo.amount.to_sat())
+        })
+        .last()
+        .expect("value expected");
+
+    let test_wallet = test_framework.get_test_wallet();
+    let refund_addrs = test_wallet
+        .get_new_address(None, None)
+        .unwrap()
+        .assume_checked();
+
+    let swap_tx = BtcSwapTx {
+        kind: SwapTxKind::Refund,
+        swap_script,
+        output_address: refund_addrs,
+        utxo,
+    };
+
+    let refund_tx = swap_tx.sign_refund(&sender_keypair, 1000).unwrap();
+
+    // Make the timelock matured and broadcast the spend
+    test_framework.generate_blocks(100);
+    test_framework
+        .as_ref()
+        .send_raw_transaction(&refund_tx)
+        .unwrap();
+    test_framework.generate_blocks(1);
+
+    let scan_result = test_framework
+        .as_ref()
+        .scan_tx_out_set_blocking(&[scan_request])
+        .unwrap();
+
+    assert_eq!(scan_result.unspents.len(), 0);
+    assert_eq!(scan_result.total_amount, Amount::from_sat(0));
+
+    let test_balance = test_wallet.get_balance(None, None).unwrap();
+
+    assert_eq!(test_balance, Amount::from_sat(19000));
+}

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -1,0 +1,91 @@
+use bitcoind::{
+    bitcoincore_rpc::{Client, RpcApi},
+    BitcoinD,
+};
+
+use bitcoin::{network::Network, Address, Amount};
+
+pub struct TestFramework {
+    bitcoind: BitcoinD,
+    mining_address: Address,
+    test_wallet: Client,
+}
+
+impl TestFramework {
+    /// Initializes the Bitcoind regtest backend, mines initial blocks,
+    /// creates a test-wallet and funds it with 10,000 sats.
+    pub fn init() -> Self {
+        let bitcoind = BitcoinD::from_downloaded().unwrap();
+
+        // Generate initial 101 blocks
+        let mining_address = bitcoind
+            .client
+            .get_new_address(None, None)
+            .unwrap()
+            .require_network(Network::Regtest)
+            .unwrap();
+        bitcoind
+            .client
+            .generate_to_address(101, &mining_address)
+            .unwrap();
+
+        let test_wallet = bitcoind.create_wallet("test-wallet").unwrap();
+
+        let test_addrs = test_wallet
+            .get_new_address(None, None)
+            .unwrap()
+            .require_network(Network::Regtest)
+            .unwrap();
+
+        bitcoind
+            .client
+            .send_to_address(
+                &test_addrs,
+                Amount::from_sat(10000),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        bitcoind
+            .client
+            .generate_to_address(1, &mining_address)
+            .unwrap();
+
+        let tf = Self {
+            bitcoind,
+            mining_address,
+            test_wallet,
+        };
+
+        tf
+    }
+
+    pub fn generate_blocks(&self, n: u64) {
+        self.bitcoind
+            .client
+            .generate_to_address(n, &self.mining_address)
+            .unwrap();
+    }
+
+    pub fn send_coins(&self, addr: &Address, amount: Amount) {
+        self.bitcoind
+            .client
+            .send_to_address(&addr, amount, None, None, None, None, None, None)
+            .unwrap();
+    }
+
+    pub fn get_test_wallet(&self) -> &Client {
+        &self.test_wallet
+    }
+}
+
+impl AsRef<Client> for TestFramework {
+    fn as_ref(&self) -> &Client {
+        &self.bitcoind.client
+    }
+}


### PR DESCRIPTION
This PR adds a basic test framework using the `bitcoind` crate. This is useful to test spending logic in regtest and verify that the most crucial part of the library is working. These tests are enforced in CI too.

This PR adds two integration tests using dummy swap values.
 - Claim: Spend the swap contract via a claim transaction using the preimage.
 - Refund: Spend the swap contract via a refund transaction using the timelock.
 
 Some modification of the spend transaction assembly logic was required. And few other auxiliary changes.