### PR TITLE
Script Path Spend: Submarine-Refund & Reverse Non-Cooperative Claim

### DIFF
--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -282,7 +282,7 @@ impl BtcSwapScript {
     }
 }
 
-fn bytes_to_u32_little_endian(bytes: &[u8]) -> u32 {
+pub fn bytes_to_u32_little_endian(bytes: &[u8]) -> u32 {
     let mut result = 0u32;
     for (i, &byte) in bytes.iter().enumerate() {
         result |= (byte as u32) << (8 * i);

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -1,9 +1,9 @@
 use bitcoind::{
     bitcoincore_rpc::{Client, RpcApi},
-    BitcoinD,
+    BitcoinD, Conf,
 };
 
-use bitcoin::{network::Network, Address, Amount};
+use bitcoin::{network::Network, Address, Amount, Txid};
 
 pub struct TestFramework {
     bitcoind: BitcoinD,
@@ -15,7 +15,10 @@ impl TestFramework {
     /// Initializes the Bitcoind regtest backend, mines initial blocks,
     /// creates a test-wallet and funds it with 10,000 sats.
     pub fn init() -> Self {
-        let bitcoind = BitcoinD::from_downloaded().unwrap();
+        let mut conf = Conf::default();
+
+        conf.args.push("-txindex=1");
+        let bitcoind = BitcoinD::from_downloaded_with_conf(&conf).unwrap();
 
         // Generate initial 101 blocks
         let mining_address = bitcoind
@@ -72,11 +75,11 @@ impl TestFramework {
             .unwrap();
     }
 
-    pub fn send_coins(&self, addr: &Address, amount: Amount) {
+    pub fn send_coins(&self, addr: &Address, amount: Amount) -> Txid {
         self.bitcoind
             .client
             .send_to_address(&addr, amount, None, None, None, None, None, None)
-            .unwrap();
+            .unwrap()
     }
 
     pub fn get_test_wallet(&self) -> &Client {


### PR DESCRIPTION
This PR includes the script path spending for the submarine and reverse swap.

For submarine the script path is for refund transactions (unhappy path). And for reverse the script_path is for non-cooperative claim, when boltz fails to give its partial signature for whatever reason. 

Integration test is not included yet, as creating dummy data and the unhappy condition is a bit involved. This will be done in a followup PR.