### PR TITLE
Liquid swapper

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "rust-analyzer.diagnostics.useRustcErrorCode": false,
+    "accessibility.signals.lineHasError": {
+        "announcement": "auto"
+    },
+    "cSpell.words": [
+        "Keypair"
+    ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ secp256k1-zkp = {git = "https://github.com/BlockstreamResearch/rust-secp256k1-zk
 
 [dev-dependencies]
 bitcoind = {version = "0.34.1", features = ["25_0"] }
+elementsd = {version  = "0.9.1", features = ["22_1_1"] }
 
 #Empty default feature set, (helpful to generalise in github actions)
 [features]

--- a/notes
+++ b/notes
@@ -1,0 +1,57 @@
+Submarine script
+ swap_tree: SwapTree {
+        claim_leaf: Leaf {
+            output: Script(
+                OP_HASH160
+                OP_PUSHBYTES_20
+                f60cae49c06b7a5bf6863afa72c36a518d39d3c1
+                OP_EQUALVERIFY
+                OP_PUSHBYTES_32
+                d9fa65e27683dd2f1924e93508e5e99133e268c578733263eb7a891f6778a43a
+                OP_CHECKSIG
+                ),
+                version: 192
+            },
+        refund_leaf: Leaf {
+            output: Script(
+                OP_PUSHBYTES_32 6cbcb0a7c0aa1721a81032e5af6bbfb0e6cc6eede4bef89b708ac2b833ebad5d
+                OP_CHECKSIGVERIFY
+                OP_PUSHBYTES_2 c900
+                OP_CLTV),
+                version: 192
+                }
+            }
+        }
+
+Reverse script
+SwapTree {
+    claim_leaf: Leaf {
+        output: Script(
+            OP_SIZE
+            OP_PUSHBYTES_1 20
+            OP_EQUALVERIFY
+            OP_HASH160
+            OP_PUSHBYTES_20 3aa2291d2c9fb830bb54d228540dbdac9d1bbe89
+            OP_EQUALVERIFY
+            OP_PUSHBYTES_32 fbc14e4c2fda02edd592b9fe24377e2fc1123c0d3b378641ae6ef14aba0c785e
+            OP_CHECKSIG
+            ),
+        version: 192
+        },
+    refund_leaf: Leaf {
+        output: Script(
+            OP_PUSHBYTES_32 5578a38b772461f2481b2a9c6f6802419b11282fb3719cde6af337c077e3d5f3
+            OP_CHECKSIGVERIFY
+            OP_PUSHBYTES_2 3b01
+            OP_CLTVscvrt
+            ),
+        version: 192
+        }
+    }
+submarine swap
+claim script: a914da623700c30db9c59a6979ea3e399ba5b24740a28820c82b90c7f7b772dc424354245ab597ff0f06bea80caeb443c7f8c888c460fdfdac
+refund script: 20fbdaef583b0e79b058c99e180a7bab334bc8267f07409554073c919d285aae87ad02c900b1
+
+reverse swap
+claim script: 82012088a91477bf3bc6b6b86fdd138f886bee0d6f807f89f04e88203e0ff1af3a7d8c9626838ae90e04aa5bac2ecc161138441157bf9b3c4a790affac
+refund script: 204d0ec2790580f2f22b2b6e7e56ca30962ea2395f01cb563afe24440e3117fc55ad023b01b1

--- a/response.json
+++ b/response.json
@@ -1,0 +1,19 @@
+{
+    "acceptZeroConf": Bool(false),
+    "address": String("tb1p5v74h2kypfneqqhf396862z0metpz2n570eg8tn4whvwpuk252yq0d27tf"),
+    "bip21": String("bitcoin:tb1p5v74h2kypfneqqhf396862z0metpz2n570eg8tn4whvwpuk252yq0d27tf?amount=0.00060362&label=Send%20to%20BTC%20lightning"),
+    "claimPublicKey": String("022f930ccf849e47d03a16d0dbd75d3a0d5238a58a09dfecbb9e1d7d2ffd0b4e1d"),
+    "expectedAmount": Number(60362),
+    "id": String("BMwKUcQLYSUp"),
+    "swapTree": Object {
+        "claimLeaf": Object {
+            "output": String("a914b7166f1895402af1bbd5a0a382240fb97e63b9dc88202f930ccf849e47d03a16d0dbd75d3a0d5238a58a09dfecbb9e1d7d2ffd0b4e1dac"),
+            "version": Number(192),
+        },
+        "refundLeaf": Object {
+            "output": String("2056cf3a2eb507ae020c05186f4457ded331aada2e034d9b4e66b9090ec45e40afad036e6527b1"),
+            "version": Number(192),
+        },
+    },
+    "timeoutBlockHeight": Number(2581870),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ pub enum Error {
     IO(std::io::Error),
     Bolt11(lightning_invoice::ParseOrSemanticError),
     LiquidEncode(elements::encode::Error),
+    BitcoinEncode(bitcoin::consensus::encode::Error),
     Blind(String),
     ConfidentialTx(elements::ConfidentialTxOutError),
     BIP32(bitcoin::bip32::Error),
@@ -214,5 +215,11 @@ impl From<elements::secp256k1_zkp::ParseError> for Error {
 impl From<elements::secp256k1_zkp::MusigSignError> for Error {
     fn from(value: elements::secp256k1_zkp::MusigSignError) -> Self {
         Self::Musig2(value.to_string())
+    }
+}
+
+impl From<bitcoin::consensus::encode::Error> for Error {
+    fn from(value: bitcoin::consensus::encode::Error) -> Self {
+        Self::BitcoinEncode(value)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -175,6 +175,18 @@ impl From<bitcoin::taproot::TaprootError> for Error {
     }
 }
 
+impl From<elements::taproot::TaprootError> for Error {
+    fn from(value: elements::taproot::TaprootError) -> Self {
+        Self::Taproot(value.to_string())
+    }
+}
+
+impl From<elements::taproot::TaprootBuilderError> for Error {
+    fn from(value: elements::taproot::TaprootBuilderError) -> Self {
+        Self::Taproot(value.to_string())
+    }
+}
+
 impl From<bitcoin::taproot::TaprootBuilderError> for Error {
     fn from(value: bitcoin::taproot::TaprootBuilderError) -> Self {
         Self::Taproot(value.to_string())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,5 +16,9 @@ pub use bitcoin::secp256k1::{Keypair, Secp256k1};
 pub use elements::secp256k1_zkp::{Keypair as ZKKeyPair, Secp256k1 as ZKSecp256k1};
 pub use lightning_invoice::Bolt11Invoice;
 
-pub use swaps::bitcoin::{BtcSwapScript, BtcSwapTx};
 pub use swaps::boltz::{SwapTxKind, SwapType};
+pub use swaps::{
+    bitcoin::{BtcSwapScript, BtcSwapTx},
+    bitcoinv2::{BtcSwapScriptV2, BtcSwapTxV2},
+    liquidv2::{LBtcSwapScriptV2, LBtcSwapTx},
+};

--- a/src/swaps/bitcoinv2.rs
+++ b/src/swaps/bitcoinv2.rs
@@ -1,0 +1,820 @@
+use bitcoin::consensus::{deserialize, Decodable};
+use bitcoin::hashes::Hash;
+use bitcoin::hex::{DisplayHex, FromHex};
+use bitcoin::key::rand::rngs::OsRng;
+use bitcoin::key::rand::{thread_rng, RngCore};
+use bitcoin::script::{PushBytes, PushBytesBuf};
+use bitcoin::secp256k1::{Keypair, Message, Secp256k1};
+use bitcoin::sighash::Prevouts;
+use bitcoin::taproot::{LeafVersion, Signature, TaprootBuilder, TaprootSpendInfo};
+use bitcoin::transaction::Version;
+use bitcoin::{
+    blockdata::script::{Builder, Instruction, Script, ScriptBuf},
+    opcodes::{all::*, OP_0},
+    Address, OutPoint, PublicKey,
+};
+use bitcoin::{sighash::SighashCache, Network, Sequence, Transaction, TxIn, TxOut, Witness};
+use bitcoin::{Amount, EcdsaSighashType, TapLeafHash, TapSighashType, Txid, XOnlyPublicKey};
+use electrum_client::ElectrumApi;
+use elements::encode::serialize;
+use std::ops::{Add, Index};
+use std::str::FromStr;
+
+use crate::swaps::boltz;
+use crate::{
+    error::Error,
+    network::{electrum::ElectrumConfig, Chain},
+    swaps::boltz::SwapTxKind,
+    util::secrets::Preimage,
+};
+
+use bitcoin::{blockdata::locktime::absolute::LockTime, hashes::hash160};
+
+use super::boltz::SwapType;
+use super::boltzv2::{BoltzApiClientV2, ClaimTxResponse, CreateSwapResponse, ReverseResp};
+
+use elements::secp256k1_zkp::{
+    MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
+    MusigSessionId,
+};
+
+/// Bitcoin swap script helper.
+// TODO: This should encode the network at global level.
+#[derive(Debug, PartialEq, Clone)]
+pub struct BtcSwapScriptV2 {
+    pub swap_type: SwapType,
+    // pub swap_id: String,
+    pub funding_addrs: Option<Address>,
+    pub hashlock: hash160::Hash,
+    pub receiver_pubkey: PublicKey,
+    pub locktime: LockTime,
+    pub sender_pubkey: PublicKey,
+}
+
+impl BtcSwapScriptV2 {
+    /// Create the struct from a submarine swap from create swap response.
+    pub fn submarine_from_swap_resp(
+        create_swap_response: &CreateSwapResponse,
+    ) -> Result<Self, Error> {
+        let claim_script = ScriptBuf::from_hex(&create_swap_response.swap_tree.claim_leaf.output)?;
+        let refund_script =
+            ScriptBuf::from_hex(&create_swap_response.swap_tree.refund_leaf.output)?;
+
+        let claim_instructions = claim_script.instructions();
+        let refund_instructions = refund_script.instructions();
+
+        let mut last_op = OP_0;
+        let mut hashlock = None;
+        let mut reciever_pubkey = None;
+        let mut timelock = None;
+        let mut sender_pubkey = None;
+
+        for instruction in claim_instructions {
+            match instruction {
+                Ok(Instruction::PushBytes(bytes)) => {
+                    if bytes.len() == 20 {
+                        hashlock = Some(hash160::Hash::from_slice(bytes.as_bytes())?);
+                    } else if bytes.len() == 32 {
+                        reciever_pubkey = Some(PublicKey::from_slice(bytes.as_bytes())?);
+                    } else {
+                        continue;
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        for instruction in refund_instructions {
+            match instruction {
+                Ok(Instruction::Op(opcode)) => last_op = opcode,
+                Ok(Instruction::PushBytes(bytes)) => {
+                    if bytes.len() == 32 {
+                        sender_pubkey = Some(PublicKey::from_slice(bytes.as_bytes())?);
+                    } else if last_op == OP_CHECKSIGVERIFY {
+                        timelock = Some(LockTime::from_consensus(bytes_to_u32_little_endian(
+                            &bytes.as_bytes(),
+                        )));
+                    } else {
+                        continue;
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        let hashlock =
+            hashlock.ok_or_else(|| Error::Protocol("No hashlock provided".to_string()))?;
+
+        let sender_pubkey = sender_pubkey
+            .ok_or_else(|| Error::Protocol("No sender_pubkey provided".to_string()))?;
+
+        let timelock =
+            timelock.ok_or_else(|| Error::Protocol("No timelock provided".to_string()))?;
+
+        let receiver_pubkey = reciever_pubkey
+            .ok_or_else(|| Error::Protocol("No receiver_pubkey provided".to_string()))?;
+
+        let funding_addrs = Address::from_str(&create_swap_response.address)?.assume_checked();
+
+        Ok(BtcSwapScriptV2 {
+            swap_type: SwapType::Submarine,
+            // swap_id: create_swap_response.id.clone(),
+            funding_addrs: Some(funding_addrs),
+            hashlock: hashlock,
+            receiver_pubkey: receiver_pubkey,
+            locktime: timelock,
+            sender_pubkey: sender_pubkey,
+        })
+    }
+
+    /// Create the struct from a reverse swap create request.
+    pub fn reverse_from_swap_resp(reverse_response: &ReverseResp) -> Result<Self, Error> {
+        let claim_script = ScriptBuf::from_hex(&reverse_response.swap_tree.claim_leaf.output)?;
+        let refund_script = ScriptBuf::from_hex(&reverse_response.swap_tree.refund_leaf.output)?;
+
+        let claim_instructions = claim_script.instructions();
+        let refund_instructions = refund_script.instructions();
+
+        let mut last_op = OP_0;
+        let mut hashlock = None;
+        let mut receiver_pubkey = None;
+        let mut timelock = None;
+        let mut sender_pubkey = None;
+
+        for instruction in claim_instructions {
+            match instruction {
+                Ok(Instruction::PushBytes(bytes)) => {
+                    if bytes.len() == 20 {
+                        hashlock = Some(hash160::Hash::from_slice(bytes.as_bytes())?);
+                    } else if bytes.len() == 32 {
+                        receiver_pubkey = Some(PublicKey::from_slice(bytes.as_bytes())?);
+                    } else {
+                        continue;
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        for instruction in refund_instructions {
+            match instruction {
+                Ok(Instruction::Op(opcode)) => last_op = opcode,
+                Ok(Instruction::PushBytes(bytes)) => {
+                    if bytes.len() == 32 {
+                        sender_pubkey = Some(PublicKey::from_slice(bytes.as_bytes())?);
+                    } else if last_op == OP_CHECKSIGVERIFY {
+                        timelock = Some(LockTime::from_consensus(bytes_to_u32_little_endian(
+                            &bytes.as_bytes(),
+                        )));
+                    } else {
+                        continue;
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        let hashlock =
+            hashlock.ok_or_else(|| Error::Protocol("No hashlock provided".to_string()))?;
+
+        let sender_pubkey = sender_pubkey
+            .ok_or_else(|| Error::Protocol("No sender_pubkey provided".to_string()))?;
+
+        let timelock =
+            timelock.ok_or_else(|| Error::Protocol("No timelock provided".to_string()))?;
+
+        let receiver_pubkey = receiver_pubkey
+            .ok_or_else(|| Error::Protocol("No receiver_pubkey provided".to_string()))?;
+
+        let funding_addrs = Address::from_str(&reverse_response.lockup_address)?.assume_checked();
+
+        Ok(BtcSwapScriptV2 {
+            swap_type: SwapType::ReverseSubmarine,
+            // swap_id: reverse_response.id.clone(),
+            funding_addrs: Some(funding_addrs),
+            hashlock: hashlock,
+            receiver_pubkey: receiver_pubkey,
+            locktime: timelock,
+            sender_pubkey: sender_pubkey,
+        })
+    }
+
+    fn claim_script(&self) -> ScriptBuf {
+        match self.swap_type {
+            SwapType::Submarine => Builder::new()
+                .push_opcode(OP_HASH160)
+                .push_slice(self.hashlock.to_byte_array())
+                .push_opcode(OP_EQUALVERIFY)
+                .push_x_only_key(&self.receiver_pubkey.inner.x_only_public_key().0)
+                .push_opcode(OP_CHECKSIG)
+                .into_script(),
+
+            SwapType::ReverseSubmarine => Builder::new()
+                .push_opcode(OP_SIZE)
+                .push_int(32)
+                .push_opcode(OP_EQUALVERIFY)
+                .push_opcode(OP_HASH160)
+                .push_slice(self.hashlock.to_byte_array())
+                .push_opcode(OP_EQUALVERIFY)
+                .push_x_only_key(&self.receiver_pubkey.inner.x_only_public_key().0)
+                .push_opcode(OP_CHECKSIG)
+                .into_script(),
+        }
+    }
+
+    fn refund_script(&self) -> ScriptBuf {
+        // Refund scripts are same for all swap types
+        Builder::new()
+            .push_x_only_key(&self.sender_pubkey.inner.x_only_public_key().0)
+            .push_opcode(OP_CHECKSIGVERIFY)
+            .push_lock_time(self.locktime)
+            .push_opcode(OP_CLTV)
+            .into_script()
+    }
+
+    /// Internally used to convert struct into a bitcoin::Script type
+    fn taproot_spendinfo(&self) -> Result<TaprootSpendInfo, Error> {
+        let secp = Secp256k1::new();
+
+        // Setup Key Aggregation cache
+        let pubkeys = [self.receiver_pubkey.inner, self.sender_pubkey.inner];
+
+        let mut key_agg_cache = MusigKeyAggCache::new(&secp, &pubkeys);
+
+        // Construct the Taproot
+        let internal_key = key_agg_cache.agg_pk();
+
+        let taproot_builder = TaprootBuilder::new();
+
+        let taproot_builder = taproot_builder
+            .add_leaf_with_ver(1, self.claim_script(), LeafVersion::TapScript)
+            .unwrap();
+        let taproot_builder = taproot_builder
+            .add_leaf_with_ver(1, self.refund_script(), LeafVersion::TapScript)
+            .unwrap();
+
+        let taproot_spend_info = taproot_builder.finalize(&secp, internal_key).unwrap();
+
+        // Verify taproot construction, only if we have funding address previously known.
+        // Which will be none only for regtest integration tests.
+        if let Some(funding_address) = &self.funding_addrs {
+            let output_key = taproot_spend_info.output_key();
+
+            let lockup_spk = funding_address.script_pubkey();
+
+            let pubkey_instruction = lockup_spk
+                .instructions()
+                .last()
+                .expect("should contain value")
+                .expect("should not fail");
+
+            let lockup_xonly_pubkey_bytes = pubkey_instruction
+                .push_bytes()
+                .expect("pubkey bytes expected");
+
+            let lockup_xonly_pubkey =
+                XOnlyPublicKey::from_slice(lockup_xonly_pubkey_bytes.as_bytes())?;
+
+            debug_assert!(lockup_xonly_pubkey == output_key.to_inner());
+
+            log::info!("Taproot creation and verification success!");
+        }
+
+        Ok(taproot_spend_info)
+    }
+
+    /// Get address for the swap script.
+    /// Submarine swaps use p2shwsh. Reverse swaps use p2wsh.
+    pub fn to_address(&self, network: Chain) -> Result<Address, Error> {
+        let spend_info = self.taproot_spendinfo()?;
+        let output_key = spend_info.output_key();
+
+        let mut network = match network {
+            Chain::Bitcoin => Network::Bitcoin,
+            Chain::BitcoinRegtest => Network::Regtest,
+            Chain::BitcoinTestnet => Network::Testnet,
+            _ => {
+                return Err(Error::Protocol(
+                    "Liquid chain used for Bitcoin operations".to_string(),
+                ))
+            }
+        };
+
+        Ok(Address::p2tr_tweaked(output_key, network))
+    }
+
+    /// Get the balance of the script
+    pub fn get_balance(&self, network_config: &ElectrumConfig) -> Result<(u64, i64), Error> {
+        let electrum_client = network_config.build_client()?;
+        let spk = self.to_address(network_config.network())?.script_pubkey();
+        let script_balance = electrum_client.script_get_balance(spk.as_script())?;
+        Ok((script_balance.confirmed, script_balance.unconfirmed))
+    }
+
+    /// Fetch (utxo,amount) pair for the script_pubkey of this swap.
+    /// Returns None if no utxo for the script_pubkey is found.
+    pub fn fetch_utxo(
+        &self,
+        network_config: &ElectrumConfig,
+    ) -> Result<Option<(OutPoint, TxOut)>, Error> {
+        let electrum_client = network_config.build_client()?;
+        let spk = self.to_address(network_config.network())?.script_pubkey();
+        let utxos = electrum_client.script_list_unspent(spk.as_script())?;
+
+        if utxos.len() == 0 {
+            // No utxo found. Return None.
+            return Ok(None);
+        } else {
+            let outpoint_0 = OutPoint::new(utxos[0].tx_hash, utxos[0].tx_pos as u32);
+            let txout = TxOut {
+                script_pubkey: spk,
+                value: Amount::from_sat(utxos[0].value),
+            };
+            Ok(Some((outpoint_0, txout)))
+        }
+    }
+}
+
+pub fn bytes_to_u32_little_endian(bytes: &[u8]) -> u32 {
+    let mut result = 0u32;
+    for (i, &byte) in bytes.iter().enumerate() {
+        result |= (byte as u32) << (8 * i);
+    }
+    result
+}
+
+/// A structure representing either a Claim or a Refund Tx.
+/// This Tx spends from the HTLC.
+pub struct BtcSwapTxV2 {
+    pub kind: SwapTxKind, // These fields needs to be public to do manual creation in IT.
+    pub swap_script: BtcSwapScriptV2,
+    pub output_address: Address,
+    // The HTLC utxo in (Outpoint, Amount) Pair
+    pub utxo: (OutPoint, TxOut),
+}
+impl BtcSwapTxV2 {
+    /// Craft a new ClaimTx. Only works for Reverse Swaps.
+    /// Returns None, if the HTLC utxo doesn't exist for the swap.
+    pub fn new_claim(
+        swap_script: BtcSwapScriptV2,
+        claim_address: String,
+        network_config: &ElectrumConfig,
+    ) -> Result<Option<BtcSwapTxV2>, Error> {
+        debug_assert!(
+            swap_script.swap_type != SwapType::Submarine,
+            "Claim transactions can only be constructed for Reverse swaps."
+        );
+        let network = if network_config.network() == Chain::Bitcoin {
+            Network::Bitcoin
+        } else {
+            Network::Testnet
+        };
+        let address = Address::from_str(&claim_address)?;
+
+        address.is_valid_for_network(network);
+
+        let utxo_info = swap_script.fetch_utxo(network_config)?;
+        if let Some(utxo) = utxo_info {
+            Ok(Some(BtcSwapTxV2 {
+                kind: SwapTxKind::Claim,
+                swap_script,
+                output_address: address.assume_checked(),
+                utxo,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Construct a RefundTX corresponding to the swap_script. Only works for Normal Swaps.
+    /// Returns None, if the HTLC UTXO for the swap doesn't exist in blockhcian.
+    pub fn new_refund(
+        swap_script: BtcSwapScriptV2,
+        refund_address: &String,
+        network_config: &ElectrumConfig,
+    ) -> Result<Option<BtcSwapTxV2>, Error> {
+        debug_assert!(
+            swap_script.swap_type != SwapType::ReverseSubmarine,
+            "Refund Txs can only be constructed for Normal Swaps"
+        );
+        let network = if network_config.network() == Chain::Bitcoin {
+            Network::Bitcoin
+        } else {
+            Network::Testnet
+        };
+
+        let address = Address::from_str(&refund_address)?;
+        assert!(address.is_valid_for_network(network));
+
+        let utxo_info = swap_script.fetch_utxo(network_config)?;
+        if let Some(utxo) = utxo_info {
+            Ok(Some(BtcSwapTxV2 {
+                kind: SwapTxKind::Refund,
+                swap_script,
+                output_address: address.assume_checked(),
+                utxo,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Compute the Musig partial signature for Submarine Swap.
+    /// This is used to cooperatively close a submarine swap.
+    pub fn submarine_partial_sig(
+        &self,
+        keys: &Keypair,
+        claim_tx_response: &ClaimTxResponse,
+    ) -> Result<(MusigPartialSignature, MusigPubNonce), Error> {
+        // Step 1: Start with a Musig KeyAgg Cache
+        let secp = Secp256k1::new();
+
+        let pubkeys = [
+            self.swap_script.receiver_pubkey.inner,
+            self.swap_script.sender_pubkey.inner,
+        ];
+
+        let mut key_agg_cache = MusigKeyAggCache::new(&secp, &pubkeys);
+
+        let session_id = MusigSessionId::new(&mut thread_rng());
+
+        let msg = Message::from_digest_slice(
+            &Vec::from_hex(&claim_tx_response.transaction_hash).unwrap(),
+        )?;
+
+        // Step 4: Start the Musig2 Signing session
+        let mut extra_rand = [0u8; 32];
+        OsRng.fill_bytes(&mut extra_rand);
+
+        let (sec_nonce, pub_nonce) =
+            key_agg_cache.nonce_gen(&secp, session_id, keys.public_key(), msg, Some(extra_rand))?;
+
+        let boltz_nonce = MusigPubNonce::from_slice(&Vec::from_hex(&claim_tx_response.pub_nonce)?)?;
+
+        let agg_nonce = MusigAggNonce::new(&secp, &[boltz_nonce, pub_nonce]);
+
+        let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+
+        let partial_sig = musig_session.partial_sign(&secp, sec_nonce, &keys, &key_agg_cache)?;
+
+        let is_partial_sig_valid = musig_session.partial_verify(
+            &secp,
+            &key_agg_cache,
+            partial_sig,
+            pub_nonce,
+            keys.public_key(),
+        );
+
+        assert!(is_partial_sig_valid == true);
+
+        log::info!("Partial Signature creation and verification success.");
+
+        Ok((partial_sig, pub_nonce))
+    }
+
+    pub fn create_unsigned_claim_tx(&self, absolute_fees: u64) -> Result<Transaction, Error> {
+        debug_assert!(
+            self.swap_script.swap_type != SwapType::Submarine,
+            "Cannot sign claim tx, for a submarine swap"
+        );
+
+        debug_assert!(
+            self.kind != SwapTxKind::Refund,
+            "Cannot sign claim with Refund type BTCSwapTx"
+        );
+
+        let txin = TxIn {
+            previous_output: self.utxo.0,
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            script_sig: ScriptBuf::new(),
+            witness: Witness::new(),
+        };
+
+        let destination_spk = self.output_address.script_pubkey();
+
+        let txout = TxOut {
+            script_pubkey: destination_spk,
+            value: Amount::from_sat(self.utxo.1.value.to_sat() - absolute_fees),
+        };
+
+        let claim_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![txin],
+            output: vec![txout],
+        };
+
+        Ok(claim_tx)
+    }
+
+    /// Sign a reverse swap claim transaction.
+    /// Panics if called on a Normal Swap or Refund Tx.
+    /// If the claim is cooperative, provide the other party's partial sigs.
+    /// If this is None, transaction will be claimed via taproot script path.
+    pub fn sign_claim(
+        &self,
+        keys: &Keypair,
+        preimage: &Preimage,
+        absolute_fees: u64,
+        is_cooperative: Option<(&BoltzApiClientV2, String)>,
+    ) -> Result<Transaction, Error> {
+        debug_assert!(
+            self.swap_script.swap_type != SwapType::Submarine,
+            "Cannot sign claim tx, for a submarine swap"
+        );
+
+        debug_assert!(
+            self.kind != SwapTxKind::Refund,
+            "Cannot sign claim with Refund type BTCSwapTx"
+        );
+
+        let preimage_bytes = if let Some(value) = preimage.bytes {
+            value
+        } else {
+            return Err(Error::Protocol(format!(
+                "No preimage provided while signing."
+            )));
+        };
+
+        let txin = TxIn {
+            previous_output: self.utxo.0,
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            script_sig: ScriptBuf::new(),
+            witness: Witness::new(),
+        };
+
+        let destination_spk = self.output_address.script_pubkey();
+
+        let txout = TxOut {
+            script_pubkey: destination_spk,
+            value: Amount::from_sat(self.utxo.1.value.to_sat() - absolute_fees),
+        };
+
+        let mut claim_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![txin],
+            output: vec![txout],
+        };
+
+        let secp = Secp256k1::new();
+
+        // If its a cooperative claim, compute the Musig2 Aggregate Signature and use Keypath spending
+        if let Some((boltz_api, swap_id)) = is_cooperative {
+            // Start the Musig session
+
+            // Step 1: Get the sighash
+            let claim_tx_taproot_hash = SighashCache::new(claim_tx.clone())
+                .taproot_key_spend_signature_hash(
+                    0,
+                    &Prevouts::All(&[&self.utxo.1]),
+                    bitcoin::TapSighashType::Default,
+                )
+                .unwrap();
+
+            let msg = Message::from_digest_slice(claim_tx_taproot_hash.as_byte_array()).unwrap();
+
+            // Step 2: Get the Public and Secret nonces
+
+            let mut key_agg_cache = MusigKeyAggCache::new(
+                &secp,
+                &[
+                    self.swap_script.receiver_pubkey.inner,
+                    self.swap_script.sender_pubkey.inner,
+                ],
+            );
+
+            let session_id = MusigSessionId::new(&mut thread_rng());
+
+            let mut extra_rand = [0u8; 32];
+            OsRng.fill_bytes(&mut extra_rand);
+
+            let (sec_nonce, pub_nonce) = key_agg_cache
+                .nonce_gen(&secp, session_id, keys.public_key(), msg, Some(extra_rand))
+                .unwrap();
+
+            // Step 7: Get boltz's partail sig
+            let claim_tx_hex = serialize(&claim_tx).to_lower_hex_string();
+            let partial_sig_resp = boltz_api
+                .get_reverse_partial_sig(&swap_id, &preimage, &pub_nonce, &claim_tx_hex)
+                .unwrap();
+
+            let boltz_public_nonce =
+                MusigPubNonce::from_slice(&Vec::from_hex(&partial_sig_resp.pub_nonce).unwrap())
+                    .unwrap();
+
+            let boltz_partial_sig = MusigPartialSignature::from_slice(
+                &Vec::from_hex(&partial_sig_resp.partial_signature).unwrap(),
+            )
+            .unwrap();
+
+            // Aggregate Our's and Other's Nonce and start the Musig session.
+            let agg_nonce = MusigAggNonce::new(&secp, &[boltz_public_nonce, pub_nonce]);
+
+            let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+
+            musig_session.partial_verify(
+                &secp,
+                &key_agg_cache,
+                boltz_partial_sig,
+                boltz_public_nonce,
+                self.swap_script.sender_pubkey.inner,
+            );
+
+            let our_partial_sig = musig_session
+                .partial_sign(&secp, sec_nonce, &keys, &key_agg_cache)
+                .unwrap();
+
+            let schnorr_sig = musig_session.partial_sig_agg(&[boltz_partial_sig, our_partial_sig]);
+
+            let final_schnorr_sig = Signature {
+                sig: schnorr_sig,
+                hash_ty: TapSighashType::Default,
+            };
+
+            // Verify the sigs.
+            let boltz_partial_sig_verify = musig_session.partial_verify(
+                &secp,
+                &key_agg_cache,
+                boltz_partial_sig,
+                boltz_public_nonce,
+                self.swap_script.sender_pubkey.inner,
+            );
+
+            assert!(boltz_partial_sig_verify == true);
+
+            let output_key = self.swap_script.taproot_spendinfo()?.output_key();
+
+            let _ = secp.verify_schnorr(&final_schnorr_sig.sig, &msg, &output_key.to_inner())?;
+
+            let mut witness = Witness::new();
+            witness.push(final_schnorr_sig.to_vec());
+
+            claim_tx.input[0].witness = witness;
+
+            let claim_tx_hex = serialize(&claim_tx).to_lower_hex_string();
+        } else {
+            // If Non-Cooperative claim use the Script Path spending
+            let leaf_hash =
+                TapLeafHash::from_script(&self.swap_script.claim_script(), LeafVersion::TapScript);
+
+            let sighash = SighashCache::new(claim_tx.clone())
+                .taproot_script_spend_signature_hash(
+                    0,
+                    &Prevouts::All(&[&self.utxo.1]),
+                    leaf_hash,
+                    TapSighashType::Default,
+                )
+                .unwrap();
+
+            let msg = Message::from_digest_slice(sighash.as_byte_array()).unwrap();
+
+            let sig = secp.sign_schnorr(&msg, &keys);
+
+            let final_sig = Signature {
+                sig,
+                hash_ty: TapSighashType::Default,
+            };
+
+            let control_block = self
+                .swap_script
+                .taproot_spendinfo()?
+                .control_block(&(self.swap_script.claim_script(), LeafVersion::TapScript))
+                .expect("Control block calculation failed");
+
+            let mut witness = Witness::new();
+
+            witness.push(final_sig.to_vec());
+            witness.push(&preimage.bytes.unwrap());
+            witness.push(self.swap_script.claim_script().as_bytes());
+            witness.push(control_block.serialize());
+
+            claim_tx.input[0].witness = witness;
+        }
+
+        Ok(claim_tx)
+    }
+
+    /// Sign a submarine swap refund transaction.
+    /// Panics if called on Reverse Swap, Claim type.
+    pub fn sign_refund(&self, keys: &Keypair, absolute_fees: u64) -> Result<Transaction, Error> {
+        debug_assert!(
+            self.swap_script.swap_type != SwapType::ReverseSubmarine,
+            "Cannot sign refund tx, for a reverse-swap"
+        );
+
+        debug_assert!(
+            self.kind != SwapTxKind::Claim,
+            "Cannot sign refund with a claim-type BtcSwapTx"
+        );
+
+        let unsigned_input: TxIn = TxIn {
+            sequence: Sequence::ZERO, // enables absolute locktime
+            previous_output: self.utxo.0,
+            script_sig: ScriptBuf::new(),
+            witness: Witness::new(),
+        };
+        let output_amount: Amount = Amount::from_sat(self.utxo.1.value.to_sat() - absolute_fees);
+        let output: TxOut = TxOut {
+            script_pubkey: self.output_address.script_pubkey(),
+            value: output_amount,
+        };
+
+        let input = TxIn {
+            previous_output: self.utxo.0,
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,
+            witness: Witness::new(),
+        };
+
+        let lock_time = self
+            .swap_script
+            .refund_script()
+            .instructions()
+            .filter_map(|i| {
+                let ins = i.unwrap();
+                if let Instruction::PushBytes(bytes) = ins {
+                    if bytes.len() < 5 as usize {
+                        Some(LockTime::from_consensus(bytes_to_u32_little_endian(
+                            &bytes.as_bytes(),
+                        )))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .next()
+            .unwrap();
+
+        let mut spending_tx = Transaction {
+            version: Version::TWO,
+            lock_time,
+            input: vec![input],
+            output: vec![output],
+        };
+
+        let leaf_hash =
+            TapLeafHash::from_script(&self.swap_script.refund_script(), LeafVersion::TapScript);
+
+        let sighash = SighashCache::new(spending_tx.clone())
+            .taproot_script_spend_signature_hash(
+                0,
+                &Prevouts::All(&[&self.utxo.1]),
+                leaf_hash,
+                TapSighashType::Default,
+            )
+            .unwrap();
+
+        let msg = Message::from_digest_slice(sighash.as_byte_array()).unwrap();
+
+        let sig = Secp256k1::new().sign_schnorr(&msg, &keys);
+
+        let final_sig = Signature {
+            sig,
+            hash_ty: TapSighashType::Default,
+        };
+
+        let control_block = self
+            .swap_script
+            .taproot_spendinfo()?
+            .control_block(&(
+                self.swap_script.refund_script().clone(),
+                LeafVersion::TapScript,
+            ))
+            .expect("Control block calculation failed");
+
+        let mut witness = Witness::new();
+
+        witness.push(final_sig.to_vec());
+        witness.push(self.swap_script.refund_script().as_bytes());
+        witness.push(control_block.serialize());
+
+        spending_tx.input[0].witness = witness;
+
+        Ok(spending_tx)
+    }
+
+    /// Calculate the size of a transaction.
+    /// Use this before calling drain to help calculate the absolute fees.
+    /// Multiply the size by the fee_rate to get the absolute fees.
+    pub fn size(&self, keys: &Keypair, preimage: &Preimage) -> Result<usize, Error> {
+        let dummy_abs_fee = 5_000;
+        let tx = match self.kind {
+            SwapTxKind::Claim => self.sign_claim(keys, preimage, dummy_abs_fee, None)?, // Can only calculate non-coperative claims
+            SwapTxKind::Refund => self.sign_refund(keys, dummy_abs_fee)?,
+        };
+        Ok(tx.vsize())
+    }
+    /// Broadcast transaction to the network
+    pub fn broadcast(
+        &self,
+        signed_tx: &Transaction,
+        network_config: &ElectrumConfig,
+    ) -> Result<Txid, Error> {
+        Ok(network_config
+            .build_client()?
+            .transaction_broadcast(signed_tx)?)
+    }
+}

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -258,7 +258,8 @@ impl Fees {
     }
     /// Calculate boltz fees for a submarine swap, given the invoice amount
     pub fn submarine_boltz(&self, invoice_amount_sat: u64) -> u64 {
-        let boltz_fee = ((self.percentage_swap_in / 100.0) * invoice_amount_sat as f64).ceil() as u64;
+        let boltz_fee =
+            ((self.percentage_swap_in / 100.0) * invoice_amount_sat as f64).ceil() as u64;
         boltz_fee
     }
     /// Get claim miner fees for a submarine swap
@@ -1060,7 +1061,8 @@ mod tests {
         let pairs = client.get_pairs().unwrap();
         let btc_pair = pairs.get_btc_pair().unwrap();
         let invoice_amount_sat = 75_000;
-        let base_fees = btc_pair.fees.reverse_boltz(invoice_amount_sat) + btc_pair.fees.reverse_lockup();
+        let base_fees =
+            btc_pair.fees.reverse_boltz(invoice_amount_sat) + btc_pair.fees.reverse_lockup();
         let claim_fee = btc_pair.fees.reverse_claim_estimate();
         println!("CALCULATED FEES: {}", base_fees);
         println!("ONCHAIN LOCKUP: {}", invoice_amount_sat - base_fees);
@@ -1082,7 +1084,10 @@ mod tests {
         );
         let response = client.create_swap(request).unwrap();
         println!("Onchain Amount: {}", response.onchain_amount.unwrap());
-        assert_eq!((invoice_amount_sat - base_fees), response.onchain_amount.unwrap());
+        assert_eq!(
+            (invoice_amount_sat - base_fees),
+            response.onchain_amount.unwrap()
+        );
 
         let _btc_rss =
             response.into_btc_rev_swap_script(&preimage, &claim_key_pair, Chain::Bitcoin);

--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -121,7 +121,7 @@ impl BoltzApiClientV2 {
 
     pub fn post_swap_req(
         &self,
-        swap_request: CreateSwapRequest,
+        swap_request: &CreateSwapRequest,
     ) -> Result<CreateSwapResponse, Error> {
         let data = serde_json::to_value(swap_request)?;
         Ok(serde_json::from_str(&self.post("swap/submarine", data)?)?)

--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -158,6 +158,12 @@ impl BoltzApiClientV2 {
         )?)
     }
 
+    pub fn get_swap_tx(&self, id: &String) -> Result<SubmarineSwapTxResp, Error> {
+        Ok(serde_json::from_str(
+            &self.get(&format!("swap/submarine/{}/transaction", id))?,
+        )?)
+    }
+
     pub fn get_reverse_partial_sig(
         &self,
         id: &String,
@@ -237,6 +243,7 @@ pub struct CreateSwapResponse {
     pub expected_amount: u64,
     pub id: String,
     pub swap_tree: SwapTree,
+    pub blinding_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -249,7 +256,7 @@ pub struct SwapTree {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Leaf {
-    pub output: ScriptBuf,
+    pub output: String,
     pub version: u8,
 }
 
@@ -290,6 +297,7 @@ pub struct ReverseResp {
     pub refund_public_key: PublicKey,
     pub timeout_block_height: u32,
     pub onchain_amount: u32,
+    pub blinding_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -298,6 +306,15 @@ pub struct ReverseSwapTxResp {
     pub id: String,
     pub hex: String,
     pub timeout_block_height: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmarineSwapTxResp {
+    pub id: String,
+    pub hex: String,
+    pub timeout_block_height: u32,
+    pub timeout_eta: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/swaps/btc_swapper.rs
+++ b/src/swaps/btc_swapper.rs
@@ -568,7 +568,7 @@ impl BtcSwapper {
 
         let invoice = Bolt11Invoice::from_str(&data.invoice).unwrap();
 
-        let create_swap_response = self.api.post_swap_req(data).unwrap();
+        let create_swap_response = self.api.post_swap_req(&data).unwrap();
 
         log::info!("Got Swap Response from Boltz server");
 

--- a/src/swaps/btc_swapper.rs
+++ b/src/swaps/btc_swapper.rs
@@ -78,11 +78,11 @@ impl BtcSwapper {
         let taproot_builder = TaprootBuilder::new();
 
         let (claim_script, claim_version) = (
-            create_swap_response.swap_tree.claim_leaf.output.clone(),
+            ScriptBuf::from_hex(&create_swap_response.swap_tree.claim_leaf.output)?,
             LeafVersion::from_consensus(create_swap_response.swap_tree.claim_leaf.version)?,
         );
         let (refund_script, refund_version) = (
-            create_swap_response.swap_tree.refund_leaf.output.clone(),
+            ScriptBuf::from_hex(&create_swap_response.swap_tree.refund_leaf.output)?,
             LeafVersion::from_consensus(create_swap_response.swap_tree.refund_leaf.version)?,
         );
 
@@ -191,11 +191,11 @@ impl BtcSwapper {
         let taproot_builder = TaprootBuilder::new();
 
         let (claim_script, claim_version) = (
-            create_swap_response.swap_tree.claim_leaf.output.clone(),
+            ScriptBuf::from_hex(&create_swap_response.swap_tree.claim_leaf.output)?,
             LeafVersion::from_consensus(create_swap_response.swap_tree.claim_leaf.version)?,
         );
         let (refund_script, refund_version) = (
-            create_swap_response.swap_tree.refund_leaf.output.clone(),
+            ScriptBuf::from_hex(&create_swap_response.swap_tree.refund_leaf.output.clone())?,
             LeafVersion::from_consensus(create_swap_response.swap_tree.refund_leaf.version)?,
         );
 
@@ -342,12 +342,12 @@ impl BtcSwapper {
         let taproot_builder = TaprootBuilder::new();
 
         let (claim_script, claim_version) = (
-            reverse_resp.swap_tree.claim_leaf.output.clone(),
-            LeafVersion::from_consensus(reverse_resp.swap_tree.claim_leaf.version).unwrap(),
+            ScriptBuf::from_hex(&reverse_resp.swap_tree.claim_leaf.output)?,
+            LeafVersion::from_consensus(reverse_resp.swap_tree.claim_leaf.version)?,
         );
         let (refund_script, refund_version) = (
-            reverse_resp.swap_tree.refund_leaf.output.clone(),
-            LeafVersion::from_consensus(reverse_resp.swap_tree.refund_leaf.version).unwrap(),
+            ScriptBuf::from_hex(&reverse_resp.swap_tree.refund_leaf.output.clone())?,
+            LeafVersion::from_consensus(reverse_resp.swap_tree.refund_leaf.version)?,
         );
 
         let taproot_builder = taproot_builder

--- a/src/swaps/liquid_swapper.rs
+++ b/src/swaps/liquid_swapper.rs
@@ -770,7 +770,7 @@ impl LiquidSwapper {
 
         let invoice = Bolt11Invoice::from_str(&data.invoice).unwrap();
 
-        let create_swap_response = self.api.post_swap_req(data).unwrap();
+        let create_swap_response = self.api.post_swap_req(&data).unwrap();
 
         log::info!("Got Swap Response from Boltz server");
 

--- a/src/swaps/liquid_swapper.rs
+++ b/src/swaps/liquid_swapper.rs
@@ -1,0 +1,992 @@
+use std::str::FromStr;
+
+use bitcoin::{
+    hashes::sha256,
+    hex::DisplayHex,
+    key::{
+        rand::{rngs::OsRng, thread_rng, RngCore},
+        Keypair, Secp256k1,
+    },
+    secp256k1::{Message, SecretKey},
+    Amount, PublicKey, Witness, XOnlyPublicKey,
+};
+use electrum_client::{Client, ElectrumApi};
+use elements::{
+    confidential::{Asset, AssetBlindingFactor, Value, ValueBlindingFactor},
+    encode::{deserialize, serialize},
+    hashes::Hash,
+    hex::FromHex,
+    script::Instruction,
+    secp256k1_zkp::{
+        MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
+        MusigSessionId,
+    },
+    sighash::{Prevouts, SighashCache},
+    taproot::{LeafVersion, TapLeafHash, TaprootBuilder},
+    Address, AssetIssuance, BlockHash, LockTime, OutPoint, SchnorrSig, SchnorrSighashType, Script,
+    Sequence, Transaction, TxIn, TxInWitness, TxOut, TxOutSecrets, TxOutWitness,
+};
+use lightning_invoice::Bolt11Invoice;
+
+use elements::secp256k1_zkp::Keypair as ZKKeyPair;
+
+use crate::{
+    error::Error,
+    network::{electrum::ElectrumConfig, Chain},
+    swaps::{
+        bitcoin::bytes_to_u32_little_endian,
+        boltzv2::{CreateReverseReq, CreateSwapRequest, Subscription, SwapUpdate, BOLTZ_REGTEST},
+    },
+    util::{secrets::Preimage, setup_logger},
+};
+
+use super::boltzv2::{BoltzApiClientV2, ClaimTxResponse, CreateSwapResponse, ReverseResp};
+
+pub struct LiquidSwapper {
+    chain: Chain,
+    api: BoltzApiClientV2,
+    keypair: Keypair,
+}
+
+/// Fetch the liquid utxo from electrum server
+pub fn fetch_utxo(
+    blinding_key: ZKKeyPair,
+    addrs: &Address,
+    network_config: &ElectrumConfig,
+) -> Result<(TxOut, OutPoint, u64, Option<Value>, Option<TxOutSecrets>), Error> {
+    let electrum_client = network_config.clone().build_client()?;
+    let history = electrum_client.script_get_history(bitcoin::Script::from_bytes(
+        addrs.to_unconfidential().script_pubkey().as_bytes(),
+    ))?;
+    if history.is_empty() {
+        return Err(Error::Protocol("No Transaction History".to_string()));
+    }
+    let bitcoin_txid = history.last().expect("txid expected").tx_hash;
+    println!("{}", bitcoin_txid);
+    let raw_tx = electrum_client.transaction_get_raw(&bitcoin_txid)?;
+    let tx: Transaction = elements::encode::deserialize(&raw_tx)?;
+    let mut vout = 0;
+    for output in tx.clone().output {
+        if output.script_pubkey == addrs.script_pubkey() {
+            let zksecp = Secp256k1::new();
+            let is_blinded = output.asset.is_confidential() && output.value.is_confidential();
+            if !is_blinded {
+                let el_txid = tx.clone().txid();
+                let outpoint_0 = OutPoint::new(el_txid, vout);
+                let output_explicit = output
+                    .value
+                    .explicit()
+                    .ok_or_else(|| Error::Protocol("No sender_pubkey provided".to_string()))?;
+                return Ok((output, outpoint_0, output_explicit, None, None));
+            } else {
+                let unblinded = output.unblind(&zksecp, blinding_key.secret_key())?;
+                let el_txid = tx.clone().txid();
+                let outpoint_0 = OutPoint::new(el_txid, vout);
+                let utxo_value = unblinded.value;
+
+                return Ok((
+                    output.clone(),
+                    outpoint_0,
+                    utxo_value,
+                    Some(output.value),
+                    Some(unblinded),
+                ));
+            }
+        }
+        vout += 1;
+    }
+    return Err(Error::Protocol(
+        "Could not find utxos for script".to_string(),
+    ));
+}
+
+impl LiquidSwapper {
+    /// Initialize a swapper
+    pub fn init(boltz_url: &str, chain: Chain) -> Self {
+        let secp = Secp256k1::new();
+
+        let keypair = Keypair::new(&secp, &mut thread_rng());
+
+        Self {
+            chain,
+            api: BoltzApiClientV2::new(boltz_url),
+            keypair,
+        }
+    }
+
+    /// Compute the Musig partial signature
+    fn submarine_partial_sig(
+        &self,
+        create_swap_response: &CreateSwapResponse,
+        claim_tx_response: &ClaimTxResponse,
+    ) -> Result<(MusigPartialSignature, MusigPubNonce), Error> {
+        // Step 1: Start with a Musig KeyAgg Cache
+        let secp = Secp256k1::new();
+
+        let pubkeys = [
+            create_swap_response.claim_public_key.inner,
+            self.keypair.public_key(),
+        ];
+
+        let mut key_agg_cache = MusigKeyAggCache::new(&secp, &pubkeys);
+
+        // Step 2: Build the Taporoot
+        let internal_key = key_agg_cache.agg_pk();
+
+        let taproot_builder = TaprootBuilder::new();
+
+        let (claim_script, claim_version) = (
+            Script::from_str(&create_swap_response.swap_tree.claim_leaf.output)?,
+            LeafVersion::from_u8(create_swap_response.swap_tree.claim_leaf.version)?,
+        );
+        let (refund_script, refund_version) = (
+            Script::from_str(&create_swap_response.swap_tree.refund_leaf.output)?,
+            LeafVersion::from_u8(create_swap_response.swap_tree.refund_leaf.version)?,
+        );
+
+        let taproot_builder = taproot_builder.add_leaf_with_ver(1, claim_script, claim_version)?;
+        let taproot_builder =
+            taproot_builder.add_leaf_with_ver(1, refund_script, refund_version)?;
+
+        let taproot_spend_info = taproot_builder.finalize(&secp, internal_key).unwrap(); // Taproot finalizing in unfailable
+
+        // Verify taproot construction
+        let output_key = taproot_spend_info.output_key();
+
+        let lockup_spk = Address::from_str(&create_swap_response.address)?.script_pubkey();
+
+        let pubkey_instruction = lockup_spk
+            .instructions()
+            .last()
+            .expect("should contain value")
+            .expect("should not fail");
+
+        let lockup_xonly_pubkey_bytes = pubkey_instruction
+            .push_bytes()
+            .expect("pubkey bytes expected");
+
+        let lockup_xonly_pubkey = XOnlyPublicKey::from_slice(lockup_xonly_pubkey_bytes)?;
+
+        debug_assert!(lockup_xonly_pubkey == output_key.into_inner());
+
+        log::info!("Taproot creation and verification success!");
+
+        // Step 3: Tweak the Key Cache with Taproot tweak
+        let tweak = taproot_spend_info.tap_tweak();
+
+        let tweaked_pubkey = key_agg_cache
+            .pubkey_xonly_tweak_add(&secp, SecretKey::from_slice(&tweak.to_byte_array())?)?;
+
+        debug_assert!(output_key.into_inner() == tweaked_pubkey.x_only_public_key().0);
+
+        log::info!("Musig2 tweaking success!");
+
+        let session_id = MusigSessionId::new(&mut thread_rng());
+
+        let msg = Message::from_digest_slice(
+            &Vec::from_hex(&claim_tx_response.transaction_hash).unwrap(),
+        )?;
+
+        // Step 4: Start the Musig2 Signing session
+        let mut extra_rand = [0u8; 32];
+        OsRng.fill_bytes(&mut extra_rand);
+
+        let (sec_nonce, pub_nonce) = key_agg_cache.nonce_gen(
+            &secp,
+            session_id,
+            self.keypair.public_key(),
+            msg,
+            Some(extra_rand),
+        )?;
+
+        let boltz_nonce = MusigPubNonce::from_slice(&Vec::from_hex(&claim_tx_response.pub_nonce)?)?;
+
+        let agg_nonce = MusigAggNonce::new(&secp, &[boltz_nonce, pub_nonce]);
+
+        let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+
+        let partial_sig =
+            musig_session.partial_sign(&secp, sec_nonce, &self.keypair, &key_agg_cache)?;
+
+        let is_partial_sig_valid = musig_session.partial_verify(
+            &secp,
+            &key_agg_cache,
+            partial_sig,
+            pub_nonce,
+            self.keypair.public_key(),
+        );
+
+        debug_assert!(is_partial_sig_valid == true);
+
+        log::info!("Partial Signature creation and verification success.");
+
+        Ok((partial_sig, pub_nonce))
+    }
+
+    /// Creates a refund timelocked transaction for subamrine swap.
+    pub fn submarine_refund(
+        &self,
+        create_swap_response: &CreateSwapResponse,
+        destination: Address,
+        fee: u64,
+    ) -> Result<Transaction, Error> {
+        // Step 1: Start with a Musig KeyAgg Cache
+        let secp = Secp256k1::new();
+
+        let pubkeys = [
+            create_swap_response.claim_public_key.inner,
+            self.keypair.public_key(),
+        ];
+
+        let mut key_agg_cache = MusigKeyAggCache::new(&secp, &pubkeys);
+
+        // Step 2: Build the Taporoot
+        let internal_key = key_agg_cache.agg_pk();
+
+        let taproot_builder = TaprootBuilder::new();
+
+        let (claim_script, claim_version) = (
+            Script::from_str(&create_swap_response.swap_tree.claim_leaf.output)?,
+            LeafVersion::from_u8(create_swap_response.swap_tree.claim_leaf.version)?,
+        );
+        let (refund_script, refund_version) = (
+            Script::from_str(&create_swap_response.swap_tree.refund_leaf.output)?,
+            LeafVersion::from_u8(create_swap_response.swap_tree.refund_leaf.version)?,
+        );
+
+        let taproot_builder = taproot_builder.add_leaf_with_ver(1, claim_script, claim_version)?;
+        let taproot_builder =
+            taproot_builder.add_leaf_with_ver(1, refund_script.clone(), refund_version)?;
+
+        let taproot_spend_info = taproot_builder.finalize(&secp, internal_key).unwrap(); // Taproot finalizing in unfailable
+
+        // Verify taproot construction
+        let output_key = taproot_spend_info.output_key();
+        let funding_addrs = Address::from_str(&create_swap_response.address)?;
+        let lockup_spk = funding_addrs.script_pubkey();
+
+        let pubkey_instruction = lockup_spk
+            .instructions()
+            .last()
+            .expect("should contain value")
+            .expect("should not fail");
+
+        let lockup_xonly_pubkey_bytes = pubkey_instruction
+            .push_bytes()
+            .expect("pubkey bytes expected");
+
+        let lockup_xonly_pubkey = XOnlyPublicKey::from_slice(lockup_xonly_pubkey_bytes)?;
+
+        debug_assert!(lockup_xonly_pubkey == output_key.into_inner());
+
+        log::info!("Taproot creation and verification success!");
+
+        // Get the funding txout
+        let blinding_str = create_swap_response
+            .blinding_key
+            .as_ref()
+            .expect("No blinding key in swap response)");
+        let blinding_key = ZKKeyPair::from_seckey_str(&secp, blinding_str)?;
+
+        let (funding_txout, funding_outpoint, unblinded_value, confidential_value, txout_secrets) =
+            fetch_utxo(
+                blinding_key,
+                &funding_addrs,
+                &ElectrumConfig::default_liquid(),
+            )?;
+
+        let txout_secrets = txout_secrets.expect("Txout secret expected");
+
+        // Create unsigned refund transaction
+        let refund_txin = TxIn {
+            sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,
+            previous_output: funding_outpoint,
+            script_sig: Script::new(),
+            witness: TxInWitness::default(),
+            is_pegin: false,
+            asset_issuance: AssetIssuance::default(),
+        };
+
+        let mut rng = OsRng::default();
+
+        let asset_id = txout_secrets.asset;
+        let out_abf = AssetBlindingFactor::new(&mut rng);
+        let exp_asset = Asset::Explicit(asset_id);
+
+        let (blinded_asset, asset_surjection_proof) =
+            exp_asset.blind(&mut rng, &secp, out_abf, &[txout_secrets])?;
+
+        let output_value = unblinded_value - fee;
+
+        let final_vbf = ValueBlindingFactor::last(
+            &secp,
+            output_value,
+            out_abf,
+            &[(
+                txout_secrets.value,
+                txout_secrets.asset_bf,
+                txout_secrets.value_bf,
+            )],
+            &[(
+                fee,
+                AssetBlindingFactor::zero(),
+                ValueBlindingFactor::zero(),
+            )],
+        );
+        let explicit_value = elements::confidential::Value::Explicit(output_value);
+        let msg = elements::RangeProofMessage {
+            asset: asset_id,
+            bf: out_abf,
+        };
+        let ephemeral_sk = SecretKey::new(&mut rng);
+        // assuming we always use a blinded address that has an extractable blinding pub
+        let blinding_key = destination
+            .blinding_pubkey
+            .ok_or(Error::Protocol("No blinding key in tx.".to_string()))?;
+        let (blinded_value, nonce, rangeproof) = explicit_value.blind(
+            &secp,
+            final_vbf,
+            blinding_key,
+            ephemeral_sk,
+            &destination.script_pubkey(),
+            &msg,
+        )?;
+
+        let tx_out_witness = TxOutWitness {
+            surjection_proof: Some(Box::new(asset_surjection_proof)), // from asset blinding
+            rangeproof: Some(Box::new(rangeproof)),                   // from value blinding
+        };
+        let payment_output: TxOut = TxOut {
+            script_pubkey: destination.script_pubkey(),
+            value: blinded_value,
+            asset: blinded_asset,
+            nonce: nonce,
+            witness: tx_out_witness,
+        };
+        let fee_output: TxOut = TxOut::new_fee(fee, asset_id);
+
+        let lock_time = refund_script
+            .instructions()
+            .filter_map(|i| {
+                let ins = i.unwrap();
+                if let Instruction::PushBytes(bytes) = ins {
+                    if bytes.len() == 3 as usize {
+                        Some(LockTime::from_consensus(bytes_to_u32_little_endian(&bytes)))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .next()
+            .unwrap();
+
+        let mut refund_tx = Transaction {
+            version: 2,
+            lock_time,
+            input: vec![refund_txin],
+            output: vec![payment_output, fee_output],
+        };
+
+        let leaf_hash = TapLeafHash::from_script(&refund_script, LeafVersion::default());
+
+        let electrum = ElectrumConfig::default_liquid().build_client()?;
+
+        let genesis_blockhash =
+            elements::BlockHash::from_raw_hash(electrum.block_header(0)?.block_hash().into());
+
+        let sighash = SighashCache::new(&refund_tx)
+            .taproot_script_spend_signature_hash(
+                0,
+                &Prevouts::All(&[funding_txout]),
+                leaf_hash,
+                SchnorrSighashType::Default,
+                genesis_blockhash,
+            )
+            .unwrap();
+
+        let msg = Message::from_digest_slice(sighash.as_byte_array()).unwrap();
+
+        let sig = secp.sign_schnorr(&msg, &self.keypair);
+
+        let final_sig = SchnorrSig {
+            sig,
+            hash_ty: SchnorrSighashType::Default,
+        };
+
+        let control_block = taproot_spend_info
+            .control_block(&(refund_script.clone(), LeafVersion::default()))
+            .unwrap();
+
+        let mut script_witness = Witness::new();
+        script_witness.push(final_sig.to_vec());
+        script_witness.push(refund_script.as_bytes());
+        script_witness.push(control_block.serialize());
+
+        let witness = TxInWitness {
+            amount_rangeproof: None,
+            inflation_keys_rangeproof: None,
+            script_witness: script_witness.to_vec(),
+            pegin_witness: vec![],
+        };
+
+        refund_tx.input[0].witness = witness;
+
+        Ok(refund_tx)
+    }
+
+    /// Compute the final signed claim tx for reverse swap
+    fn reverse_claim_tx(
+        &self,
+        reverse_resp: &ReverseResp,
+        preimage: &Preimage,
+        destination: Address,
+        fee: u64,
+        is_cooperative: bool,
+    ) -> Result<Transaction, Error> {
+        // Get the tx in mempool
+        let tx_resp = self.api.get_reverse_tx(&reverse_resp.id).unwrap();
+
+        let lockup_tx: Transaction = deserialize(&Vec::from_hex(&tx_resp.hex).unwrap()).unwrap();
+
+        let secp = Secp256k1::new();
+        // Start Musig
+
+        // Step 1: Setup Key Aggregation cache
+        let boltz_pubkey = reverse_resp.refund_public_key;
+        let pubkeys = [boltz_pubkey.inner, self.keypair.public_key()];
+
+        let mut key_agg_cache = MusigKeyAggCache::new(&secp, &pubkeys);
+
+        //Step 2: Construct the Taproot
+        let internal_key = key_agg_cache.agg_pk();
+
+        let taproot_builder = TaprootBuilder::new();
+
+        let (claim_script, claim_version) = (
+            Script::from_str(&reverse_resp.swap_tree.claim_leaf.output)?,
+            LeafVersion::from_u8(reverse_resp.swap_tree.claim_leaf.version).unwrap(),
+        );
+        let (refund_script, refund_version) = (
+            Script::from_str(&reverse_resp.swap_tree.refund_leaf.output)?,
+            LeafVersion::from_u8(reverse_resp.swap_tree.refund_leaf.version).unwrap(),
+        );
+
+        let taproot_builder = taproot_builder
+            .add_leaf_with_ver(1, claim_script.clone(), claim_version)
+            .unwrap();
+        let taproot_builder = taproot_builder
+            .add_leaf_with_ver(1, refund_script, refund_version)
+            .unwrap();
+
+        let taproot_spend_info = taproot_builder.finalize(&secp, internal_key).unwrap();
+
+        // Verify taproot construction
+        let output_key = taproot_spend_info.output_key();
+
+        let lockup_spk = Address::from_str(&reverse_resp.lockup_address)
+            .unwrap()
+            .script_pubkey();
+
+        let pubkey_instruction = lockup_spk.instructions().last().expect("expected").unwrap();
+
+        let lockup_xonly_pubkey_bytes = pubkey_instruction
+            .push_bytes()
+            .expect("pubkey bytes expected");
+
+        let lockup_xonly_pubkey = XOnlyPublicKey::from_slice(lockup_xonly_pubkey_bytes).unwrap();
+
+        assert_eq!(lockup_xonly_pubkey, output_key.into_inner());
+
+        log::info!("Taproot creation and verification success!");
+
+        // Step 3: Tweak the Musig aggregated key with the taproot tweak
+        let tweak = taproot_spend_info.tap_tweak();
+
+        let tweaked_pubkey = key_agg_cache
+            .pubkey_xonly_tweak_add(
+                &secp,
+                SecretKey::from_slice(&tweak.to_byte_array()).unwrap(),
+            )
+            .unwrap();
+
+        debug_assert!(output_key.into_inner() == tweaked_pubkey.x_only_public_key().0);
+
+        log::info!("Musig2 tweaking success!");
+
+        // Step 4: Start the Musig Session
+        let session_id = MusigSessionId::new(&mut thread_rng());
+
+        // Create unsigned claim transaction
+        let (vout, funding_txout) = lockup_tx
+            .output
+            .iter()
+            .enumerate()
+            .find(|(vout, txout)| txout.script_pubkey == lockup_spk)
+            .expect("Cannot find funding txout in funding tx");
+
+        let blinding_str = reverse_resp
+            .blinding_key
+            .as_ref()
+            .expect("No blinding key in swap response)");
+        let blinding_key = ZKKeyPair::from_seckey_str(&secp, blinding_str)?;
+
+        let txout_secrets = funding_txout.unblind(&secp, blinding_key.secret_key())?;
+
+        let claim_txin = TxIn {
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            previous_output: OutPoint::new(lockup_tx.txid(), vout as u32),
+            script_sig: Script::new(),
+            witness: TxInWitness::default(),
+            is_pegin: false,
+            asset_issuance: AssetIssuance::default(),
+        };
+
+        let mut rng = OsRng::default();
+
+        let asset_id = txout_secrets.asset;
+        let out_abf = AssetBlindingFactor::new(&mut rng);
+        let exp_asset = Asset::Explicit(asset_id);
+
+        let (blinded_asset, asset_surjection_proof) =
+            exp_asset.blind(&mut rng, &secp, out_abf, &[txout_secrets])?;
+
+        let output_value = txout_secrets.value - fee;
+
+        let final_vbf = ValueBlindingFactor::last(
+            &secp,
+            output_value,
+            out_abf,
+            &[(
+                txout_secrets.value,
+                txout_secrets.asset_bf,
+                txout_secrets.value_bf,
+            )],
+            &[(
+                fee,
+                AssetBlindingFactor::zero(),
+                ValueBlindingFactor::zero(),
+            )],
+        );
+        let explicit_value = elements::confidential::Value::Explicit(output_value);
+        let msg = elements::RangeProofMessage {
+            asset: asset_id,
+            bf: out_abf,
+        };
+        let ephemeral_sk = SecretKey::new(&mut rng);
+        // assuming we always use a blinded address that has an extractable blinding pub
+        let blinding_key = destination
+            .blinding_pubkey
+            .ok_or(Error::Protocol("No blinding key in tx.".to_string()))?;
+        let (blinded_value, nonce, rangeproof) = explicit_value.blind(
+            &secp,
+            final_vbf,
+            blinding_key,
+            ephemeral_sk,
+            &destination.script_pubkey(),
+            &msg,
+        )?;
+
+        let tx_out_witness = TxOutWitness {
+            surjection_proof: Some(Box::new(asset_surjection_proof)), // from asset blinding
+            rangeproof: Some(Box::new(rangeproof)),                   // from value blinding
+        };
+        let payment_output: TxOut = TxOut {
+            script_pubkey: destination.script_pubkey(),
+            value: blinded_value,
+            asset: blinded_asset,
+            nonce: nonce,
+            witness: tx_out_witness,
+        };
+        let fee_output: TxOut = TxOut::new_fee(fee, asset_id);
+
+        let mut claim_tx = Transaction {
+            version: 2,
+            lock_time: LockTime::ZERO,
+            input: vec![claim_txin],
+            output: vec![payment_output, fee_output],
+        };
+
+        // If its a cooperative claim, compute the Musig2 Aggregate Signature and use Keypath spending
+        if is_cooperative {
+            let electrum = ElectrumConfig::default_liquid().build_client()?;
+
+            let genesis_blockhash =
+                elements::BlockHash::from_raw_hash(electrum.block_header(0)?.block_hash().into());
+
+            let claim_tx_taproot_hash = SighashCache::new(&claim_tx)
+                .taproot_key_spend_signature_hash(
+                    0,
+                    &Prevouts::All(&[funding_txout]),
+                    SchnorrSighashType::Default,
+                    genesis_blockhash,
+                )
+                .unwrap();
+
+            // Step 6: Generate secret and public nonces
+            let msg = Message::from_digest_slice(claim_tx_taproot_hash.as_byte_array()).unwrap();
+
+            let mut extra_rand = [0u8; 32];
+            OsRng.fill_bytes(&mut extra_rand);
+
+            let (sec_nonce, pub_nonce) = key_agg_cache
+                .nonce_gen(
+                    &secp,
+                    session_id,
+                    self.keypair.public_key(),
+                    msg,
+                    Some(extra_rand),
+                )
+                .unwrap();
+
+            // Step 7: Get boltz's partail sig
+            let claim_tx_hex = serialize(&claim_tx).to_lower_hex_string();
+            let partial_sig_resp = self
+                .api
+                .get_reverse_partial_sig(&reverse_resp.id, &preimage, &pub_nonce, &claim_tx_hex)
+                .unwrap();
+
+            let boltz_nonce =
+                MusigPubNonce::from_slice(&Vec::from_hex(&partial_sig_resp.pub_nonce).unwrap())
+                    .unwrap();
+
+            let boltz_partial_sig = MusigPartialSignature::from_slice(
+                &Vec::from_hex(&partial_sig_resp.partial_signature).unwrap(),
+            )
+            .unwrap();
+
+            // Step 7: Perform
+
+            let agg_nonce = MusigAggNonce::new(&secp, &[boltz_nonce, pub_nonce]);
+
+            let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+
+            let our_partial_sig = musig_session
+                .partial_sign(&secp, sec_nonce, &self.keypair, &key_agg_cache)
+                .unwrap();
+
+            let schnorr_sig = musig_session.partial_sig_agg(&[boltz_partial_sig, our_partial_sig]);
+
+            let final_schnorr_sig = SchnorrSig {
+                sig: schnorr_sig,
+                hash_ty: SchnorrSighashType::Default,
+            };
+
+            // Verify the sigs.
+            let boltz_partial_sig_verify = musig_session.partial_verify(
+                &secp,
+                &key_agg_cache,
+                boltz_partial_sig,
+                boltz_nonce,
+                boltz_pubkey.inner,
+            );
+
+            debug_assert!(boltz_partial_sig_verify == true);
+
+            let final_sig_verify =
+                secp.verify_schnorr(&final_schnorr_sig.sig, &msg, &output_key.into_inner())?;
+
+            debug_assert!(final_sig_verify == ());
+
+            let mut script_witness = Witness::new();
+            script_witness.push(final_schnorr_sig.to_vec());
+
+            let witness = TxInWitness {
+                amount_rangeproof: None,
+                inflation_keys_rangeproof: None,
+                script_witness: script_witness.to_vec(),
+                pegin_witness: vec![],
+            };
+
+            claim_tx.input[0].witness = witness;
+
+            let claim_tx_hex = serialize(&claim_tx).to_lower_hex_string();
+        } else {
+            // If Non-Cooperative claim use the Script Path spending
+            let electrum = ElectrumConfig::default_liquid().build_client()?;
+
+            let genesis_blockhash =
+                elements::BlockHash::from_raw_hash(electrum.block_header(0)?.block_hash().into());
+
+            let leaf_hash = TapLeafHash::from_script(&claim_script, LeafVersion::default());
+
+            let sighash = SighashCache::new(&claim_tx)
+                .taproot_script_spend_signature_hash(
+                    0,
+                    &Prevouts::All(&[funding_txout]),
+                    leaf_hash,
+                    SchnorrSighashType::Default,
+                    genesis_blockhash,
+                )
+                .unwrap();
+
+            let msg = Message::from_digest_slice(sighash.as_byte_array()).unwrap();
+
+            let sig = secp.sign_schnorr(&msg, &self.keypair);
+
+            let final_sig = SchnorrSig {
+                sig,
+                hash_ty: SchnorrSighashType::Default,
+            };
+
+            let control_block = taproot_spend_info
+                .control_block(&(claim_script.clone(), LeafVersion::default()))
+                .unwrap();
+
+            let mut script_witness = Witness::new();
+            script_witness.push(final_sig.to_vec());
+            script_witness.push(claim_script.as_bytes());
+            script_witness.push(control_block.serialize());
+
+            let witness = TxInWitness {
+                amount_rangeproof: None,
+                inflation_keys_rangeproof: None,
+                script_witness: script_witness.to_vec(),
+                pegin_witness: vec![],
+            };
+
+            claim_tx.input[0].witness = witness;
+        }
+
+        Ok(claim_tx)
+    }
+
+    /// Perform a submarine swap with Boltz
+    pub fn do_submarine(&self, invoice: &str) -> Result<(), Error> {
+        setup_logger();
+
+        let refund_public_key = PublicKey {
+            inner: self.keypair.public_key(),
+            compressed: true,
+        };
+
+        let data = CreateSwapRequest {
+            from: "L-BTC".to_string(),
+            to: "BTC".to_string(),
+            invoice: invoice.to_string(),
+            refund_public_key,
+        };
+
+        let invoice = Bolt11Invoice::from_str(&data.invoice).unwrap();
+
+        let create_swap_response = self.api.post_swap_req(data).unwrap();
+
+        log::info!("Got Swap Response from Boltz server");
+
+        log::debug!("Swap Response: {:?}", create_swap_response);
+
+        let mut socket = self.api.connect_ws()?;
+
+        let subscription = Subscription::new(&create_swap_response.id);
+
+        socket.send(tungstenite::Message::Text(
+            serde_json::to_string(&subscription).unwrap(),
+        ))?;
+
+        loop {
+            let response = serde_json::from_str(&socket.read().unwrap().to_string());
+
+            if response.is_err() {
+                if response.err().expect("expected").is_eof() {
+                    continue;
+                }
+            } else {
+                match response.unwrap() {
+                    SwapUpdate::Subscription {
+                        event,
+                        channel,
+                        args,
+                    } => {
+                        debug_assert!(event == "subscribe");
+                        debug_assert!(channel == "swap.update");
+                        debug_assert!(args.get(0).expect("expected") == &create_swap_response.id);
+                        log::info!(
+                            "Subscription successful for swap : {}",
+                            create_swap_response.id
+                        );
+                    }
+
+                    SwapUpdate::Update {
+                        event,
+                        channel,
+                        args,
+                    } => {
+                        debug_assert!(event == "update");
+                        debug_assert!(channel == "swap.update");
+                        let update = args.get(0).expect("expected");
+                        assert!(update.id == create_swap_response.id);
+                        log::info!("Got Update from server: {}", update.status);
+
+                        if update.status == "invoice.set" {
+                            log::info!(
+                                "Send {} sats to BTC address {}",
+                                create_swap_response.expected_amount,
+                                create_swap_response.address
+                            );
+                        }
+
+                        if update.status == "transaction.claim.pending" {
+                            // Step 1: Get the claim tx details and check preimage hash
+                            let claim_tx_response =
+                                self.api.get_claim_tx_details(&create_swap_response.id)?;
+
+                            log::debug!("Received claim tx details : {:?}", claim_tx_response);
+
+                            let preimage = Vec::from_hex(&claim_tx_response.preimage)?;
+
+                            let preimage_hash = sha256::Hash::hash(&preimage);
+
+                            let invoice_payment_hash = invoice.payment_hash();
+
+                            if invoice_payment_hash.to_string() != preimage_hash.to_string() {
+                                return Err(Error::Protocol(
+                                    "Preimage Hash missmatch with LN invoice".to_string(),
+                                ));
+                            }
+
+                            log::info!("Correct Claim TX Response Received from Boltz.");
+
+                            let (partial_sig, pub_nonce) = self
+                                .submarine_partial_sig(&create_swap_response, &claim_tx_response)?;
+
+                            self.api.post_claim_tx_details(
+                                &create_swap_response.id,
+                                pub_nonce,
+                                partial_sig,
+                            )?;
+
+                            log::info!("Successfully Sent partial signature");
+                        }
+
+                        if update.status == "transaction.claimed" {
+                            log::info!("Successfully completed sunmarine swap");
+                            return Ok(());
+                        }
+                    }
+
+                    SwapUpdate::Error {
+                        event,
+                        channel,
+                        args,
+                    } => {
+                        assert!(event == "update");
+                        assert!(channel == "swap.update");
+                        let error = args.get(0).expect("expected");
+                        log::error!(
+                            "Got Boltz response error : {} for swap: {}",
+                            error.error,
+                            error.id
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Perform a reverse swap with Boltz
+    pub fn do_reverse_swap(
+        &self,
+        invoice_amount: u32,
+        claim_addrs: Address,
+        claim_tx_fee: u64,
+    ) -> Result<(), Error> {
+        setup_logger();
+        let preimage = Preimage::new();
+
+        let create_reverse_req = CreateReverseReq {
+            invoice_amount,
+            from: "BTC".to_string(),
+            to: "L-BTC".to_string(),
+            preimage_hash: preimage.sha256,
+            claim_public_key: PublicKey {
+                compressed: true,
+                inner: self.keypair.public_key(),
+            },
+        };
+
+        let reverse_resp = self.api.post_reverse_req(create_reverse_req).unwrap();
+
+        log::debug!("Got Reverse swap response: {:?}", reverse_resp);
+
+        let mut socket = self.api.connect_ws()?;
+
+        let subscription = Subscription::new(&reverse_resp.id);
+
+        socket.send(tungstenite::Message::Text(
+            serde_json::to_string(&subscription).unwrap(),
+        ))?;
+
+        loop {
+            let response = serde_json::from_str(&socket.read().unwrap().to_string());
+
+            if response.is_err() {
+                if response.err().expect("expected").is_eof() {
+                    continue;
+                }
+            } else {
+                match response.as_ref().unwrap() {
+                    SwapUpdate::Subscription {
+                        event,
+                        channel,
+                        args,
+                    } => {
+                        debug_assert!(event == "subscribe");
+                        debug_assert!(channel == "swap.update");
+                        debug_assert!(args.get(0).expect("expected") == &reverse_resp.id);
+                        log::info!("Subscription successful for swap : {}", reverse_resp.id);
+                    }
+
+                    SwapUpdate::Update {
+                        event,
+                        channel,
+                        args,
+                    } => {
+                        debug_assert!(event == "update");
+                        debug_assert!(channel == "swap.update");
+                        let update = args.get(0).expect("expected");
+                        debug_assert!(&update.id == &reverse_resp.id);
+                        log::info!("Got Update from server: {}", update.status);
+
+                        if update.status == "swap.created" {
+                            log::info!("Waiting for Invoice to be paid: {}", reverse_resp.invoice);
+                            continue;
+                        }
+
+                        if update.status == "transaction.mempool" {
+                            let tx = self.reverse_claim_tx(
+                                &reverse_resp,
+                                &preimage,
+                                claim_addrs.clone(),
+                                claim_tx_fee,
+                                true,
+                            )?;
+
+                            let claim_tx_hex = serialize(&tx).to_lower_hex_string();
+                            self.api.broadcast_tx(self.chain, &claim_tx_hex)?;
+
+                            log::info!("Succesfully broadcasted claim tx!");
+                            log::debug!("Claim Tx Hex: {}", claim_tx_hex);
+                        }
+
+                        if update.status == "invoice.settled" {
+                            log::info!("Reverse Swap Successful!");
+                            return Ok(());
+                        }
+                    }
+
+                    SwapUpdate::Error {
+                        event,
+                        channel,
+                        args,
+                    } => {
+                        assert!(event == "update");
+                        assert!(channel == "swap.update");
+                        let error = args.get(0).expect("expected");
+                        println!("Got error : {} for swap: {}", error.error, error.id);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/swaps/liquidv2.rs
+++ b/src/swaps/liquidv2.rs
@@ -1,0 +1,945 @@
+use electrum_client::ElectrumApi;
+use std::{hash, str::FromStr};
+
+use bitcoin::{
+    hashes::{hash160, Hash},
+    hex::DisplayHex,
+    key::rand::{rngs::OsRng, thread_rng, RngCore},
+    script::Script as BitcoinScript,
+    secp256k1::Keypair,
+    Witness, XOnlyPublicKey,
+};
+use elements::{
+    confidential::{self, Asset, AssetBlindingFactor, Value, ValueBlindingFactor},
+    hex::{FromHex, ToHex},
+    secp256k1_zkp::{
+        self, MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
+        MusigSessionId, Secp256k1, SecretKey,
+    },
+    sighash::{Prevouts, SighashCache},
+    taproot::{LeafVersion, TapLeafHash, TaprootBuilder, TaprootSpendInfo},
+    Address, AssetIssuance, BlockHash, LockTime, OutPoint, SchnorrSig, SchnorrSighashType, Script,
+    Sequence, Transaction, TxIn, TxInWitness, TxOut, TxOutSecrets, TxOutWitness,
+};
+
+use elements::encode::serialize;
+use elements::secp256k1_zkp::Message;
+
+use crate::{
+    network::{electrum::ElectrumConfig, Chain},
+    swaps::boltz::SwapTxKind,
+    util::secrets::Preimage,
+};
+
+use crate::error::Error;
+
+use elements::bitcoin::PublicKey;
+use elements::secp256k1_zkp::Keypair as ZKKeyPair;
+use elements::{
+    address::Address as EAddress,
+    opcodes::all::*,
+    script::{Builder as EBuilder, Instruction, Script as EScript},
+    AddressParams,
+};
+
+use super::{
+    boltz::SwapType,
+    boltzv2::{ClaimTxResponse, CreateSwapResponse, ReverseResp},
+};
+
+/// Liquid swap script helper.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LBtcSwapScriptV2 {
+    pub swap_type: SwapType,
+    pub funding_addrs: Address,
+    pub hashlock: hash160::Hash,
+    pub receiver_pubkey: PublicKey,
+    pub locktime: LockTime,
+    pub sender_pubkey: PublicKey,
+    pub blinding_key: ZKKeyPair,
+}
+
+impl LBtcSwapScriptV2 {
+    /// Create the struct from a submarine swap from create swap response.
+    pub fn submarine_from_swap_resp(
+        create_swap_response: &CreateSwapResponse,
+    ) -> Result<Self, Error> {
+        let claim_script = Script::from_str(&create_swap_response.swap_tree.claim_leaf.output)?;
+        let refund_script = Script::from_str(&create_swap_response.swap_tree.refund_leaf.output)?;
+
+        let claim_instructions = claim_script.instructions();
+        let refund_instructions = refund_script.instructions();
+
+        let mut last_op = OP_0NOTEQUAL;
+        let mut hashlock = None;
+        let mut reciever_pubkey = None;
+        let mut locktime = None;
+        let mut sender_pubkey = None;
+
+        for instruction in claim_instructions {
+            match instruction {
+                Ok(Instruction::PushBytes(bytes)) => {
+                    if bytes.len() == 20 {
+                        hashlock = Some(hash160::Hash::from_slice(bytes)?);
+                    } else if bytes.len() == 32 {
+                        reciever_pubkey = Some(PublicKey::from_slice(bytes)?);
+                    } else {
+                        continue;
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        for instruction in refund_instructions {
+            match instruction {
+                Ok(Instruction::Op(opcode)) => last_op = opcode,
+                Ok(Instruction::PushBytes(bytes)) => {
+                    if bytes.len() == 32 {
+                        sender_pubkey = Some(PublicKey::from_slice(bytes)?);
+                    } else if last_op == OP_CHECKSIGVERIFY {
+                        locktime =
+                            Some(LockTime::from_consensus(bytes_to_u32_little_endian(&bytes)));
+                    } else {
+                        continue;
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        let hashlock =
+            hashlock.ok_or_else(|| Error::Protocol("No hashlock provided".to_string()))?;
+
+        let sender_pubkey = sender_pubkey
+            .ok_or_else(|| Error::Protocol("No sender_pubkey provided".to_string()))?;
+
+        let locktime =
+            locktime.ok_or_else(|| Error::Protocol("No timelock provided".to_string()))?;
+
+        let receiver_pubkey = reciever_pubkey
+            .ok_or_else(|| Error::Protocol("No receiver_pubkey provided".to_string()))?;
+
+        let funding_addrs = Address::from_str(&create_swap_response.address)?;
+
+        let blinding_str = create_swap_response
+            .blinding_key
+            .as_ref()
+            .expect("No blinding key provided in CreateSwapResp");
+        let blinding_key = ZKKeyPair::from_seckey_str(&Secp256k1::new(), blinding_str)?;
+
+        Ok(Self {
+            swap_type: SwapType::Submarine,
+            funding_addrs,
+            hashlock,
+            receiver_pubkey,
+            locktime,
+            sender_pubkey,
+            blinding_key,
+        })
+    }
+
+    /// Create the struct from a reverse swap create request.
+    pub fn reverse_from_swap_resp(reverse_response: &ReverseResp) -> Result<Self, Error> {
+        let claim_script = Script::from_str(&reverse_response.swap_tree.claim_leaf.output)?;
+        let refund_script = Script::from_str(&reverse_response.swap_tree.refund_leaf.output)?;
+
+        let claim_instructions = claim_script.instructions();
+        let refund_instructions = refund_script.instructions();
+
+        let mut last_op = OP_0NOTEQUAL;
+        let mut hashlock = None;
+        let mut reciever_pubkey = None;
+        let mut locktime = None;
+        let mut sender_pubkey = None;
+
+        for instruction in claim_instructions {
+            match instruction {
+                Ok(Instruction::PushBytes(bytes)) => {
+                    if bytes.len() == 20 {
+                        hashlock = Some(hash160::Hash::from_slice(bytes)?);
+                    } else if bytes.len() == 32 {
+                        reciever_pubkey = Some(PublicKey::from_slice(bytes)?);
+                    } else {
+                        continue;
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        for instruction in refund_instructions {
+            match instruction {
+                Ok(Instruction::Op(opcode)) => last_op = opcode,
+                Ok(Instruction::PushBytes(bytes)) => {
+                    if bytes.len() == 32 {
+                        sender_pubkey = Some(PublicKey::from_slice(bytes)?);
+                    } else if last_op == OP_CHECKSIGVERIFY {
+                        locktime =
+                            Some(LockTime::from_consensus(bytes_to_u32_little_endian(&bytes)));
+                    } else {
+                        continue;
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        let hashlock =
+            hashlock.ok_or_else(|| Error::Protocol("No hashlock provided".to_string()))?;
+
+        let sender_pubkey = sender_pubkey
+            .ok_or_else(|| Error::Protocol("No sender_pubkey provided".to_string()))?;
+
+        let locktime =
+            locktime.ok_or_else(|| Error::Protocol("No timelock provided".to_string()))?;
+
+        let receiver_pubkey = reciever_pubkey
+            .ok_or_else(|| Error::Protocol("No receiver_pubkey provided".to_string()))?;
+
+        let funding_addrs = Address::from_str(&reverse_response.lockup_address)?;
+
+        let blinding_str = reverse_response
+            .blinding_key
+            .as_ref()
+            .expect("No blinding key provided in CreateSwapResp");
+        let blinding_key = ZKKeyPair::from_seckey_str(&Secp256k1::new(), blinding_str)?;
+
+        Ok(Self {
+            swap_type: SwapType::Submarine,
+            funding_addrs,
+            hashlock,
+            receiver_pubkey,
+            locktime,
+            sender_pubkey,
+            blinding_key,
+        })
+    }
+
+    fn claim_script(&self) -> Script {
+        match self.swap_type {
+            SwapType::Submarine => EBuilder::new()
+                .push_opcode(OP_HASH160)
+                .push_slice(self.hashlock.as_byte_array())
+                .push_opcode(OP_EQUALVERIFY)
+                .push_key(&self.receiver_pubkey)
+                .push_opcode(OP_CHECKSIG)
+                .into_script(),
+
+            SwapType::ReverseSubmarine => EBuilder::new()
+                .push_opcode(OP_SIZE)
+                .push_int(20)
+                .push_opcode(OP_EQUALVERIFY)
+                .push_opcode(OP_HASH160)
+                .push_slice(self.hashlock.as_byte_array())
+                .push_opcode(OP_EQUALVERIFY)
+                .push_key(&self.receiver_pubkey)
+                .push_opcode(OP_CHECKSIG)
+                .into_script(),
+        }
+    }
+
+    fn refund_script(&self) -> Script {
+        match self.swap_type {
+            SwapType::Submarine => EBuilder::new()
+                .push_key(&self.sender_pubkey)
+                .push_opcode(OP_CHECKSIGVERIFY)
+                .push_int(self.locktime.to_consensus_u32() as i64)
+                .push_opcode(OP_CLTV)
+                .into_script(),
+            SwapType::ReverseSubmarine => EBuilder::new()
+                .push_key(&self.sender_pubkey)
+                .push_opcode(OP_CHECKSIGVERIFY)
+                .push_int(self.locktime.to_consensus_u32() as i64)
+                .push_opcode(OP_CLTV)
+                .into_script(),
+        }
+    }
+
+    /// Internally used to convert struct into a bitcoin::Script type
+    fn taproot_spendinfo(&self) -> Result<TaprootSpendInfo, Error> {
+        let secp = Secp256k1::new();
+
+        // Setup Key Aggregation cache
+        let pubkeys = [self.receiver_pubkey.inner, self.sender_pubkey.inner];
+
+        let mut key_agg_cache = MusigKeyAggCache::new(&secp, &pubkeys);
+
+        // Construct the Taproot
+        let internal_key = key_agg_cache.agg_pk();
+
+        let taproot_builder = TaprootBuilder::new();
+
+        let taproot_builder = taproot_builder
+            .add_leaf_with_ver(1, self.claim_script(), LeafVersion::default())
+            .unwrap();
+        let taproot_builder = taproot_builder
+            .add_leaf_with_ver(1, self.refund_script(), LeafVersion::default())
+            .unwrap();
+
+        let taproot_spend_info = taproot_builder.finalize(&secp, internal_key).unwrap();
+
+        // Verify taproot construction
+        let output_key = taproot_spend_info.output_key();
+
+        let lockup_spk = self.funding_addrs.script_pubkey();
+
+        let pubkey_instruction = lockup_spk
+            .instructions()
+            .last()
+            .expect("should contain value")
+            .expect("should not fail");
+
+        let lockup_xonly_pubkey_bytes = pubkey_instruction
+            .push_bytes()
+            .expect("pubkey bytes expected");
+
+        let lockup_xonly_pubkey = XOnlyPublicKey::from_slice(lockup_xonly_pubkey_bytes)?;
+
+        assert!(lockup_xonly_pubkey == output_key.into_inner());
+
+        log::info!("Taproot creation and verification success!");
+
+        Ok(taproot_spend_info)
+    }
+
+    /// Get address for the swap script.
+    /// Submarine swaps use p2shwsh. Reverse swaps use p2wsh.
+    /// Always returns a confidential address
+    pub fn to_address(&self, network: Chain) -> Result<EAddress, Error> {
+        let taproot_spend_info = self.taproot_spendinfo()?;
+        let address_params = match network {
+            Chain::Liquid => &AddressParams::LIQUID,
+            Chain::LiquidTestnet => &AddressParams::LIQUID_TESTNET,
+            _ => {
+                return Err(Error::Address(
+                    "Cannot derive Liquid address for Bitcoin network".to_string(),
+                ))
+            }
+        };
+
+        Ok(EAddress::p2tr(
+            &Secp256k1::new(),
+            taproot_spend_info.internal_key(),
+            taproot_spend_info.merkle_root(),
+            Some(self.blinding_key.public_key()),
+            address_params,
+        ))
+    }
+
+    /// Get balance for the swap script
+    pub fn get_balance(&self, network_config: &ElectrumConfig) -> Result<(u64, i64), Error> {
+        let electrum_client = network_config.clone().build_client()?;
+
+        let _ = electrum_client.script_subscribe(BitcoinScript::from_bytes(
+            &self
+                .to_address(network_config.network())?
+                .script_pubkey()
+                .as_bytes(),
+        ))?;
+
+        let balance = electrum_client.script_get_balance(BitcoinScript::from_bytes(
+            &self
+                .to_address(network_config.network())?
+                .script_pubkey()
+                .as_bytes(),
+        ))?;
+
+        let _ = electrum_client.script_unsubscribe(BitcoinScript::from_bytes(
+            &self
+                .to_address(network_config.network())?
+                .script_pubkey()
+                .as_bytes(),
+        ))?;
+        Ok((balance.confirmed, balance.unconfirmed))
+    }
+
+    /// Fetch utxo for script
+    pub fn fetch_utxo(&self, network_config: &ElectrumConfig) -> Result<(OutPoint, TxOut), Error> {
+        let electrum_client = network_config.clone().build_client()?;
+        let address = self.to_address(network_config.network())?;
+        let history = electrum_client.script_get_history(BitcoinScript::from_bytes(
+            self.to_address(network_config.network())?
+                .to_unconfidential()
+                .script_pubkey()
+                .as_bytes(),
+        ))?;
+        if history.is_empty() {
+            return Err(Error::Protocol("No Transaction History".to_string()));
+        }
+        let bitcoin_txid = history.last().expect("txid expected").tx_hash;
+        let raw_tx = electrum_client.transaction_get_raw(&bitcoin_txid)?;
+        let tx: Transaction = elements::encode::deserialize(&raw_tx)?;
+        let mut vout = 0;
+        for output in tx.clone().output {
+            if output.script_pubkey == address.script_pubkey() {
+                let outpoint_0 = OutPoint::new(tx.txid(), vout);
+
+                return Ok((outpoint_0, output));
+            }
+            vout += 1;
+        }
+        return Err(Error::Protocol(
+            "Could not find utxos for script".to_string(),
+        ));
+    }
+
+    // Get the chain genesis hash. Requires for sighash calculation
+    pub fn genesis_hash(
+        &self,
+        electrum_config: &ElectrumConfig,
+    ) -> Result<elements::BlockHash, Error> {
+        let electrum = electrum_config.build_client()?;
+        Ok(elements::BlockHash::from_raw_hash(
+            electrum.block_header(0)?.block_hash().into(),
+        ))
+    }
+}
+
+fn bytes_to_u32_little_endian(bytes: &[u8]) -> u32 {
+    let mut result = 0u32;
+    for (i, &byte) in bytes.iter().enumerate() {
+        result |= (byte as u32) << (8 * i);
+    }
+    result
+}
+
+/// Liquid swap transaction helper.
+#[derive(Debug, Clone)]
+pub struct LBtcSwapTx {
+    kind: SwapTxKind,
+    swap_script: LBtcSwapScriptV2,
+    output_address: Address,
+    funding_outpoint: OutPoint,
+    funding_utxo: TxOut,     // there should only ever be one outpoint in a swap
+    genesis_hash: BlockHash, // Required to calculate sighash
+}
+
+impl LBtcSwapTx {
+    /// Required to claim reverse swaps only. This is never used for submarine swaps.WW
+    pub fn new_claim(
+        swap_script: LBtcSwapScriptV2,
+        output_address: String,
+        network_config: &ElectrumConfig,
+    ) -> Result<LBtcSwapTx, Error> {
+        debug_assert!(
+            swap_script.swap_type != SwapType::Submarine,
+            "Claim transactions can only be constructed for Reverse swaps."
+        );
+
+        let (funding_outpoint, funding_utxo) = swap_script.fetch_utxo(network_config)?;
+
+        let electrum = network_config.build_client()?;
+        let genesis_hash =
+            elements::BlockHash::from_raw_hash(electrum.block_header(0)?.block_hash().into());
+
+        Ok(LBtcSwapTx {
+            kind: SwapTxKind::Claim,
+            swap_script: swap_script,
+            output_address: Address::from_str(&output_address)?,
+            funding_outpoint,
+            funding_utxo,
+            genesis_hash,
+        })
+    }
+    /// Required to claim submarine swaps only. This is never used for reverse swaps.
+    pub fn new_refund(
+        swap_script: LBtcSwapScriptV2,
+        output_address: String,
+        network_config: &ElectrumConfig,
+    ) -> Result<LBtcSwapTx, Error> {
+        debug_assert!(
+            swap_script.swap_type != SwapType::ReverseSubmarine,
+            "Refund transactions can only be constructed for Submarine swaps."
+        );
+        let address = Address::from_str(&output_address)?;
+
+        let (funding_outpoint, funding_utxo) = swap_script.fetch_utxo(network_config)?;
+
+        let electrum = network_config.build_client()?;
+        let genesis_hash =
+            elements::BlockHash::from_raw_hash(electrum.block_header(0)?.block_hash().into());
+
+        Ok(LBtcSwapTx {
+            kind: SwapTxKind::Refund,
+            swap_script: swap_script,
+            output_address: address,
+            funding_outpoint,
+            funding_utxo,
+            genesis_hash,
+        })
+    }
+
+    /// Compute the Musig partial signature for Submarine Swap.
+    /// This is used to cooperatively close a submarine swap.
+    fn submarine_partial_sig(
+        &self,
+        keys: &Keypair,
+        claim_tx_response: &ClaimTxResponse,
+    ) -> Result<(MusigPartialSignature, MusigPubNonce), Error> {
+        // Step 1: Start with a Musig KeyAgg Cache
+        let secp = Secp256k1::new();
+
+        let pubkeys = [
+            self.swap_script.receiver_pubkey.inner,
+            self.swap_script.sender_pubkey.inner,
+        ];
+
+        let mut key_agg_cache = MusigKeyAggCache::new(&secp, &pubkeys);
+
+        let session_id = MusigSessionId::new(&mut thread_rng());
+
+        let msg = Message::from_digest_slice(
+            &Vec::from_hex(&claim_tx_response.transaction_hash).unwrap(),
+        )?;
+
+        // Step 4: Start the Musig2 Signing session
+        let mut extra_rand = [0u8; 32];
+        OsRng.fill_bytes(&mut extra_rand);
+
+        let (sec_nonce, pub_nonce) =
+            key_agg_cache.nonce_gen(&secp, session_id, keys.public_key(), msg, Some(extra_rand))?;
+
+        let boltz_nonce = MusigPubNonce::from_slice(&Vec::from_hex(&claim_tx_response.pub_nonce)?)?;
+
+        let agg_nonce = MusigAggNonce::new(&secp, &[boltz_nonce, pub_nonce]);
+
+        let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+
+        let partial_sig = musig_session.partial_sign(&secp, sec_nonce, &keys, &key_agg_cache)?;
+
+        let is_partial_sig_valid = musig_session.partial_verify(
+            &secp,
+            &key_agg_cache,
+            partial_sig,
+            pub_nonce,
+            keys.public_key(),
+        );
+
+        assert!(is_partial_sig_valid == true);
+
+        log::info!("Partial Signature creation and verification success.");
+
+        Ok((partial_sig, pub_nonce))
+    }
+
+    /// Sign a reverse swap claim transaction.
+    /// Panics if called on a Normal Swap or Refund Tx.
+    /// If the claim is cooperative, provide the other party's partial sigs.
+    /// If this is None, transaction will be claimed via taproot script path.
+    pub fn sign_claim(
+        &self,
+        keys: &Keypair,
+        preimage: &Preimage,
+        absolute_fees: u64,
+        is_cooperative: Option<(MusigPartialSignature, MusigPubNonce)>,
+    ) -> Result<Transaction, Error> {
+        debug_assert!(
+            self.swap_script.swap_type != SwapType::Submarine,
+            "Claim transactions can only be constructed for Reverse swaps."
+        );
+        debug_assert!(
+            self.kind != SwapTxKind::Refund,
+            "Constructed transaction is a refund. Cannot claim."
+        );
+        let preimage_bytes = preimage
+            .bytes
+            .ok_or(Error::Protocol("No preimage provided".to_string()))?;
+
+        let claim_txin = TxIn {
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            previous_output: self.funding_outpoint,
+            script_sig: Script::new(),
+            witness: TxInWitness::default(),
+            is_pegin: false,
+            asset_issuance: AssetIssuance::default(),
+        };
+
+        let secp = Secp256k1::new();
+
+        // Unblind the funding utxo
+        let unblinded_utxo = self
+            .funding_utxo
+            .unblind(&secp, self.swap_script.blinding_key.secret_key())?;
+
+        let output_value = unblinded_utxo.value - absolute_fees;
+        let exp_asset = Asset::Explicit(unblinded_utxo.asset);
+        let exp_value = elements::confidential::Value::Explicit(output_value);
+
+        // Create new Blinding Factors
+        let asset_bf = AssetBlindingFactor::new(&mut thread_rng());
+        let msg = elements::RangeProofMessage {
+            asset: unblinded_utxo.asset,
+            bf: asset_bf,
+        };
+        let value_bf = ValueBlindingFactor::last(
+            &secp,
+            output_value,
+            asset_bf,
+            &[(
+                unblinded_utxo.value,
+                unblinded_utxo.asset_bf,
+                unblinded_utxo.value_bf,
+            )],
+            &[(
+                absolute_fees,
+                AssetBlindingFactor::zero(),
+                ValueBlindingFactor::zero(),
+            )],
+        );
+
+        // Blind the Value
+        let blinding_key = self.output_address.blinding_pubkey.ok_or(Error::Protocol(
+            "We can only send to blinded address.".to_string(),
+        ))?;
+
+        let (blinded_value, nonce, range_proof) = exp_value.blind(
+            &secp,
+            value_bf,
+            blinding_key,
+            SecretKey::new(&mut thread_rng()),
+            &self.output_address.script_pubkey(),
+            &msg,
+        )?;
+
+        // Blind the Asset
+        let (blinded_asset, surjection_proof) = exp_asset.blind(
+            &mut thread_rng(),
+            &secp,
+            AssetBlindingFactor::new(&mut thread_rng()),
+            &[unblinded_utxo],
+        )?;
+
+        // Create the witness and the outputs
+        let tx_out_witness = TxOutWitness {
+            surjection_proof: Some(Box::new(surjection_proof)), // from asset blinding
+            rangeproof: Some(Box::new(range_proof)),            // from value blinding
+        };
+
+        let payment_output: TxOut = TxOut {
+            script_pubkey: self.output_address.script_pubkey(),
+            value: blinded_value,
+            asset: blinded_asset,
+            nonce: nonce,
+            witness: tx_out_witness,
+        };
+        let fee_output: TxOut = TxOut::new_fee(absolute_fees, unblinded_utxo.asset);
+
+        let mut claim_tx = Transaction {
+            version: 2,
+            lock_time: LockTime::ZERO,
+            input: vec![claim_txin],
+            output: vec![payment_output, fee_output],
+        };
+
+        // If its a cooperative claim, compute the Musig2 Aggregate Signature and use Keypath spending
+        if let Some((boltz_partial_sig, boltz_public_nonce)) = is_cooperative {
+            let claim_tx_taproot_hash = SighashCache::new(&claim_tx)
+                .taproot_key_spend_signature_hash(
+                    0,
+                    &Prevouts::All(&[&self.funding_utxo]),
+                    SchnorrSighashType::Default,
+                    self.genesis_hash,
+                )
+                .unwrap();
+
+            let msg = Message::from_digest_slice(claim_tx_taproot_hash.as_byte_array()).unwrap();
+
+            let mut key_agg_cache = MusigKeyAggCache::new(
+                &secp,
+                &[
+                    self.swap_script.receiver_pubkey.inner,
+                    self.swap_script.sender_pubkey.inner,
+                ],
+            );
+
+            let session_id = MusigSessionId::new(&mut thread_rng());
+
+            let mut extra_rand = [0u8; 32];
+            OsRng.fill_bytes(&mut extra_rand);
+
+            let (sec_nonce, pub_nonce) = key_agg_cache
+                .nonce_gen(&secp, session_id, keys.public_key(), msg, Some(extra_rand))
+                .unwrap();
+
+            let agg_nonce = MusigAggNonce::new(&secp, &[boltz_public_nonce, pub_nonce]);
+
+            let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+
+            let our_partial_sig = musig_session
+                .partial_sign(&secp, sec_nonce, &keys, &key_agg_cache)
+                .unwrap();
+
+            let schnorr_sig = musig_session.partial_sig_agg(&[boltz_partial_sig, our_partial_sig]);
+
+            let final_schnorr_sig = SchnorrSig {
+                sig: schnorr_sig,
+                hash_ty: SchnorrSighashType::Default,
+            };
+
+            // Verify the sigs.
+            let boltz_partial_sig_verify = musig_session.partial_verify(
+                &secp,
+                &key_agg_cache,
+                boltz_partial_sig,
+                boltz_public_nonce,
+                self.swap_script.sender_pubkey.inner,
+            );
+
+            assert!(boltz_partial_sig_verify == true);
+
+            let output_key = self.swap_script.taproot_spendinfo()?.output_key();
+
+            let _ = secp.verify_schnorr(&final_schnorr_sig.sig, &msg, &output_key.into_inner())?;
+
+            let mut script_witness = Witness::new();
+            script_witness.push(final_schnorr_sig.to_vec());
+
+            let witness = TxInWitness {
+                amount_rangeproof: None,
+                inflation_keys_rangeproof: None,
+                script_witness: script_witness.to_vec(),
+                pegin_witness: vec![],
+            };
+
+            claim_tx.input[0].witness = witness;
+
+            let claim_tx_hex = serialize(&claim_tx).to_lower_hex_string();
+        } else {
+            // If Non-Cooperative claim use the Script Path spending
+
+            let claim_script = self.swap_script.claim_script();
+            let leaf_hash = TapLeafHash::from_script(&claim_script, LeafVersion::default());
+
+            let sighash = SighashCache::new(&claim_tx)
+                .taproot_script_spend_signature_hash(
+                    0,
+                    &Prevouts::All(&[&self.funding_utxo]),
+                    leaf_hash,
+                    SchnorrSighashType::Default,
+                    self.genesis_hash,
+                )
+                .unwrap();
+
+            let msg = Message::from_digest_slice(sighash.as_byte_array()).unwrap();
+
+            let sig = secp.sign_schnorr(&msg, &keys);
+
+            let final_sig = SchnorrSig {
+                sig,
+                hash_ty: SchnorrSighashType::Default,
+            };
+
+            let control_block = self
+                .swap_script
+                .taproot_spendinfo()?
+                .control_block(&(claim_script.clone(), LeafVersion::default()))
+                .unwrap();
+
+            let mut script_witness = Witness::new();
+            script_witness.push(final_sig.to_vec());
+            script_witness.push(claim_script.as_bytes());
+            script_witness.push(control_block.serialize());
+
+            let witness = TxInWitness {
+                amount_rangeproof: None,
+                inflation_keys_rangeproof: None,
+                script_witness: script_witness.to_vec(),
+                pegin_witness: vec![],
+            };
+
+            claim_tx.input[0].witness = witness;
+        }
+
+        Ok(claim_tx)
+    }
+
+    /// Sign a refund transaction for a submarine swap
+    pub fn sign_refund(&self, keys: &Keypair, absolute_fees: u64) -> Result<Transaction, Error> {
+        debug_assert!(
+            self.swap_script.swap_type != SwapType::ReverseSubmarine,
+            "Refund transactions can only be constructed for Submarine swaps."
+        );
+        debug_assert!(
+            self.kind != SwapTxKind::Claim,
+            "Constructed transaction is a claim. Cannot refund."
+        );
+
+        // Create unsigned refund transaction
+        let refund_txin = TxIn {
+            sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,
+            previous_output: self.funding_outpoint,
+            script_sig: Script::new(),
+            witness: TxInWitness::default(),
+            is_pegin: false,
+            asset_issuance: AssetIssuance::default(),
+        };
+
+        let secp = Secp256k1::new();
+
+        let unblined_utxo = self
+            .funding_utxo
+            .unblind(&secp, self.swap_script.blinding_key.secret_key())?;
+        let asset_id = unblined_utxo.asset;
+        let out_abf = AssetBlindingFactor::new(&mut thread_rng());
+        let exp_asset = Asset::Explicit(asset_id);
+
+        let (blinded_asset, asset_surjection_proof) =
+            exp_asset.blind(&mut thread_rng(), &secp, out_abf, &[unblined_utxo])?;
+
+        let output_value = unblined_utxo.value - absolute_fees;
+
+        let final_vbf = ValueBlindingFactor::last(
+            &secp,
+            output_value,
+            out_abf,
+            &[(
+                unblined_utxo.value,
+                unblined_utxo.asset_bf,
+                unblined_utxo.value_bf,
+            )],
+            &[(
+                absolute_fees,
+                AssetBlindingFactor::zero(),
+                ValueBlindingFactor::zero(),
+            )],
+        );
+        let explicit_value = elements::confidential::Value::Explicit(output_value);
+        let msg = elements::RangeProofMessage {
+            asset: asset_id,
+            bf: out_abf,
+        };
+        let ephemeral_sk = SecretKey::new(&mut thread_rng());
+
+        // assuming we always use a blinded address that has an extractable blinding pub
+        let blinding_key = self
+            .output_address
+            .blinding_pubkey
+            .ok_or(Error::Protocol("No blinding key in tx.".to_string()))?;
+        let (blinded_value, nonce, rangeproof) = explicit_value.blind(
+            &secp,
+            final_vbf,
+            blinding_key,
+            ephemeral_sk,
+            &self.output_address.script_pubkey(),
+            &msg,
+        )?;
+
+        let tx_out_witness = TxOutWitness {
+            surjection_proof: Some(Box::new(asset_surjection_proof)), // from asset blinding
+            rangeproof: Some(Box::new(rangeproof)),                   // from value blinding
+        };
+        let payment_output: TxOut = TxOut {
+            script_pubkey: self.output_address.script_pubkey(),
+            value: blinded_value,
+            asset: blinded_asset,
+            nonce: nonce,
+            witness: tx_out_witness,
+        };
+        let fee_output: TxOut = TxOut::new_fee(absolute_fees, asset_id);
+
+        let refund_script = self.swap_script.refund_script();
+
+        let lock_time = refund_script
+            .instructions()
+            .filter_map(|i| {
+                let ins = i.unwrap();
+                if let Instruction::PushBytes(bytes) = ins {
+                    if bytes.len() == 3 as usize {
+                        Some(LockTime::from_consensus(bytes_to_u32_little_endian(&bytes)))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .next()
+            .unwrap();
+
+        let mut refund_tx = Transaction {
+            version: 2,
+            lock_time,
+            input: vec![refund_txin],
+            output: vec![payment_output, fee_output],
+        };
+
+        let leaf_hash = TapLeafHash::from_script(&refund_script, LeafVersion::default());
+
+        let electrum = ElectrumConfig::default_liquid().build_client()?;
+
+        let genesis_blockhash =
+            elements::BlockHash::from_raw_hash(electrum.block_header(0)?.block_hash().into());
+
+        let sighash = SighashCache::new(&refund_tx)
+            .taproot_script_spend_signature_hash(
+                0,
+                &Prevouts::All(&[&self.funding_utxo]),
+                leaf_hash,
+                SchnorrSighashType::Default,
+                genesis_blockhash,
+            )
+            .unwrap();
+
+        let msg = Message::from_digest_slice(sighash.as_byte_array()).unwrap();
+
+        let sig = secp.sign_schnorr(&msg, &keys);
+
+        let final_sig = SchnorrSig {
+            sig,
+            hash_ty: SchnorrSighashType::Default,
+        };
+
+        let control_block = self
+            .swap_script
+            .taproot_spendinfo()?
+            .control_block(&(refund_script.clone(), LeafVersion::default()))
+            .unwrap();
+
+        let mut script_witness = Witness::new();
+        script_witness.push(final_sig.to_vec());
+        script_witness.push(refund_script.as_bytes());
+        script_witness.push(control_block.serialize());
+
+        let witness = TxInWitness {
+            amount_rangeproof: None,
+            inflation_keys_rangeproof: None,
+            script_witness: script_witness.to_vec(),
+            pegin_witness: vec![],
+        };
+
+        refund_tx.input[0].witness = witness;
+
+        Ok(refund_tx)
+    }
+
+    /// Calculate the size of a transaction.
+    /// Use this before calling drain to help calculate the absolute fees.
+    /// Multiply the size by the fee_rate to get the absolute fees.
+    pub fn size(
+        &self,
+        keys: &Keypair,
+        preimage: &Preimage,
+        is_cooperative: Option<(MusigPartialSignature, MusigPubNonce)>,
+    ) -> Result<usize, Error> {
+        let dummy_abs_fee = 5_000;
+        let tx = match self.kind {
+            SwapTxKind::Claim => self.sign_claim(keys, preimage, dummy_abs_fee, is_cooperative)?,
+            SwapTxKind::Refund => self.sign_refund(keys, dummy_abs_fee)?,
+        };
+        Ok(tx.vsize())
+    }
+
+    /// Broadcast transaction to the network
+    pub fn broadcast(
+        &self,
+        signed_tx: Transaction,
+        network_config: &ElectrumConfig,
+    ) -> Result<String, Error> {
+        let electrum_client = network_config.build_client()?;
+        let serialized = serialize(&signed_tx);
+        Ok(electrum_client
+            .transaction_broadcast_raw(&serialized)?
+            .to_string())
+    }
+}

--- a/src/swaps/mod.rs
+++ b/src/swaps/mod.rs
@@ -3,3 +3,4 @@ pub mod boltz;
 pub mod boltzv2;
 pub mod btc_swapper;
 pub mod liquid;
+pub mod liquid_swapper;

--- a/src/swaps/mod.rs
+++ b/src/swaps/mod.rs
@@ -1,6 +1,8 @@
 pub mod bitcoin;
+pub mod bitcoinv2;
 pub mod boltz;
 pub mod boltzv2;
 pub mod btc_swapper;
 pub mod liquid;
 pub mod liquid_swapper;
+pub mod liquidv2;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -6,10 +6,9 @@ pub mod secrets;
 /// Setup function that will only run once, even if called multiple times.
 pub fn setup_logger() {
     Once::new().call_once(|| {
-        env::set_var("RUST_LOG", "info");
         env_logger::Builder::from_env(
             env_logger::Env::default()
-                .default_filter_or("coinswap=info")
+                .default_filter_or("debug")
                 .default_write_style_or("always"),
         )
         // .is_test(true)

--- a/tests/bitcoin_v2.rs
+++ b/tests/bitcoin_v2.rs
@@ -1,0 +1,305 @@
+use std::str::FromStr;
+
+use boltz_client::{
+    network::electrum::ElectrumConfig,
+    swaps::{
+        boltz::BOLTZ_TESTNET_URL,
+        boltzv2::{
+            BoltzApiClientV2, CreateReverseReq, CreateSwapRequest, Subscription, SwapUpdate,
+            BOLTZ_TESTNET_URL_V2,
+        },
+    },
+    util::{secrets::Preimage, setup_logger},
+    Bolt11Invoice, BtcSwapScriptV2, BtcSwapTxV2, Secp256k1,
+};
+
+use bitcoin::{
+    hashes::{sha256, Hash},
+    hex::FromHex,
+    key::rand::thread_rng,
+    secp256k1::Keypair,
+    PublicKey,
+};
+
+pub mod test_utils;
+
+#[test]
+#[ignore = "Requires testnet invoice and refund address"]
+fn bitcoin_v2_submarine() {
+    setup_logger();
+
+    let secp = Secp256k1::new();
+    let our_keys = Keypair::new(&secp, &mut thread_rng());
+
+    let refund_public_key = PublicKey {
+        inner: our_keys.public_key(),
+        compressed: true,
+    };
+
+    // Set a new invoice string and refund address for each test.
+    let invoice = "lntb650u1pjut6cfpp5h7dgn6wghmsm8dfky9cjzrlyf5c2xaszk2lxamfqm2w4eurevpwqdq8d3skk6qxqyjw5qcqp2sp5nyk5mtwjf250uv0uf2l2trhyycefndu868dya04zlrvw5gvaev2srzjq2gyp9za7vc7vd8m59fvu63pu00u4pak35n4upuv4mhyw5l586dvkf6vkyqq20gqqqqqqqqpqqqqqzsqqc9qyyssqva5tvj5gxfsdmc84hvreme8djgwj3rqr37kwtsa6qttgwzhe7s0yfy482afyje45ppualmatfwnmlmk2py7wc7l3l849jl7vdpa86aqqxmqmws".to_string();
+    let refund_address = "tb1qq20a7gqewc0un9mxxlqyqwn7ut7zjrj9y3d0mu".to_string();
+
+    // Initiate the swap with Boltz
+    let create_swap_req = CreateSwapRequest {
+        from: "BTC".to_string(),
+        to: "BTC".to_string(),
+        invoice: invoice.to_string(),
+        refund_public_key,
+    };
+
+    let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL_V2);
+
+    let create_swap_response = boltz_api_v2.post_swap_req(&create_swap_req).unwrap();
+
+    log::info!("Got Swap Response from Boltz server");
+
+    log::debug!("Swap Response: {:?}", create_swap_response);
+
+    let swap_script = BtcSwapScriptV2::submarine_from_swap_resp(&create_swap_response).unwrap();
+
+    log::debug!("Created Swap Script. : {:?}", swap_script);
+
+    // Subscribe to websocket updates
+    let mut socket = boltz_api_v2.connect_ws().unwrap();
+
+    socket
+        .send(tungstenite::Message::Text(
+            serde_json::to_string(&Subscription::new(&create_swap_response.id)).unwrap(),
+        ))
+        .unwrap();
+
+    // Event handlers for various swap status.
+    loop {
+        let response = serde_json::from_str(&socket.read().unwrap().to_string());
+
+        if response.is_err() {
+            if response.err().expect("expected").is_eof() {
+                continue;
+            }
+        } else {
+            match response.unwrap() {
+                SwapUpdate::Subscription {
+                    event,
+                    channel,
+                    args,
+                } => {
+                    assert!(event == "subscribe");
+                    assert!(channel == "swap.update");
+                    assert!(args.get(0).expect("expected") == &create_swap_response.id);
+                    log::info!(
+                        "Successfully subscribed for Swap updates. Swap ID : {}",
+                        create_swap_response.id
+                    );
+                }
+
+                SwapUpdate::Update {
+                    event,
+                    channel,
+                    args,
+                } => {
+                    assert!(event == "update");
+                    assert!(channel == "swap.update");
+                    let update = args.get(0).expect("expected");
+                    assert!(update.id == create_swap_response.id);
+                    log::info!("Got Update from server: {}", update.status);
+
+                    // Invoice is Set. Waiting for us to send onchain tx.
+                    if update.status == "invoice.set" {
+                        log::info!(
+                            "Send {} sats to BTC address {}",
+                            create_swap_response.expected_amount,
+                            create_swap_response.address
+                        );
+                    }
+
+                    // Boltz has paid the invoice, and waiting for our partial sig.
+                    if update.status == "transaction.claim.pending" {
+                        // Create the refund transaction at this stage
+                        // This will fail if the funding transaction isn't confirmed yet. Which should not happen.
+                        let swap_tx = BtcSwapTxV2::new_refund(
+                            swap_script.clone(),
+                            &refund_address,
+                            &ElectrumConfig::default_bitcoin(),
+                        )
+                        .unwrap()
+                        .expect("Funding UTXO not found");
+
+                        let claim_tx_response = boltz_api_v2
+                            .get_claim_tx_details(&create_swap_response.id)
+                            .unwrap();
+
+                        log::debug!("Received claim tx details : {:?}", claim_tx_response);
+
+                        // Check that boltz have the correct preimage.
+                        // At this stage the client should verify that LN invoice has been paid.
+                        let preimage = Vec::from_hex(&claim_tx_response.preimage).unwrap();
+                        let preimage_hash = sha256::Hash::hash(&preimage);
+                        let invoice = Bolt11Invoice::from_str(&create_swap_req.invoice).unwrap();
+                        let invoice_payment_hash = invoice.payment_hash();
+                        assert!(invoice_payment_hash.to_string() == preimage_hash.to_string());
+                        log::info!("Correct Hash preimage received from Boltz.");
+
+                        // Compute and send Musig2 partial sig
+                        let (partial_sig, pub_nonce) = swap_tx
+                            .submarine_partial_sig(&our_keys, &claim_tx_response)
+                            .unwrap();
+                        boltz_api_v2
+                            .post_claim_tx_details(&create_swap_response.id, pub_nonce, partial_sig)
+                            .unwrap();
+                        log::info!("Successfully Sent partial signature");
+                    }
+
+                    if update.status == "transaction.claimed" {
+                        log::info!("Successfully completed submarine swap");
+                        break;
+                    }
+                }
+
+                SwapUpdate::Error {
+                    event,
+                    channel,
+                    args,
+                } => {
+                    assert!(event == "update");
+                    assert!(channel == "swap.update");
+                    let error = args.get(0).expect("expected");
+                    log::error!(
+                        "Got Boltz response error : {} for swap: {}",
+                        error.error,
+                        error.id
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+//#[ignore = "reason"]
+fn bitcoin_v2_reverse() {
+    setup_logger();
+
+    let secp = Secp256k1::new();
+    let preimage = Preimage::new();
+    let our_keys = Keypair::new(&secp, &mut thread_rng());
+    let invoice_amount = 100000;
+
+    // Give a valid claim address or else funds will be lost.
+    let claim_address = "tb1qq20a7gqewc0un9mxxlqyqwn7ut7zjrj9y3d0mu".to_string();
+
+    let create_reverse_req = CreateReverseReq {
+        invoice_amount,
+        from: "BTC".to_string(),
+        to: "BTC".to_string(),
+        preimage_hash: preimage.sha256,
+        claim_public_key: PublicKey {
+            compressed: true,
+            inner: our_keys.public_key(),
+        },
+    };
+
+    let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL);
+
+    let reverse_resp = boltz_api_v2.post_reverse_req(create_reverse_req).unwrap();
+
+    log::debug!("Got Reverse swap response: {:?}", reverse_resp);
+
+    let swap_script = BtcSwapScriptV2::reverse_from_swap_resp(&reverse_resp).unwrap();
+
+    // Subscribe to wss status updates
+    let mut socket = boltz_api_v2.connect_ws().unwrap();
+
+    let subscription = Subscription::new(&reverse_resp.id);
+
+    socket
+        .send(tungstenite::Message::Text(
+            serde_json::to_string(&subscription).unwrap(),
+        ))
+        .unwrap();
+
+    // Event handlers for various swap status.
+    loop {
+        let response = serde_json::from_str(&socket.read().unwrap().to_string());
+
+        if response.is_err() {
+            if response.err().expect("expected").is_eof() {
+                continue;
+            }
+        } else {
+            match response.as_ref().unwrap() {
+                SwapUpdate::Subscription {
+                    event,
+                    channel,
+                    args,
+                } => {
+                    assert!(event == "subscribe");
+                    assert!(channel == "swap.update");
+                    assert!(args.get(0).expect("expected") == &reverse_resp.id);
+                    log::info!("Subscription successful for swap : {}", &reverse_resp.id);
+                }
+
+                SwapUpdate::Update {
+                    event,
+                    channel,
+                    args,
+                } => {
+                    assert!(event == "update");
+                    assert!(channel == "swap.update");
+                    let update = args.get(0).expect("expected");
+                    assert!(&update.id == &reverse_resp.id);
+                    log::info!("Got Update from server: {}", update.status);
+
+                    if update.status == "swap.created" {
+                        log::info!("Waiting for Invoice to be paid: {}", &reverse_resp.invoice);
+                        continue;
+                    }
+
+                    if update.status == "transaction.mempool" {
+                        log::info!("Boltz broadcasted funding tx");
+
+                        let claim_tx = BtcSwapTxV2::new_claim(
+                            swap_script.clone(),
+                            claim_address.clone(),
+                            &ElectrumConfig::default_bitcoin(),
+                        )
+                        .unwrap()
+                        .expect("Funding tx expected");
+
+                        let tx = claim_tx
+                            .sign_claim(
+                                &our_keys,
+                                &preimage,
+                                1000,
+                                Some((&boltz_api_v2, reverse_resp.id.clone())),
+                            )
+                            .unwrap();
+
+                        claim_tx
+                            .broadcast(&tx, &ElectrumConfig::default_bitcoin())
+                            .unwrap();
+
+                        log::info!("Succesfully broadcasted claim tx!");
+                        log::debug!("Claim Tx {:?}", tx);
+                    }
+
+                    if update.status == "invoice.settled" {
+                        log::info!("Reverse Swap Successful!");
+                        break;
+                    }
+                }
+
+                SwapUpdate::Error {
+                    event,
+                    channel,
+                    args,
+                } => {
+                    assert!(event == "update");
+                    assert!(channel == "swap.update");
+                    let error = args.get(0).expect("expected");
+                    println!("Got error : {} for swap: {}", error.error, error.id);
+                }
+            }
+        }
+    }
+}

--- a/tests/regtest-claim.rs
+++ b/tests/regtest-claim.rs
@@ -10,12 +10,12 @@ use boltz_client::util::secrets::Preimage;
 use boltz_client::{BtcSwapScript, BtcSwapTx};
 use boltz_client::{SwapTxKind, SwapType};
 mod test_framework;
-use test_framework::TestFramework;
+use test_framework::BtcTestFramework;
 
 #[test]
 fn test_reverse_claim_regtest() {
     // Init test framework and get a test-wallet
-    let test_framework = TestFramework::init();
+    let test_framework = BtcTestFramework::init();
 
     // Generate a random preimage and hash it.
     let preimage = Preimage::new();

--- a/tests/regtest-refund.rs
+++ b/tests/regtest-refund.rs
@@ -11,12 +11,12 @@ use boltz_client::network::Chain;
 use boltz_client::{BtcSwapScript, BtcSwapTx};
 use boltz_client::{SwapTxKind, SwapType};
 mod test_framework;
-use test_framework::TestFramework;
+use test_framework::BtcTestFramework;
 
 #[test]
 fn test_submarine_refund_regtest() {
     // Init test framework and get a test-wallet
-    let test_framework = TestFramework::init();
+    let test_framework = BtcTestFramework::init();
 
     // Generate a random preimage and hash it.
     let mut bytes = [0u8; 32];

--- a/tests/regtest_v2.rs
+++ b/tests/regtest_v2.rs
@@ -1,0 +1,203 @@
+use bitcoin::absolute::LockTime;
+use bitcoin::key::rand::thread_rng;
+use bitcoin::key::{Keypair, PublicKey};
+use bitcoin::secp256k1::Secp256k1;
+use bitcoin::{Amount, OutPoint, TxOut};
+use bitcoind::bitcoincore_rpc::json::ScanTxOutRequest;
+use bitcoind::bitcoincore_rpc::RpcApi;
+use boltz_client::network::Chain;
+use boltz_client::util::secrets::Preimage;
+use boltz_client::{BtcSwapScriptV2, BtcSwapTxV2};
+use boltz_client::{SwapTxKind, SwapType};
+mod test_framework;
+use test_framework::BtcTestFramework;
+
+#[test]
+fn test_reverse_claim_regtest() {
+    // Init test framework and get a test-wallet
+    let test_framework = BtcTestFramework::init();
+
+    // Generate a random preimage and hash it.
+    let preimage = Preimage::new();
+
+    // Generate dummy receiver and sender's keypair
+    let secp = Secp256k1::new();
+    let recvr_keypair = Keypair::new(&secp, &mut thread_rng());
+    let sender_keypair = Keypair::new(&secp, &mut thread_rng());
+
+    // create a btc swap script.
+    let swap_script = BtcSwapScriptV2 {
+        swap_type: SwapType::ReverseSubmarine,
+        funding_addrs: None,
+        hashlock: preimage.hash160,
+        receiver_pubkey: PublicKey {
+            compressed: true,
+            inner: recvr_keypair.public_key(),
+        },
+        locktime: LockTime::from_height(200).unwrap(),
+        sender_pubkey: PublicKey {
+            compressed: true,
+            inner: sender_keypair.public_key(),
+        },
+    };
+
+    // Send coin the swapscript address and confirm tx
+    let swap_addrs = swap_script.to_address(Chain::BitcoinRegtest).unwrap();
+    let spk = swap_addrs.script_pubkey();
+    println!("spk: {}", spk);
+    test_framework.send_coins(&swap_addrs, Amount::from_sat(10000));
+    test_framework.generate_blocks(1);
+
+    let scan_request = ScanTxOutRequest::Single(format!("addr({})", swap_addrs));
+
+    let scan_result = test_framework
+        .as_ref()
+        .scan_tx_out_set_blocking(&[scan_request.clone()])
+        .unwrap();
+
+    assert_eq!(scan_result.unspents.len(), 1);
+    assert_eq!(scan_result.total_amount, Amount::from_sat(10000));
+
+    // Create a refund spending transaction from the swap
+    let utxo = scan_result
+        .unspents
+        .iter()
+        .map(|utxo| {
+            let outpoint = OutPoint::new(utxo.txid, utxo.vout);
+            let txout = TxOut {
+                script_pubkey: utxo.script_pub_key.clone(),
+                value: utxo.amount,
+            };
+            (outpoint, txout)
+        })
+        .last()
+        .expect("value expected");
+
+    let test_wallet = test_framework.get_test_wallet();
+    let refund_addrs = test_wallet
+        .get_new_address(None, None)
+        .unwrap()
+        .assume_checked();
+
+    let swap_tx = BtcSwapTxV2 {
+        kind: SwapTxKind::Claim,
+        swap_script,
+        output_address: refund_addrs,
+        utxo,
+    };
+
+    let claim_tx = swap_tx
+        .sign_claim(&recvr_keypair, &preimage, 1000, None)
+        .unwrap();
+
+    test_framework
+        .as_ref()
+        .send_raw_transaction(&claim_tx)
+        .unwrap();
+    test_framework.generate_blocks(1);
+
+    let scan_result = test_framework
+        .as_ref()
+        .scan_tx_out_set_blocking(&[scan_request])
+        .unwrap();
+
+    assert_eq!(scan_result.unspents.len(), 0);
+    assert_eq!(scan_result.total_amount, Amount::from_sat(0));
+
+    let test_balance = test_wallet.get_balance(None, None).unwrap();
+
+    assert_eq!(test_balance, Amount::from_sat(19000));
+}
+
+#[test]
+fn test_submarine_refund_regtest() {
+    // Init test framework and get a test-wallet
+    let test_framework = BtcTestFramework::init();
+
+    // Generate dummy receiver and sender's keypair
+    let preimage = Preimage::new();
+    let secp = Secp256k1::new();
+    let recvr_keypair = Keypair::new(&secp, &mut thread_rng());
+    let sender_keypair = Keypair::new(&secp, &mut thread_rng());
+
+    // create a btc swap script.
+    let swap_script = BtcSwapScriptV2 {
+        swap_type: SwapType::Submarine,
+        funding_addrs: None,
+        hashlock: preimage.hash160,
+        receiver_pubkey: PublicKey {
+            compressed: true,
+            inner: recvr_keypair.public_key(),
+        },
+        locktime: LockTime::from_height(200).unwrap(),
+        sender_pubkey: PublicKey {
+            compressed: true,
+            inner: sender_keypair.public_key(),
+        },
+    };
+
+    // Send coin the swapscript address and confirm tx
+    let swap_addrs = swap_script.to_address(Chain::BitcoinRegtest).unwrap();
+    test_framework.send_coins(&swap_addrs, Amount::from_sat(10000));
+    test_framework.generate_blocks(1);
+
+    let scan_request = ScanTxOutRequest::Single(format!("addr({})", swap_addrs));
+
+    let scan_result = test_framework
+        .as_ref()
+        .scan_tx_out_set_blocking(&[scan_request.clone()])
+        .unwrap();
+
+    assert_eq!(scan_result.unspents.len(), 1);
+    assert_eq!(scan_result.total_amount, Amount::from_sat(10000));
+
+    // Create a refund spending transaction from the swap
+    let utxo = scan_result
+        .unspents
+        .iter()
+        .map(|utxo| {
+            let outpoint = OutPoint::new(utxo.txid, utxo.vout);
+            let txout = TxOut {
+                script_pubkey: utxo.script_pub_key.clone(),
+                value: utxo.amount,
+            };
+            (outpoint, txout)
+        })
+        .last()
+        .expect("value expected");
+
+    let test_wallet = test_framework.get_test_wallet();
+    let refund_addrs = test_wallet
+        .get_new_address(None, None)
+        .unwrap()
+        .assume_checked();
+
+    let swap_tx = BtcSwapTxV2 {
+        kind: SwapTxKind::Refund,
+        swap_script,
+        output_address: refund_addrs,
+        utxo,
+    };
+
+    let refund_tx = swap_tx.sign_refund(&sender_keypair, 1000).unwrap();
+
+    // Make the timelock matured and broadcast the spend
+    test_framework.generate_blocks(100);
+    test_framework
+        .as_ref()
+        .send_raw_transaction(&refund_tx)
+        .unwrap();
+    test_framework.generate_blocks(1);
+
+    let scan_result = test_framework
+        .as_ref()
+        .scan_tx_out_set_blocking(&[scan_request])
+        .unwrap();
+
+    assert_eq!(scan_result.unspents.len(), 0);
+    assert_eq!(scan_result.total_amount, Amount::from_sat(0));
+
+    let test_balance = test_wallet.get_balance(None, None).unwrap();
+
+    assert_eq!(test_balance, Amount::from_sat(19000));
+}

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -1,17 +1,24 @@
+use std::str::FromStr;
+
 use bitcoind::{
     bitcoincore_rpc::{Client, RpcApi},
     BitcoinD, Conf,
 };
 
-use bitcoin::{network::Network, Address, Amount, Txid};
+use elementsd::{downloaded_exe_path, ElementsD};
 
-pub struct TestFramework {
+use elements::Address as EAddress;
+
+use bitcoin::{network::Network, Address, Amount, Txid};
+use serde_json::Value;
+
+pub struct BtcTestFramework {
     bitcoind: BitcoinD,
     mining_address: Address,
     test_wallet: Client,
 }
 
-impl TestFramework {
+impl BtcTestFramework {
     /// Initializes the Bitcoind regtest backend, mines initial blocks,
     /// creates a test-wallet and funds it with 10,000 sats.
     pub fn init() -> Self {
@@ -87,8 +94,70 @@ impl TestFramework {
     }
 }
 
-impl AsRef<Client> for TestFramework {
+impl AsRef<Client> for BtcTestFramework {
     fn as_ref(&self) -> &Client {
         &self.bitcoind.client
     }
+}
+
+pub struct LbtcTestFramework {
+    elementsd: ElementsD,
+}
+
+impl LbtcTestFramework {
+    /// Initializes the Bitcoind regtest backend, mines initial blocks,
+    /// creates a test-wallet and funds it with 10,000 sats.
+    pub fn init() -> Self {
+        let elementsd = ElementsD::new(downloaded_exe_path().unwrap()).unwrap();
+
+        let mining_address = elementsd
+            .client()
+            .call::<Value>("getnewaddress", &[])
+            .unwrap()
+            .to_string();
+
+        elementsd.client().call::<Value>("generatetoaddress", &[101.into(), mining_address.into()]).unwrap();
+
+        elementsd
+            .client()
+            .call::<Value>("rescanblockchain", &[])
+            .unwrap();
+
+        let balance = elementsd
+            .client()
+            .call::<Value>("getbalances", &[])
+            .unwrap();
+
+        println!("balance : {}", balance);
+
+        LbtcTestFramework { elementsd }
+    }
+
+    pub fn generate_blocks(&self, n: u64) {
+        let mining_address = self
+            .elementsd
+            .client()
+            .get_new_address(None, None)
+            .unwrap()
+            .assume_checked();
+        self.elementsd
+            .client()
+            .generate_to_address(n, &mining_address)
+            .unwrap();
+
+        self.elementsd.client().rescan_blockchain(None, None);
+    }
+
+    // pub fn send_coins(&self, addr: &EAddress, amount: Amount) -> Txid {
+
+    // }
+
+    // pub fn get_test_wallet(&self) -> &Client {
+    //     &self.test_wallet
+    // }
+}
+
+#[test]
+fn test() {
+    let x = LbtcTestFramework::init();
 }

--- a/tests/test_v2_api.rs
+++ b/tests/test_v2_api.rs
@@ -28,7 +28,7 @@ fn test_v2_reverse() {
 
     let mut claim_addrs_str = String::new();
 
-    println!("Enter a claim address");
+    println!("Etenr a claim address");
     std::io::stdin().read_line(&mut claim_addrs_str).unwrap();
 
     let claim_addrs_str = claim_addrs_str.trim();


### PR DESCRIPTION
This PR adds the Liquid swapper API for Boltz V2.

API structure is similar to `BtcSwapper`. 

No test is added because unlike Bitcoin, Liquid taproot sighash calculation requires the genesis blockhash of the chain, which has to be obtained by connecting to the docker elements node of legend-regtest environment, which is not implemented currently.

The API should work with a testnet electrum client and the usual swap flow. 