### PR TITLE
Boltz API V2 + Musig2 + Taproot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,13 @@ electrum-client = "0.19.0"
 bitcoin = {version = "0.31.1", features = ["rand", "base64", "rand-std"]}
 elements = { version = "0.24.0", features = ["serde"] }
 lightning-invoice = "0.26.0"
+tungstenite = { version = "0.21.0", features = ["native-tls"] }
+url = "2.5.0"
+log = "^0.4"
+env_logger = "0.7"
+
+[patch.crates-io]
+secp256k1-zkp = {git = "https://github.com/BlockstreamResearch/rust-secp256k1-zkp.git", rev = "60e631c24588a0c9e271badd61959294848c665d"}
 
 [dev-dependencies]
 bitcoind = {version = "0.34.1", features = ["25_0"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,10 @@ pub enum Error {
     BIP39(bip39::Error),
     Hash(bitcoin::hashes::FromSliceError),
     Locktime(String),
+    Url(url::ParseError),
+    WebSocket(tungstenite::Error),
+    Taproot(String),
+    Musig2(String),
 }
 
 impl From<electrum_client::Error> for Error {
@@ -150,5 +154,53 @@ impl From<bitcoin::absolute::Error> for Error {
 impl From<elements::locktime::Error> for Error {
     fn from(value: elements::locktime::Error) -> Self {
         Self::Locktime(value.to_string())
+    }
+}
+
+impl From<url::ParseError> for Error {
+    fn from(value: url::ParseError) -> Self {
+        Self::Url(value)
+    }
+}
+
+impl From<tungstenite::Error> for Error {
+    fn from(value: tungstenite::Error) -> Self {
+        Self::WebSocket(value)
+    }
+}
+
+impl From<bitcoin::taproot::TaprootError> for Error {
+    fn from(value: bitcoin::taproot::TaprootError) -> Self {
+        Self::Taproot(value.to_string())
+    }
+}
+
+impl From<bitcoin::taproot::TaprootBuilderError> for Error {
+    fn from(value: bitcoin::taproot::TaprootBuilderError) -> Self {
+        Self::Taproot(value.to_string())
+    }
+}
+
+impl From<elements::secp256k1_zkp::MusigTweakErr> for Error {
+    fn from(value: elements::secp256k1_zkp::MusigTweakErr) -> Self {
+        Self::Musig2(value.to_string())
+    }
+}
+
+impl From<elements::secp256k1_zkp::MusigNonceGenError> for Error {
+    fn from(value: elements::secp256k1_zkp::MusigNonceGenError) -> Self {
+        Self::Musig2(value.to_string())
+    }
+}
+
+impl From<elements::secp256k1_zkp::ParseError> for Error {
+    fn from(value: elements::secp256k1_zkp::ParseError) -> Self {
+        Self::Musig2(value.to_string())
+    }
+}
+
+impl From<elements::secp256k1_zkp::MusigSignError> for Error {
+    fn from(value: elements::secp256k1_zkp::MusigSignError) -> Self {
+        Self::Musig2(value.to_string())
     }
 }

--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -1,0 +1,340 @@
+use std::{collections::HashMap, fmt::format, net::TcpStream};
+
+use bitcoin::{
+    hashes::sha256, hex::DisplayHex, taproot::TapLeaf, PublicKey, ScriptBuf, Transaction,
+};
+use lightning_invoice::Bolt11Invoice;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tungstenite::{connect, stream::MaybeTlsStream, WebSocket};
+use ureq::json;
+
+use crate::{error::Error, network::Chain, util::secrets::Preimage};
+
+use super::boltz::GetFeeEstimationResponse;
+
+pub const BOLTZ_TESTNET_URL_V2: &str = "https://api.testnet.boltz.exchange/v2";
+pub const BOLTZ_MAINNET_URL_V2: &str = "https://api.boltz.exchange/v2";
+pub const BOLTZ_REGTEST: &str = "http://127.0.0.1:9001/v2";
+
+use url::Url;
+
+use elements::secp256k1_zkp::{
+    MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
+    MusigSessionId,
+};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct HeightResponse {
+    #[serde(rename = "BTC")]
+    pub btc: u32,
+    #[serde(rename = "L-BTC")]
+    pub lbtc: u32,
+}
+
+/// Various limits of swap parameters
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Limits {
+    /// Maximum swap amount
+    pub maximal: u64,
+    /// Minimum swap amount
+    pub minimal: u64,
+    /// Maximum amount allowed for zero-conf
+    pub maximal_zero_conf: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Fees {
+    /// The percentage of the "send amount" that is charged by Boltz as "Boltz Fee".
+    percentage: f64,
+    /// The network fees charged for locking up and claiming funds onchain. These values are absolute, denominated in 10 ** -8 of the quote asset.
+    miner_fees: u64,
+}
+
+/// Various swap parameters associated with different assets.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapParams {
+    /// Pair hash, representing an id for an asset-pair swap
+    pub hash: String,
+    /// The exchange rate of the pair
+    pub rate: f64,
+    /// The swap limits
+    pub limits: Limits,
+    /// Total fees required for the swap
+    pub fees: Fees,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwapResponse {
+    #[serde(rename = "BTC")]
+    btc: HashMap<String, SwapParams>,
+    #[serde(rename = "L-BTC")]
+    lbtc: HashMap<String, SwapParams>,
+}
+
+/// Reference Documnetation: https://docs.boltz.exchange/v/api/
+pub struct BoltzApiClientV2 {
+    base_url: String,
+}
+
+impl BoltzApiClientV2 {
+    pub fn new(base_url: &str) -> Self {
+        Self {
+            base_url: base_url.to_string(),
+        }
+    }
+
+    /// Returns the web socket connection to the boltz server
+    pub fn connect_ws(&self) -> Result<WebSocket<MaybeTlsStream<TcpStream>>, Error> {
+        let ws_string = self.base_url.clone().replace("http", "ws") + "/ws";
+        let (socket, response) = connect(Url::parse(&ws_string)?)?;
+        log::debug!("websocket response: {:?}", response);
+        Ok(socket)
+    }
+
+    /// Make a get request. returns the Response
+    fn get(&self, end_point: &str) -> Result<String, Error> {
+        let url = format!("{}/{}", self.base_url, end_point);
+        Ok(ureq::get(&url).call()?.into_string()?)
+    }
+
+    /// Make a Post request. Returns the Response
+    fn post(&self, end_point: &str, data: impl Serialize) -> Result<String, Error> {
+        let url = format!("{}/{}", self.base_url, end_point);
+        Ok(ureq::post(&url).send_json(data)?.into_string()?)
+    }
+
+    pub fn get_fee_estimation(&self) -> Result<GetFeeEstimationResponse, Error> {
+        Ok(serde_json::from_str(&self.get("chain/fees")?)?)
+    }
+
+    pub fn get_height(&self) -> Result<HeightResponse, Error> {
+        Ok(serde_json::from_str(&self.get("chain/heights")?)?)
+    }
+
+    pub fn get_pairs(&self) -> Result<SwapResponse, Error> {
+        Ok(serde_json::from_str(&self.get("swap/submarine")?)?)
+    }
+
+    pub fn post_swap_req(
+        &self,
+        swap_request: CreateSwapRequest,
+    ) -> Result<CreateSwapResponse, Error> {
+        let data = serde_json::to_value(swap_request)?;
+        Ok(serde_json::from_str(&self.post("swap/submarine", data)?)?)
+    }
+
+    pub fn get_claim_tx_details(&self, id: &String) -> Result<ClaimTxResponse, Error> {
+        let endpoint = format!("swap/submarine/{}/claim", id);
+        Ok(serde_json::from_str(&self.get(&endpoint)?)?)
+    }
+
+    pub fn post_claim_tx_details(
+        &self,
+        id: &String,
+        pub_nonce: MusigPubNonce,
+        partial_sig: MusigPartialSignature,
+    ) -> Result<Value, Error> {
+        let data = json!(
+            {
+                "pubNonce": pub_nonce.serialize().to_lower_hex_string(),
+                "partialSignature": partial_sig.serialize().to_lower_hex_string()
+            }
+        );
+        let endpoint = format!("swap/submarine/{}/claim", id);
+        Ok(serde_json::from_str(&self.post(&endpoint, data)?)?)
+    }
+
+    pub fn post_reverse_req(&self, req: CreateReverseReq) -> Result<ReverseResp, Error> {
+        Ok(serde_json::from_str(&self.post("swap/reverse", req)?)?)
+    }
+
+    pub fn get_reverse_tx(&self, id: &String) -> Result<ReverseSwapTxResp, Error> {
+        Ok(serde_json::from_str(
+            &self.get(&format!("swap/reverse/{}/transaction", id))?,
+        )?)
+    }
+
+    pub fn get_reverse_partial_sig(
+        &self,
+        id: &String,
+        preimage: &Preimage,
+        pub_nonce: &MusigPubNonce,
+        claim_tx_hex: &String,
+    ) -> Result<ReversePartialSig, Error> {
+        let data = json!(
+            {
+                "preimage": preimage.bytes.expect("expected").to_lower_hex_string(),
+                "pubNonce": pub_nonce.serialize().to_lower_hex_string(),
+                "transaction": claim_tx_hex,
+                "index": 0
+            }
+        );
+
+        let endpoint = format!("swap/reverse/{}/claim", id);
+        Ok(serde_json::from_str(&self.post(&endpoint, data)?)?)
+    }
+
+    pub fn broadcast_tx(&self, chain: Chain, tx_hex: &String) -> Result<Value, Error> {
+        let data = json!(
+            {
+                "hex": tx_hex
+            }
+        );
+
+        let chain = match chain {
+            Chain::Bitcoin | Chain::BitcoinRegtest | Chain::BitcoinTestnet => "BTC",
+            Chain::Liquid | Chain::LiquidTestnet => "L-BTC",
+        };
+
+        let end_point = format!("chain/{}/transaction", chain);
+        Ok(serde_json::from_str(&self.post(&end_point, data)?)?)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimTxResponse {
+    pub preimage: String,
+    pub pub_nonce: String,
+    pub public_key: PublicKey,
+    pub transaction_hash: String,
+}
+
+/// Various swap parameters associated with different assets.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimTxData {
+    /// Pair hash, representing an id for an asset-pair swap
+    pub hash: String,
+    /// The exchange rate of the pair
+    pub rate: f64,
+    /// The swap limits
+    pub limits: Limits,
+    /// Total fees required for the swap
+    pub fees: Fees,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateSwapRequest {
+    pub from: String,
+    pub to: String,
+    pub invoice: String,
+    pub refund_public_key: PublicKey,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateSwapResponse {
+    accept_zero_conf: bool,
+    pub address: String,
+    bip21: String,
+    pub claim_public_key: PublicKey,
+    pub expected_amount: u64,
+    pub id: String,
+    pub swap_tree: SwapTree,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapTree {
+    pub claim_leaf: Leaf,
+    pub refund_leaf: Leaf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Leaf {
+    pub output: ScriptBuf,
+    pub version: u8,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Subscription {
+    op: String,
+    channel: String,
+    args: Vec<String>,
+}
+
+impl Subscription {
+    pub fn new(id: &String) -> Self {
+        Self {
+            op: "subscribe".to_string(),
+            channel: "swap.update".to_string(),
+            args: vec![id.clone()],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateReverseReq {
+    pub invoice_amount: u32,
+    pub from: String,
+    pub to: String,
+    pub preimage_hash: sha256::Hash,
+    pub claim_public_key: PublicKey,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReverseResp {
+    pub id: String,
+    pub invoice: String,
+    pub swap_tree: SwapTree,
+    pub lockup_address: String,
+    pub refund_public_key: PublicKey,
+    pub timeout_block_height: u32,
+    pub onchain_amount: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReverseSwapTxResp {
+    pub id: String,
+    pub hex: String,
+    pub timeout_block_height: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReversePartialSig {
+    pub pub_nonce: String,
+    pub partial_signature: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Update {
+    pub id: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RespError {
+    pub id: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SwapUpdate {
+    Subscription {
+        event: String,
+        channel: String,
+        args: Vec<String>,
+    },
+    Update {
+        event: String,
+        channel: String,
+        args: Vec<Update>,
+    },
+    Error {
+        event: String,
+        channel: String,
+        args: Vec<RespError>,
+    },
+}

--- a/src/swaps/btc_swapper.rs
+++ b/src/swaps/btc_swapper.rs
@@ -1,0 +1,602 @@
+use std::str::FromStr;
+
+use bitcoin::{
+    absolute::LockTime,
+    consensus::{deserialize, serialize},
+    hashes::{sha256, Hash},
+    hex::{DisplayHex, FromHex},
+    key::{
+        rand::{rngs::OsRng, thread_rng, RngCore},
+        Keypair, Secp256k1,
+    },
+    secp256k1::{Message, SecretKey},
+    sighash::{Prevouts, SighashCache},
+    taproot::{LeafVersion, Signature, TaprootBuilder},
+    transaction::Version,
+    Address, Amount, OutPoint, PublicKey, ScriptBuf, Sequence, TapSighashType, Transaction, TxIn,
+    TxOut, Witness, XOnlyPublicKey,
+};
+use elements::secp256k1_zkp::{
+    MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
+    MusigSessionId,
+};
+use lightning_invoice::Bolt11Invoice;
+
+use crate::{
+    error::Error,
+    network::Chain,
+    swaps::boltzv2::{
+        CreateReverseReq, CreateSwapRequest, Subscription, SwapUpdate, BOLTZ_REGTEST,
+    },
+    util::{secrets::Preimage, setup_logger},
+};
+
+use super::boltzv2::{BoltzApiClientV2, ClaimTxResponse, CreateSwapResponse, ReverseResp};
+
+pub struct BtcSwapper {
+    chain: Chain,
+    api: BoltzApiClientV2,
+    keypair: Keypair,
+}
+
+impl BtcSwapper {
+    /// Initialize a swapper
+    pub fn init(boltz_url: &str, chain: Chain) -> Self {
+        let secp = Secp256k1::new();
+
+        let keypair = Keypair::new(&secp, &mut thread_rng());
+
+        Self {
+            chain,
+            api: BoltzApiClientV2::new(boltz_url),
+            keypair,
+        }
+    }
+
+    /// Compute the Musig partial signature
+    fn submarine_partial_sig(
+        &self,
+        create_swap_response: &CreateSwapResponse,
+        claim_tx_response: &ClaimTxResponse,
+    ) -> Result<(MusigPartialSignature, MusigPubNonce), Error> {
+        // Step 1: Start with a Musig KeyAgg Cache
+        let secp = Secp256k1::new();
+
+        let pubkeys = [
+            create_swap_response.claim_public_key.inner,
+            self.keypair.public_key(),
+        ];
+
+        let mut key_agg_cache = MusigKeyAggCache::new(&secp, &pubkeys);
+
+        // Step 2: Build the Taporoot
+        let internal_key = key_agg_cache.agg_pk();
+
+        let taproot_builder = TaprootBuilder::new();
+
+        let (claim_script, claim_version) = (
+            create_swap_response.swap_tree.claim_leaf.output.clone(),
+            LeafVersion::from_consensus(create_swap_response.swap_tree.claim_leaf.version)?,
+        );
+        let (refund_script, refund_version) = (
+            create_swap_response.swap_tree.refund_leaf.output.clone(),
+            LeafVersion::from_consensus(create_swap_response.swap_tree.refund_leaf.version)?,
+        );
+
+        let taproot_builder = taproot_builder.add_leaf_with_ver(1, claim_script, claim_version)?;
+        let taproot_builder =
+            taproot_builder.add_leaf_with_ver(1, refund_script, refund_version)?;
+
+        let taproot_spend_info = taproot_builder.finalize(&secp, internal_key).unwrap(); // Taproot finalizing in unfailable
+
+        // Verify taproot construction
+        let output_key = taproot_spend_info.output_key();
+
+        let lockup_spk = Address::from_str(&create_swap_response.address)?
+            .assume_checked()
+            .script_pubkey();
+
+        let pubkey_instruction = lockup_spk
+            .instructions()
+            .last()
+            .expect("should contain value")
+            .expect("should not fail");
+
+        let lockup_xonly_pubkey_bytes = pubkey_instruction
+            .push_bytes()
+            .expect("pubkey bytes expected");
+
+        let lockup_xonly_pubkey = XOnlyPublicKey::from_slice(lockup_xonly_pubkey_bytes.as_bytes())?;
+
+        debug_assert!(lockup_xonly_pubkey == output_key.to_inner());
+
+        log::info!("Taproot creation and verification success!");
+
+        // Step 3: Tweak the Key Cache with Taproot tweak
+        let tweak = taproot_spend_info.tap_tweak();
+
+        let tweaked_pubkey = key_agg_cache
+            .pubkey_xonly_tweak_add(&secp, SecretKey::from_slice(&tweak.to_byte_array())?)?;
+
+        debug_assert!(output_key.to_inner() == tweaked_pubkey.x_only_public_key().0);
+
+        log::info!("Musig2 tweaking success!");
+
+        let session_id = MusigSessionId::new(&mut thread_rng());
+
+        let msg = Message::from_digest_slice(
+            &Vec::from_hex(&claim_tx_response.transaction_hash).unwrap(),
+        )?;
+
+        // Step 4: Start the Musig2 Signing session
+        let mut extra_rand = [0u8; 32];
+        OsRng.fill_bytes(&mut extra_rand);
+
+        let (sec_nonce, pub_nonce) = key_agg_cache.nonce_gen(
+            &secp,
+            session_id,
+            self.keypair.public_key(),
+            msg,
+            Some(extra_rand),
+        )?;
+
+        let boltz_nonce = MusigPubNonce::from_slice(&Vec::from_hex(&claim_tx_response.pub_nonce)?)?;
+
+        let agg_nonce = MusigAggNonce::new(&secp, &[boltz_nonce, pub_nonce]);
+
+        let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+
+        let partial_sig =
+            musig_session.partial_sign(&secp, sec_nonce, &self.keypair, &key_agg_cache)?;
+
+        let is_partial_sig_valid = musig_session.partial_verify(
+            &secp,
+            &key_agg_cache,
+            partial_sig,
+            pub_nonce,
+            self.keypair.public_key(),
+        );
+
+        debug_assert!(is_partial_sig_valid == true);
+
+        log::info!("Partial Signature creation and verification success.");
+
+        Ok((partial_sig, pub_nonce))
+    }
+
+    /// Compute the final signed claim tx for reverse swap
+    fn reverse_claim_tx(
+        &self,
+        reverse_resp: &ReverseResp,
+        preimage: &Preimage,
+        destination: Address,
+        fee: Amount,
+    ) -> Result<Transaction, Error> {
+        // Get the tx in mempool
+        let tx_resp = self.api.get_reverse_tx(&reverse_resp.id).unwrap();
+
+        let lockup_tx: Transaction = deserialize(&Vec::from_hex(&tx_resp.hex).unwrap()).unwrap();
+
+        let secp = Secp256k1::new();
+        // Start Musig
+
+        // Step 1: Setup Key Aggregation cache
+        let boltz_pubkey = reverse_resp.refund_public_key;
+        let pubkeys = [boltz_pubkey.inner, self.keypair.public_key()];
+
+        let mut key_agg_cache = MusigKeyAggCache::new(&secp, &pubkeys);
+
+        //Step 2: Construct the Taproot
+        let internal_key = key_agg_cache.agg_pk();
+
+        let taproot_builder = TaprootBuilder::new();
+
+        let (claim_script, claim_version) = (
+            reverse_resp.swap_tree.claim_leaf.output.clone(),
+            LeafVersion::from_consensus(reverse_resp.swap_tree.claim_leaf.version).unwrap(),
+        );
+        let (refund_script, refund_version) = (
+            reverse_resp.swap_tree.refund_leaf.output.clone(),
+            LeafVersion::from_consensus(reverse_resp.swap_tree.refund_leaf.version).unwrap(),
+        );
+
+        let taproot_builder = taproot_builder
+            .add_leaf_with_ver(1, claim_script, claim_version)
+            .unwrap();
+        let taproot_builder = taproot_builder
+            .add_leaf_with_ver(1, refund_script, refund_version)
+            .unwrap();
+
+        let taproot_spend_info = taproot_builder.finalize(&secp, internal_key).unwrap();
+
+        // Verify taproot construction
+        let output_key = taproot_spend_info.output_key();
+
+        let lockup_spk = Address::from_str(&reverse_resp.lockup_address)
+            .unwrap()
+            .assume_checked()
+            .script_pubkey();
+
+        let pubkey_instruction = lockup_spk.instructions().last().expect("expected").unwrap();
+
+        let lockup_xonly_pubkey_bytes = pubkey_instruction
+            .push_bytes()
+            .expect("pubkey bytes expected");
+
+        let lockup_xonly_pubkey =
+            XOnlyPublicKey::from_slice(lockup_xonly_pubkey_bytes.as_bytes()).unwrap();
+
+        assert_eq!(lockup_xonly_pubkey, output_key.to_inner());
+
+        log::info!("Taproot creation and verification success!");
+
+        // Step 3: Tweak the Musig aggregated key with the taproot tweak
+        let tweak = taproot_spend_info.tap_tweak();
+
+        let tweaked_pubkey = key_agg_cache
+            .pubkey_xonly_tweak_add(
+                &secp,
+                SecretKey::from_slice(&tweak.to_byte_array()).unwrap(),
+            )
+            .unwrap();
+
+        debug_assert!(output_key.to_inner() == tweaked_pubkey.x_only_public_key().0);
+
+        log::info!("Musig2 tweaking success!");
+
+        // Step 4: Start the Musig Session
+        let session_id = MusigSessionId::new(&mut thread_rng());
+
+        // Step 5: Create the claim Tx
+        let (lockup_outpoint, lockup_txout) = {
+            let txid = lockup_tx.txid();
+            let (vout, txout) = lockup_tx
+                .output
+                .iter()
+                .enumerate()
+                .find(|(index, txout)| txout.script_pubkey == lockup_spk)
+                .expect("atleast one output expected");
+            (OutPoint::new(txid, vout as u32), txout)
+        };
+
+        let txin = TxIn {
+            previous_output: lockup_outpoint,
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            script_sig: ScriptBuf::new(),
+            witness: Witness::new(),
+        };
+
+        let destination_spk = destination.script_pubkey();
+
+        let txout = TxOut {
+            script_pubkey: destination_spk,
+            value: lockup_txout.value - fee,
+        };
+
+        let mut claim_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![txin],
+            output: vec![txout],
+        };
+
+        let claim_tx_taproot_hash = SighashCache::new(claim_tx.clone())
+            .taproot_key_spend_signature_hash(
+                0,
+                &Prevouts::All(&[lockup_txout]),
+                bitcoin::TapSighashType::Default,
+            )
+            .unwrap();
+
+        // Step 6: Generate secret and public nonces
+        let msg = Message::from_digest_slice(claim_tx_taproot_hash.as_byte_array()).unwrap();
+
+        let mut extra_rand = [0u8; 32];
+        OsRng.fill_bytes(&mut extra_rand);
+
+        let (sec_nonce, pub_nonce) = key_agg_cache
+            .nonce_gen(
+                &secp,
+                session_id,
+                self.keypair.public_key(),
+                msg,
+                Some(extra_rand),
+            )
+            .unwrap();
+
+        // Step 7: Get boltz's partail sig
+        let claim_tx_hex = serialize(&claim_tx).to_lower_hex_string();
+        let partial_sig_resp = self
+            .api
+            .get_reverse_partial_sig(&reverse_resp.id, &preimage, &pub_nonce, &claim_tx_hex)
+            .unwrap();
+
+        let boltz_nonce =
+            MusigPubNonce::from_slice(&Vec::from_hex(&partial_sig_resp.pub_nonce).unwrap())
+                .unwrap();
+
+        let boltz_partial_sig = MusigPartialSignature::from_slice(
+            &Vec::from_hex(&partial_sig_resp.partial_signature).unwrap(),
+        )
+        .unwrap();
+
+        // Step 7: Perform
+
+        let agg_nonce = MusigAggNonce::new(&secp, &[boltz_nonce, pub_nonce]);
+
+        let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+
+        let our_partial_sig = musig_session
+            .partial_sign(&secp, sec_nonce, &self.keypair, &key_agg_cache)
+            .unwrap();
+
+        let schnorr_sig = musig_session.partial_sig_agg(&[boltz_partial_sig, our_partial_sig]);
+
+        let final_schnorr_sig = Signature {
+            sig: schnorr_sig,
+            hash_ty: TapSighashType::Default,
+        };
+
+        let mut witness = Witness::new();
+        witness.push(final_schnorr_sig.to_vec());
+
+        claim_tx.input[0].witness = witness;
+
+        let claim_tx_hex = serialize(&claim_tx).to_lower_hex_string();
+
+        // Verify the sigs. These are both failing.
+        let boltz_partial_sig_verify = musig_session.partial_verify(
+            &secp,
+            &key_agg_cache,
+            boltz_partial_sig,
+            boltz_nonce,
+            boltz_pubkey.inner,
+        );
+
+        debug_assert!(boltz_partial_sig_verify == true);
+
+        let final_sig_verify =
+            secp.verify_schnorr(&final_schnorr_sig.sig, &msg, &output_key.to_inner())?;
+
+        debug_assert!(final_sig_verify == ());
+
+        Ok(claim_tx)
+    }
+
+    /// Perform a submarine swap with Boltz
+    pub fn do_submarine(&self, invoice: &str) -> Result<(), Error> {
+        setup_logger();
+
+        let refund_public_key = PublicKey {
+            inner: self.keypair.public_key(),
+            compressed: true,
+        };
+
+        let data = CreateSwapRequest {
+            from: "BTC".to_string(),
+            to: "BTC".to_string(),
+            invoice: invoice.to_string(),
+            refund_public_key,
+        };
+
+        let invoice = Bolt11Invoice::from_str(&data.invoice).unwrap();
+
+        let create_swap_response = self.api.post_swap_req(data).unwrap();
+
+        log::info!("Got Swap Response from Boltz server");
+
+        log::debug!("Swap Response: {:?}", create_swap_response);
+
+        let mut socket = self.api.connect_ws()?;
+
+        let subscription = Subscription::new(&create_swap_response.id);
+
+        socket.send(tungstenite::Message::Text(
+            serde_json::to_string(&subscription).unwrap(),
+        ))?;
+
+        loop {
+            let response = serde_json::from_str(&socket.read().unwrap().to_string());
+
+            if response.is_err() {
+                if response.err().expect("expected").is_eof() {
+                    continue;
+                }
+            } else {
+                match response.unwrap() {
+                    SwapUpdate::Subscription {
+                        event,
+                        channel,
+                        args,
+                    } => {
+                        debug_assert!(event == "subscribe");
+                        debug_assert!(channel == "swap.update");
+                        debug_assert!(args.get(0).expect("expected") == &create_swap_response.id);
+                        log::info!(
+                            "Subscription successful for swap : {}",
+                            create_swap_response.id
+                        );
+                    }
+
+                    SwapUpdate::Update {
+                        event,
+                        channel,
+                        args,
+                    } => {
+                        debug_assert!(event == "update");
+                        debug_assert!(channel == "swap.update");
+                        let update = args.get(0).expect("expected");
+                        assert!(update.id == create_swap_response.id);
+                        log::info!("Got Update from server: {}", update.status);
+
+                        if update.status == "invoice.set" {
+                            log::info!(
+                                "Send {} sats to BTC address {}",
+                                create_swap_response.expected_amount,
+                                create_swap_response.address
+                            );
+                        }
+
+                        if update.status == "transaction.claim.pending" {
+                            // Step 1: Get the claim tx details and check preimage hash
+                            let claim_tx_response =
+                                self.api.get_claim_tx_details(&create_swap_response.id)?;
+
+                            log::debug!("Received claim tx details : {:?}", claim_tx_response);
+
+                            let preimage = Vec::from_hex(&claim_tx_response.preimage)?;
+
+                            let preimage_hash = sha256::Hash::hash(&preimage);
+
+                            let invoice_payment_hash = invoice.payment_hash();
+
+                            if invoice_payment_hash.to_string() != preimage_hash.to_string() {
+                                return Err(Error::Protocol(
+                                    "Preimage Hash missmatch with LN invoice".to_string(),
+                                ));
+                            }
+
+                            log::info!("Correct Claim TX Response Received from Boltz.");
+
+                            let (partial_sig, pub_nonce) = self
+                                .submarine_partial_sig(&create_swap_response, &claim_tx_response)?;
+
+                            self.api.post_claim_tx_details(
+                                &create_swap_response.id,
+                                pub_nonce,
+                                partial_sig,
+                            )?;
+
+                            log::info!("Successfully Sent partial signature");
+                        }
+
+                        if update.status == "transaction.claimed" {
+                            log::info!("Successfully completed sunmarine swap");
+                            return Ok(());
+                        }
+                    }
+
+                    SwapUpdate::Error {
+                        event,
+                        channel,
+                        args,
+                    } => {
+                        assert!(event == "update");
+                        assert!(channel == "swap.update");
+                        let error = args.get(0).expect("expected");
+                        log::error!(
+                            "Got Boltz response error : {} for swap: {}",
+                            error.error,
+                            error.id
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Perform a reverse swap with Boltz
+    pub fn do_reverse_swap(
+        &self,
+        invoice_amount: u32,
+        claim_addrs: Address,
+        claim_tx_fee: Amount,
+    ) -> Result<(), Error> {
+        setup_logger();
+        let preimage = Preimage::new();
+
+        let create_reverse_req = CreateReverseReq {
+            invoice_amount,
+            from: "BTC".to_string(),
+            to: "BTC".to_string(),
+            preimage_hash: preimage.sha256,
+            claim_public_key: PublicKey {
+                compressed: true,
+                inner: self.keypair.public_key(),
+            },
+        };
+
+        let reverse_resp = self.api.post_reverse_req(create_reverse_req).unwrap();
+
+        log::debug!("Got Reverse swap response: {:?}", reverse_resp);
+
+        let mut socket = self.api.connect_ws()?;
+
+        let subscription = Subscription::new(&reverse_resp.id);
+
+        socket.send(tungstenite::Message::Text(
+            serde_json::to_string(&subscription).unwrap(),
+        ))?;
+
+        loop {
+            let response = serde_json::from_str(&socket.read().unwrap().to_string());
+
+            if response.is_err() {
+                if response.err().expect("expected").is_eof() {
+                    continue;
+                }
+            } else {
+                match response.as_ref().unwrap() {
+                    SwapUpdate::Subscription {
+                        event,
+                        channel,
+                        args,
+                    } => {
+                        debug_assert!(event == "subscribe");
+                        debug_assert!(channel == "swap.update");
+                        debug_assert!(args.get(0).expect("expected") == &reverse_resp.id);
+                        log::info!("Subscription successful for swap : {}", reverse_resp.id);
+                    }
+
+                    SwapUpdate::Update {
+                        event,
+                        channel,
+                        args,
+                    } => {
+                        debug_assert!(event == "update");
+                        debug_assert!(channel == "swap.update");
+                        let update = args.get(0).expect("expected");
+                        debug_assert!(&update.id == &reverse_resp.id);
+                        log::info!("Got Update from server: {}", update.status);
+
+                        if update.status == "swap.created" {
+                            log::info!("Waiting for Invoice to be paid: {}", reverse_resp.invoice);
+                            continue;
+                        }
+
+                        if update.status == "transaction.mempool" {
+                            let tx = self.reverse_claim_tx(
+                                &reverse_resp,
+                                &preimage,
+                                claim_addrs.clone(),
+                                claim_tx_fee,
+                            )?;
+
+                            let claim_tx_hex = serialize(&tx).to_lower_hex_string();
+                            self.api.broadcast_tx(self.chain, &claim_tx_hex)?;
+
+                            log::info!("Succesfully broadcasted claim tx!");
+                            log::debug!("Claim Tx Hex: {}", claim_tx_hex);
+                        }
+
+                        if update.status == "invoice.settled" {
+                            log::info!("Reverse Swap Successful!");
+                            return Ok(());
+                        }
+                    }
+
+                    SwapUpdate::Error {
+                        event,
+                        channel,
+                        args,
+                    } => {
+                        assert!(event == "update");
+                        assert!(channel == "swap.update");
+                        let error = args.get(0).expect("expected");
+                        println!("Got error : {} for swap: {}", error.error, error.id);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/swaps/mod.rs
+++ b/src/swaps/mod.rs
@@ -1,3 +1,5 @@
 pub mod bitcoin;
 pub mod boltz;
+pub mod boltzv2;
+pub mod btc_swapper;
 pub mod liquid;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,2 +1,18 @@
+use std::{env, sync::Once};
+
 pub mod ec;
 pub mod secrets;
+
+/// Setup function that will only run once, even if called multiple times.
+pub fn setup_logger() {
+    Once::new().call_once(|| {
+        env::set_var("RUST_LOG", "info");
+        env_logger::Builder::from_env(
+            env_logger::Env::default()
+                .default_filter_or("coinswap=info")
+                .default_write_style_or("always"),
+        )
+        // .is_test(true)
+        .init();
+    });
+}

--- a/tests/test_v2_api.rs
+++ b/tests/test_v2_api.rs
@@ -1,0 +1,41 @@
+use std::str::FromStr;
+
+use bitcoin::{Address, Amount};
+use boltz_client::{
+    network::Chain,
+    swaps::{boltzv2::BOLTZ_REGTEST, btc_swapper::BtcSwapper},
+};
+
+#[test]
+fn test_v2_submarine() {
+    let swapper = BtcSwapper::init(BOLTZ_REGTEST, Chain::BitcoinRegtest);
+
+    println!("Enter a BOLT-11 Invoice with minimum 60,000 sats");
+
+    let mut invoice = String::new();
+
+    std::io::stdin().read_line(&mut invoice).unwrap();
+
+    let invoice = invoice.trim();
+    swapper.do_submarine(&invoice).unwrap();
+}
+
+#[test]
+fn test_v2_reverse() {
+    let swapper = BtcSwapper::init(BOLTZ_REGTEST, Chain::BitcoinRegtest);
+
+    let mut claim_addrs_str = String::new();
+
+    println!("Enter a claim address");
+    std::io::stdin().read_line(&mut claim_addrs_str).unwrap();
+
+    let claim_addrs_str = claim_addrs_str.trim();
+
+    let claim_addrs = Address::from_str(&claim_addrs_str)
+        .unwrap()
+        .assume_checked();
+
+    swapper
+        .do_reverse_swap(100000, claim_addrs, Amount::from_sat(1000))
+        .unwrap();
+}

--- a/tests/test_v2_api.rs
+++ b/tests/test_v2_api.rs
@@ -7,6 +7,7 @@ use boltz_client::{
 };
 
 #[test]
+#[ignore = "Run legend-regtest"]
 fn test_v2_submarine() {
     let swapper = BtcSwapper::init(BOLTZ_REGTEST, Chain::BitcoinRegtest);
 
@@ -21,6 +22,7 @@ fn test_v2_submarine() {
 }
 
 #[test]
+#[ignore = "Run legend-regtest"]
 fn test_v2_reverse() {
     let swapper = BtcSwapper::init(BOLTZ_REGTEST, Chain::BitcoinRegtest);
 


### PR DESCRIPTION
This PR adds the Boltz V2 API.

The new logic is handled by a structure `BtcSwapper`. 

Two tests are added to test the logic. Tests are ignored. Will require legend-regtest env to run. 
