### PR TITLE
Cooperative Refund + Lowball Broadcast

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,17 @@ pub mod swaps;
 /// utilities (key, preimage, error)
 pub mod util;
 
-pub use bitcoin::{PublicKey,secp256k1::{Keypair, Secp256k1}, Address,blockdata::locktime::absolute::LockTime,hashes::hash160::Hash, Amount};
-pub use elements::{secp256k1_zkp::{Keypair as ZKKeyPair, Secp256k1 as ZKSecp256k1}, address::Address as ElementsAddress, locktime::LockTime as ElementsLockTime};
+pub use bitcoin::{
+    blockdata::locktime::absolute::LockTime,
+    hashes::hash160::Hash,
+    secp256k1::{Keypair, Secp256k1},
+    Address, Amount, PublicKey,
+};
+pub use elements::{
+    address::Address as ElementsAddress,
+    locktime::LockTime as ElementsLockTime,
+    secp256k1_zkp::{Keypair as ZKKeyPair, Secp256k1 as ZKSecp256k1},
+};
 pub use lightning_invoice::Bolt11Invoice;
 
 pub use swaps::boltz::{SwapTxKind, SwapType};

--- a/src/network/electrum.rs
+++ b/src/network/electrum.rs
@@ -39,10 +39,13 @@ pub struct ElectrumConfig {
 }
 
 impl ElectrumConfig {
-    
     pub fn default(chain: Chain, regtest_url: Option<String>) -> Result<Self, Error> {
-        if (chain == Chain::LiquidRegtest || chain == Chain::BitcoinRegtest ) && regtest_url.is_none() {
-            return Err(Error::Electrum(electrum_client::Error::Message("Regtest requires using a custom url".to_string())))
+        if (chain == Chain::LiquidRegtest || chain == Chain::BitcoinRegtest)
+            && regtest_url.is_none()
+        {
+            return Err(Error::Electrum(electrum_client::Error::Message(
+                "Regtest requires using a custom url".to_string(),
+            )));
         }
         match chain {
             Chain::Bitcoin => Ok(ElectrumConfig::new(

--- a/src/swaps/bitcoinv2.rs
+++ b/src/swaps/bitcoinv2.rs
@@ -815,6 +815,8 @@ impl BtcSwapTxV2 {
             witness.push(final_schnorr_sig.to_vec());
 
             refund_tx.input[0].witness = witness;
+
+            refund_tx.lock_time = LockTime::ZERO; // No locktime for cooperative spend
         } else {
             let leaf_hash =
                 TapLeafHash::from_script(&self.swap_script.refund_script(), LeafVersion::TapScript);

--- a/src/swaps/bitcoinv2.rs
+++ b/src/swaps/bitcoinv2.rs
@@ -563,7 +563,7 @@ impl BtcSwapTxV2 {
                 Some(extra_rand),
             )?;
 
-            // Step 7: Get boltz's partail sig
+            // Step 7: Get boltz's partial sig
             let claim_tx_hex = serialize(&claim_tx).to_lower_hex_string();
             let partial_sig_resp = boltz_api.get_reverse_partial_sig(
                 &swap_id,
@@ -765,7 +765,7 @@ impl BtcSwapTxV2 {
                 Some(extra_rand),
             )?;
 
-            // Step 7: Get boltz's partail sig
+            // Step 7: Get boltz's partial sig
             let refund_tx_hex = serialize(&refund_tx).to_lower_hex_string();
             let partial_sig_resp =
                 boltz_api.get_submarine_partial_sig(&swap_id, &pub_nonce, &refund_tx_hex)?;
@@ -872,33 +872,13 @@ impl BtcSwapTxV2 {
     }
 
     /// Broadcast transaction to the network.
-    ///
-    /// Lowall sending can be enabled with `is_lowball` option and by providing a [BoltzApiClientV2] and a [Chain].
     pub fn broadcast(
         &self,
         signed_tx: &Transaction,
         network_config: &ElectrumConfig,
-        is_lowball: Option<(&BoltzApiClientV2, Chain)>,
     ) -> Result<Txid, Error> {
-        if let Some((boltz_api, chain)) = is_lowball {
-            log::info!("Attempting lowball braodcast");
-            let tx_hex = serialize(signed_tx).to_lower_hex_string();
-            let response = boltz_api.broadcast_tx(chain, &tx_hex)?;
-            let txid = Txid::from_str(
-                &response
-                    .as_object()
-                    .unwrap()
-                    .get("id")
-                    .unwrap()
-                    .as_str()
-                    .unwrap(),
-            )?;
-            log::info!("Broadcasted transaction via Boltz: {}", txid);
-            return Ok(txid);
-        } else {
-            Ok(network_config
-                .build_client()?
-                .transaction_broadcast(signed_tx)?)
-        }
+        Ok(network_config
+            .build_client()?
+            .transaction_broadcast(signed_tx)?)
     }
 }

--- a/src/swaps/bitcoinv2.rs
+++ b/src/swaps/bitcoinv2.rs
@@ -17,6 +17,7 @@ use bitcoin::{sighash::SighashCache, Network, Sequence, Transaction, TxIn, TxOut
 use bitcoin::{Amount, EcdsaSighashType, TapLeafHash, TapSighashType, Txid, XOnlyPublicKey};
 use electrum_client::ElectrumApi;
 use elements::encode::serialize;
+use elements::pset::serialize::Serialize;
 use std::ops::{Add, Index};
 use std::str::FromStr;
 
@@ -31,7 +32,9 @@ use crate::{
 use bitcoin::{blockdata::locktime::absolute::LockTime, hashes::hash160};
 
 use super::boltz::SwapType;
-use super::boltzv2::{BoltzApiClientV2, ClaimTxResponse, CreateSubmarineResponse, CreateReverseResponse};
+use super::boltzv2::{
+    BoltzApiClientV2, ClaimTxResponse, CreateReverseResponse, CreateSubmarineResponse,
+};
 
 use elements::secp256k1_zkp::{
     MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
@@ -241,12 +244,10 @@ impl BtcSwapScriptV2 {
 
         let taproot_builder = TaprootBuilder::new();
 
-        let taproot_builder = taproot_builder
-            .add_leaf_with_ver(1, self.claim_script(), LeafVersion::TapScript)
-            ?;
-        let taproot_builder = taproot_builder
-            .add_leaf_with_ver(1, self.refund_script(), LeafVersion::TapScript)
-            ?;
+        let taproot_builder =
+            taproot_builder.add_leaf_with_ver(1, self.claim_script(), LeafVersion::TapScript)?;
+        let taproot_builder =
+            taproot_builder.add_leaf_with_ver(1, self.refund_script(), LeafVersion::TapScript)?;
 
         let taproot_spend_info = taproot_builder.finalize(&secp, internal_key).unwrap();
 
@@ -448,9 +449,7 @@ impl BtcSwapTxV2 {
 
         let session_id = MusigSessionId::new(&mut thread_rng());
 
-        let msg = Message::from_digest_slice(
-            &Vec::from_hex(&claim_tx_response.transaction_hash)?,
-        )?;
+        let msg = Message::from_digest_slice(&Vec::from_hex(&claim_tx_response.transaction_hash)?)?;
 
         // Step 4: Start the Musig2 Signing session
         let mut extra_rand = [0u8; 32];
@@ -534,8 +533,7 @@ impl BtcSwapTxV2 {
                     0,
                     &Prevouts::All(&[&self.utxo.1]),
                     bitcoin::TapSighashType::Default,
-                )
-                ?;
+                )?;
 
             let msg = Message::from_digest_slice(claim_tx_taproot_hash.as_byte_array())?;
 
@@ -557,24 +555,29 @@ impl BtcSwapTxV2 {
             let mut extra_rand = [0u8; 32];
             OsRng.fill_bytes(&mut extra_rand);
 
-            let (sec_nonce, pub_nonce) = key_agg_cache
-                .nonce_gen(&secp, session_id, keys.public_key(), msg, Some(extra_rand))
-                ?;
+            let (sec_nonce, pub_nonce) = key_agg_cache.nonce_gen(
+                &secp,
+                session_id,
+                keys.public_key(),
+                msg,
+                Some(extra_rand),
+            )?;
 
             // Step 7: Get boltz's partail sig
             let claim_tx_hex = serialize(&claim_tx).to_lower_hex_string();
-            let partial_sig_resp = boltz_api
-                .get_reverse_partial_sig(&swap_id, &preimage, &pub_nonce, &claim_tx_hex)
-                ?;
+            let partial_sig_resp = boltz_api.get_reverse_partial_sig(
+                &swap_id,
+                &preimage,
+                &pub_nonce,
+                &claim_tx_hex,
+            )?;
 
             let boltz_public_nonce =
-                MusigPubNonce::from_slice(&Vec::from_hex(&partial_sig_resp.pub_nonce)?)
-                    ?;
+                MusigPubNonce::from_slice(&Vec::from_hex(&partial_sig_resp.pub_nonce)?)?;
 
-            let boltz_partial_sig = MusigPartialSignature::from_slice(
-                &Vec::from_hex(&partial_sig_resp.partial_signature)?,
-            )
-            ?;
+            let boltz_partial_sig = MusigPartialSignature::from_slice(&Vec::from_hex(
+                &partial_sig_resp.partial_signature,
+            )?)?;
 
             // Aggregate Our's and Other's Nonce and start the Musig session.
             let agg_nonce = MusigAggNonce::new(&secp, &[boltz_public_nonce, pub_nonce]);
@@ -590,11 +593,14 @@ impl BtcSwapTxV2 {
                 self.swap_script.sender_pubkey.inner,
             );
 
-            assert!(boltz_partial_sig_verify == true);
+            if !boltz_partial_sig_verify {
+                return Err(Error::Protocol(
+                    "Invalid partial-sig received from Boltz".to_string(),
+                ));
+            }
 
-            let our_partial_sig = musig_session
-                .partial_sign(&secp, sec_nonce, &keys, &key_agg_cache)
-                ?;
+            let our_partial_sig =
+                musig_session.partial_sign(&secp, sec_nonce, &keys, &key_agg_cache)?;
 
             let schnorr_sig = musig_session.partial_sig_agg(&[boltz_partial_sig, our_partial_sig]);
 
@@ -611,21 +617,17 @@ impl BtcSwapTxV2 {
             witness.push(final_schnorr_sig.to_vec());
 
             claim_tx.input[0].witness = witness;
-
-            let claim_tx_hex = serialize(&claim_tx).to_lower_hex_string();
         } else {
             // If Non-Cooperative claim use the Script Path spending
             let leaf_hash =
                 TapLeafHash::from_script(&self.swap_script.claim_script(), LeafVersion::TapScript);
 
-            let sighash = SighashCache::new(claim_tx.clone())
-                .taproot_script_spend_signature_hash(
-                    0,
-                    &Prevouts::All(&[&self.utxo.1]),
-                    leaf_hash,
-                    TapSighashType::Default,
-                )
-                ?;
+            let sighash = SighashCache::new(claim_tx.clone()).taproot_script_spend_signature_hash(
+                0,
+                &Prevouts::All(&[&self.utxo.1]),
+                leaf_hash,
+                TapSighashType::Default,
+            )?;
 
             let msg = Message::from_digest_slice(sighash.as_byte_array())?;
 
@@ -657,7 +659,12 @@ impl BtcSwapTxV2 {
 
     /// Sign a submarine swap refund transaction.
     /// Panics if called on Reverse Swap, Claim type.
-    pub fn sign_refund(&self, keys: &Keypair, absolute_fees: u64) -> Result<Transaction, Error> {
+    pub fn sign_refund(
+        &self,
+        keys: &Keypair,
+        absolute_fees: u64,
+        is_cooperative: Option<(&BoltzApiClientV2, &String)>,
+    ) -> Result<Transaction, Error> {
         if self.swap_script.swap_type == SwapType::ReverseSubmarine {
             return Err(Error::Protocol(
                 "Cannot sign refund tx, for a reverse-swap".to_string(),
@@ -710,52 +717,144 @@ impl BtcSwapTxV2 {
             .next()
             .unwrap();
 
-        let mut spending_tx = Transaction {
+        let mut refund_tx = Transaction {
             version: Version::TWO,
             lock_time,
             input: vec![input],
             output: vec![output],
         };
 
-        let leaf_hash =
-            TapLeafHash::from_script(&self.swap_script.refund_script(), LeafVersion::TapScript);
+        let secp = Secp256k1::new();
 
-        let sighash = SighashCache::new(spending_tx.clone())
-            .taproot_script_spend_signature_hash(
-                0,
-                &Prevouts::All(&[&self.utxo.1]),
-                leaf_hash,
-                TapSighashType::Default,
-            )
-            ?;
+        if let Some((boltz_api, swap_id)) = is_cooperative {
+            // Start the Musig session
 
-        let msg = Message::from_digest_slice(sighash.as_byte_array())?;
+            // Step 1: Get the sighash
+            let refund_tx_taproot_hash = SighashCache::new(refund_tx.clone())
+                .taproot_key_spend_signature_hash(
+                    0,
+                    &Prevouts::All(&[&self.utxo.1]),
+                    bitcoin::TapSighashType::Default,
+                )?;
 
-        let sig = Secp256k1::new().sign_schnorr(&msg, &keys);
+            let msg = Message::from_digest_slice(refund_tx_taproot_hash.as_byte_array())?;
 
-        let final_sig = Signature {
-            sig,
-            hash_ty: TapSighashType::Default,
-        };
+            // Step 2: Get the Public and Secret nonces
 
-        let control_block = self
-            .swap_script
-            .taproot_spendinfo()?
-            .control_block(&(
-                self.swap_script.refund_script().clone(),
-                LeafVersion::TapScript,
-            ))
-            .expect("Control block calculation failed");
+            let mut key_agg_cache = self.swap_script.musig_keyagg_cache();
 
-        let mut witness = Witness::new();
+            let tweak = SecretKey::from_slice(
+                self.swap_script
+                    .taproot_spendinfo()?
+                    .tap_tweak()
+                    .as_byte_array(),
+            )?;
 
-        witness.push(final_sig.to_vec());
-        witness.push(self.swap_script.refund_script().as_bytes());
-        witness.push(control_block.serialize());
+            let _ = key_agg_cache.pubkey_xonly_tweak_add(&secp, tweak)?;
 
-        spending_tx.input[0].witness = witness;
+            let session_id = MusigSessionId::new(&mut thread_rng());
 
-        Ok(spending_tx)
+            let mut extra_rand = [0u8; 32];
+            OsRng.fill_bytes(&mut extra_rand);
+
+            let (sec_nonce, pub_nonce) = key_agg_cache.nonce_gen(
+                &secp,
+                session_id,
+                keys.public_key(),
+                msg,
+                Some(extra_rand),
+            )?;
+
+            // Step 7: Get boltz's partail sig
+            let refund_tx_hex = serialize(&refund_tx).to_lower_hex_string();
+            let partial_sig_resp =
+                boltz_api.get_submarine_partial_sig(&swap_id, &pub_nonce, &refund_tx_hex)?;
+
+            let boltz_public_nonce =
+                MusigPubNonce::from_slice(&Vec::from_hex(&partial_sig_resp.pub_nonce)?)?;
+
+            let boltz_partial_sig = MusigPartialSignature::from_slice(&Vec::from_hex(
+                &partial_sig_resp.partial_signature,
+            )?)?;
+
+            // Aggregate Our's and Other's Nonce and start the Musig session.
+            let agg_nonce = MusigAggNonce::new(&secp, &[boltz_public_nonce, pub_nonce]);
+
+            let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+
+            // Verify the Boltz's sig.
+            let boltz_partial_sig_verify = musig_session.partial_verify(
+                &secp,
+                &key_agg_cache,
+                boltz_partial_sig,
+                boltz_public_nonce,
+                self.swap_script.sender_pubkey.inner,
+            );
+
+            if !boltz_partial_sig_verify {
+                return Err(Error::Protocol(
+                    "Invalid partial-sig received from Boltz".to_string(),
+                ));
+            }
+
+            let our_partial_sig =
+                musig_session.partial_sign(&secp, sec_nonce, &keys, &key_agg_cache)?;
+
+            let schnorr_sig = musig_session.partial_sig_agg(&[boltz_partial_sig, our_partial_sig]);
+
+            let final_schnorr_sig = Signature {
+                sig: schnorr_sig,
+                hash_ty: TapSighashType::Default,
+            };
+
+            let output_key = self.swap_script.taproot_spendinfo()?.output_key();
+
+            let _ = secp.verify_schnorr(&final_schnorr_sig.sig, &msg, &output_key.to_inner())?;
+
+            let mut witness = Witness::new();
+            witness.push(final_schnorr_sig.to_vec());
+
+            refund_tx.input[0].witness = witness;
+        } else {
+            let leaf_hash =
+                TapLeafHash::from_script(&self.swap_script.refund_script(), LeafVersion::TapScript);
+
+            let sighash = SighashCache::new(refund_tx.clone())
+                .taproot_script_spend_signature_hash(
+                    0,
+                    &Prevouts::All(&[&self.utxo.1]),
+                    leaf_hash,
+                    TapSighashType::Default,
+                )?;
+
+            let msg = Message::from_digest_slice(sighash.as_byte_array())?;
+
+            let sig = Secp256k1::new().sign_schnorr(&msg, &keys);
+
+            let final_sig = Signature {
+                sig,
+                hash_ty: TapSighashType::Default,
+            };
+
+            let control_block = self
+                .swap_script
+                .taproot_spendinfo()?
+                .control_block(&(
+                    self.swap_script.refund_script().clone(),
+                    LeafVersion::TapScript,
+                ))
+                .expect("Control block calculation failed");
+
+            let mut witness = Witness::new();
+
+            witness.push(final_sig.to_vec());
+            witness.push(self.swap_script.refund_script().as_bytes());
+            witness.push(control_block.serialize());
+
+            refund_tx.input[0].witness = witness;
+        }
+
+        Ok(refund_tx)
     }
 
     /// Calculate the size of a transaction.
@@ -765,18 +864,39 @@ impl BtcSwapTxV2 {
         let dummy_abs_fee = 5_000;
         let tx = match self.kind {
             SwapTxKind::Claim => self.sign_claim(keys, preimage, dummy_abs_fee, None)?, // Can only calculate non-coperative claims
-            SwapTxKind::Refund => self.sign_refund(keys, dummy_abs_fee)?,
+            SwapTxKind::Refund => self.sign_refund(keys, dummy_abs_fee, None)?,
         };
         Ok(tx.vsize())
     }
-    /// Broadcast transaction to the network
+
+    /// Broadcast transaction to the network.
+    ///
+    /// Lowall sending can be enabled with `is_lowball` option and by providing a [BoltzApiClientV2] and a [Chain].
     pub fn broadcast(
         &self,
         signed_tx: &Transaction,
         network_config: &ElectrumConfig,
+        is_lowball: Option<(&BoltzApiClientV2, Chain)>,
     ) -> Result<Txid, Error> {
-        Ok(network_config
-            .build_client()?
-            .transaction_broadcast(signed_tx)?)
+        if let Some((boltz_api, chain)) = is_lowball {
+            log::info!("Attempting lowball braodcast");
+            let tx_hex = serialize(signed_tx).to_lower_hex_string();
+            let response = boltz_api.broadcast_tx(chain, &tx_hex)?;
+            let txid = Txid::from_str(
+                &response
+                    .as_object()
+                    .unwrap()
+                    .get("id")
+                    .unwrap()
+                    .as_str()
+                    .unwrap(),
+            )?;
+            log::info!("Broadcasted transaction via Boltz: {}", txid);
+            return Ok(txid);
+        } else {
+            Ok(network_config
+                .build_client()?
+                .transaction_broadcast(signed_tx)?)
+        }
     }
 }

--- a/src/swaps/bitcoinv2.rs
+++ b/src/swaps/bitcoinv2.rs
@@ -788,7 +788,7 @@ impl BtcSwapTxV2 {
                 &key_agg_cache,
                 boltz_partial_sig,
                 boltz_public_nonce,
-                self.swap_script.sender_pubkey.inner,
+                self.swap_script.receiver_pubkey.inner,
             );
 
             if !boltz_partial_sig_verify {

--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -6,7 +6,7 @@ use bitcoin::{
 use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tungstenite::{connect, stream::MaybeTlsStream, WebSocket};
+use tungstenite::{connect, http::response, stream::MaybeTlsStream, WebSocket};
 use ureq::json;
 
 use crate::{error::Error, network::Chain, util::secrets::Preimage};
@@ -148,7 +148,10 @@ impl BoltzApiClientV2 {
         Ok(serde_json::from_str(&self.post(&endpoint, data)?)?)
     }
 
-    pub fn post_reverse_req(&self, req: CreateReverseRequest) -> Result<CreateReverseResponse, Error> {
+    pub fn post_reverse_req(
+        &self,
+        req: CreateReverseRequest,
+    ) -> Result<CreateReverseResponse, Error> {
         Ok(serde_json::from_str(&self.post("swap/reverse", req)?)?)
     }
 
@@ -181,6 +184,24 @@ impl BoltzApiClientV2 {
         );
 
         let endpoint = format!("swap/reverse/{}/claim", id);
+        Ok(serde_json::from_str(&self.post(&endpoint, data)?)?)
+    }
+
+    pub fn get_submarine_partial_sig(
+        &self,
+        id: &String,
+        pub_nonce: &MusigPubNonce,
+        refund_tx_hex: &String,
+    ) -> Result<ReversePartialSig, Error> {
+        let data = json!(
+            {
+                "pubNonce": pub_nonce.serialize().to_lower_hex_string(),
+                "transaction": refund_tx_hex,
+                "index": 0
+            }
+        );
+
+        let endpoint = format!("swap/submarine/{}/claim", id);
         Ok(serde_json::from_str(&self.post(&endpoint, data)?)?)
     }
 

--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -201,7 +201,7 @@ impl BoltzApiClientV2 {
             }
         );
 
-        let endpoint = format!("swap/submarine/{}/claim", id);
+        let endpoint = format!("swap/submarine/{}/refund", id);
         Ok(serde_json::from_str(&self.post(&endpoint, data)?)?)
     }
 

--- a/src/swaps/liquidv2.rs
+++ b/src/swaps/liquidv2.rs
@@ -974,6 +974,8 @@ impl LBtcSwapTxV2 {
             };
 
             refund_tx.input[0].witness = witness;
+
+            refund_tx.lock_time = LockTime::ZERO;
         } else {
             let leaf_hash = TapLeafHash::from_script(&refund_script, LeafVersion::default());
 

--- a/src/swaps/liquidv2.rs
+++ b/src/swaps/liquidv2.rs
@@ -940,7 +940,7 @@ impl LBtcSwapTxV2 {
                 &key_agg_cache,
                 boltz_partial_sig,
                 boltz_public_nonce,
-                self.swap_script.sender_pubkey.inner,
+                self.swap_script.receiver_pubkey.inner,
             );
 
             if (!boltz_partial_sig_verify) {

--- a/src/swaps/liquidv2.rs
+++ b/src/swaps/liquidv2.rs
@@ -28,7 +28,7 @@ use elements::secp256k1_zkp::Message;
 use crate::{
     network::{electrum::ElectrumConfig, Chain},
     swaps::boltz::{self, SwapTxKind},
-    util::secrets::Preimage,
+    util::{liquid_genesis_hash, secrets::Preimage},
 };
 
 use crate::error::Error;
@@ -418,8 +418,7 @@ impl LBtcSwapTxV2 {
         let (funding_outpoint, funding_utxo) = swap_script.fetch_utxo(network_config)?;
 
         let electrum = network_config.build_client()?;
-        let genesis_hash =
-            elements::BlockHash::from_raw_hash(electrum.block_header(0)?.block_hash().into());
+        let genesis_hash = liquid_genesis_hash(&network_config)?;
 
         Ok(LBtcSwapTxV2 {
             kind: SwapTxKind::Claim,
@@ -447,8 +446,7 @@ impl LBtcSwapTxV2 {
         let (funding_outpoint, funding_utxo) = swap_script.fetch_utxo(network_config)?;
 
         let electrum = network_config.build_client()?;
-        let genesis_hash =
-            elements::BlockHash::from_raw_hash(electrum.block_header(0)?.block_hash().into());
+        let genesis_hash = liquid_genesis_hash(&network_config)?;
 
         Ok(LBtcSwapTxV2 {
             kind: SwapTxKind::Refund,

--- a/src/swaps/liquidv2.rs
+++ b/src/swaps/liquidv2.rs
@@ -1042,6 +1042,11 @@ impl LBtcSwapTxV2 {
         is_lowball: Option<(&BoltzApiClientV2, Chain)>,
     ) -> Result<String, Error> {
         if let Some((boltz_api, chain)) = is_lowball {
+            if chain == Chain::Liquid {
+                return Err(Error::Protocol(
+                    "Lowball broadcast is not active for main chain".to_string(),
+                ));
+            }
             log::info!("Attempting lowball braodcast");
             let tx_hex = serialize(signed_tx).to_lower_hex_string();
             let response = boltz_api.broadcast_tx(chain, &tx_hex)?;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,9 +1,29 @@
 use std::{env, sync::Once};
 
+use electrum_client::ElectrumApi;
+use elements::encode::Decodable;
+
+use crate::{error::Error, network::electrum::ElectrumConfig};
+
 pub mod ec;
 pub mod secrets;
 
 /// Setup function that will only run once, even if called multiple times.
+
+pub fn liquid_genesis_hash(electrum_config: &ElectrumConfig) -> Result<elements::BlockHash, Error> {
+    let electrum = electrum_config.build_client()?;
+    println!("ELECTRUM NETWORK: {:?}", electrum_config.network());
+
+    let response = electrum.block_header_raw(0)?;
+    println!("{:#?}", response);
+    let block_header = elements::BlockHeader::consensus_decode(&*response)?;
+    println!("{:#?}", block_header);
+
+    Ok(elements::BlockHash::from_raw_hash(
+        block_header.block_hash().into(),
+    ))
+}
+
 pub fn setup_logger() {
     Once::new().call_once(|| {
         env_logger::Builder::from_env(

--- a/tests/bitcoin_v2.rs
+++ b/tests/bitcoin_v2.rs
@@ -160,7 +160,9 @@ fn bitcoin_v2_submarine() {
 
                     // This means the funding transaction was rejected by Boltz for whatever reason, and we need to get
                     // fund back via refund.
-                    if update.status == "transaction.lockup.failed" {
+                    if update.status == "transaction.lockupFailed"
+                        || update.status == "invoice.failedToPay"
+                    {
                         let swap_tx = BtcSwapTxV2::new_refund(
                             swap_script.clone(),
                             &refund_address,
@@ -176,7 +178,7 @@ fn bitcoin_v2_submarine() {
                         ) {
                             Ok(tx) => {
                                 let txid = swap_tx
-                                    .broadcast(&tx, &ElectrumConfig::default_bitcoin(), None)
+                                    .broadcast(&tx, &ElectrumConfig::default_bitcoin())
                                     .unwrap();
                                 log::info!("Cooperative Refund Successfully broadcasted: {}", txid);
                             }
@@ -186,7 +188,7 @@ fn bitcoin_v2_submarine() {
 
                                 let tx = swap_tx.sign_refund(&our_keys, 1000, None).unwrap();
                                 let txid = swap_tx
-                                    .broadcast(&tx, &ElectrumConfig::default_bitcoin(), None)
+                                    .broadcast(&tx, &ElectrumConfig::default_bitcoin())
                                     .unwrap();
                                 log::info!(
                                     "Non-cooperative Refund Successfully broadcasted: {}",
@@ -322,17 +324,8 @@ fn bitcoin_v2_reverse() {
                             .unwrap();
 
                         claim_tx
-                            .broadcast(&tx, &ElectrumConfig::default_bitcoin(), None)
+                            .broadcast(&tx, &ElectrumConfig::default_bitcoin())
                             .unwrap();
-
-                        // To test Lowball broadcast uncomment below line
-                        // claim_tx
-                        //     .broadcast(
-                        //         &tx,
-                        //         &ElectrumConfig::default_bitcoin(),
-                        //         Some((&boltz_api_v2, boltz_client::network::Chain::BitcoinTestnet)),
-                        //     )
-                        //     .unwrap();
 
                         log::info!("Successfully broadcasted claim tx!");
                         log::debug!("Claim Tx {:?}", tx);

--- a/tests/bitcoin_v2.rs
+++ b/tests/bitcoin_v2.rs
@@ -111,6 +111,9 @@ fn bitcoin_v2_submarine() {
                             create_swap_response.expected_amount,
                             create_swap_response.address
                         );
+
+                        // Test Cooperative Refund.
+                        // Send 1 sat less to than expected amount to Boltz, and let Boltz fail the swap.
                     }
 
                     // Boltz has paid the invoice, and waiting for our partial sig.
@@ -153,6 +156,44 @@ fn bitcoin_v2_submarine() {
                     if update.status == "transaction.claimed" {
                         log::info!("Successfully completed submarine swap");
                         break;
+                    }
+
+                    // This means the funding transaction was rejected by Boltz for whatever reason, and we need to get
+                    // fund back via refund.
+                    if update.status == "transaction.lockup.failed" {
+                        let swap_tx = BtcSwapTxV2::new_refund(
+                            swap_script.clone(),
+                            &refund_address,
+                            &ElectrumConfig::default_bitcoin(),
+                        )
+                        .unwrap()
+                        .expect("Funding UTXO not found");
+
+                        match swap_tx.sign_refund(
+                            &our_keys,
+                            1000,
+                            Some((&boltz_api_v2, &create_swap_response.id)),
+                        ) {
+                            Ok(tx) => {
+                                let txid = swap_tx
+                                    .broadcast(&tx, &ElectrumConfig::default_bitcoin(), None)
+                                    .unwrap();
+                                log::info!("Cooperative Refund Successfully broadcasted: {}", txid);
+                            }
+                            Err(e) => {
+                                log::info!("Cooperative refund failed. {:?}", e);
+                                log::info!("Attempting Non-cooperative refund.");
+
+                                let tx = swap_tx.sign_refund(&our_keys, 1000, None).unwrap();
+                                let txid = swap_tx
+                                    .broadcast(&tx, &ElectrumConfig::default_bitcoin(), None)
+                                    .unwrap();
+                                log::info!(
+                                    "Non-cooperative Refund Successfully broadcasted: {}",
+                                    txid
+                                );
+                            }
+                        }
                     }
                 }
 
@@ -281,10 +322,19 @@ fn bitcoin_v2_reverse() {
                             .unwrap();
 
                         claim_tx
-                            .broadcast(&tx, &ElectrumConfig::default_bitcoin())
+                            .broadcast(&tx, &ElectrumConfig::default_bitcoin(), None)
                             .unwrap();
 
-                        log::info!("Succesfully broadcasted claim tx!");
+                        // To test Lowball broadcast uncomment below line
+                        // claim_tx
+                        //     .broadcast(
+                        //         &tx,
+                        //         &ElectrumConfig::default_bitcoin(),
+                        //         Some((&boltz_api_v2, boltz_client::network::Chain::BitcoinTestnet)),
+                        //     )
+                        //     .unwrap();
+
+                        log::info!("Successfully broadcasted claim tx!");
                         log::debug!("Claim Tx {:?}", tx);
                     }
 

--- a/tests/liquid_v2.rs
+++ b/tests/liquid_v2.rs
@@ -150,7 +150,9 @@ fn liquid_v2_submarine() {
 
                     // This means the funding transaction was rejected by Boltz for whatever reason, and we need to get
                     // fund back via refund.
-                    if update.status == "transaction.lockup.failed" {
+                    if update.status == "transaction.lockupFailed"
+                        || update.status == "invoice.failedToPay"
+                    {
                         let swap_tx = LBtcSwapTxV2::new_refund(
                             swap_script.clone(),
                             &refund_address,

--- a/tests/liquid_v2.rs
+++ b/tests/liquid_v2.rs
@@ -119,7 +119,7 @@ fn liquid_v2_submarine() {
                         let swap_tx = LBtcSwapTxV2::new_refund(
                             swap_script.clone(),
                             &refund_address,
-                            &ElectrumConfig::default_bitcoin(),
+                            &ElectrumConfig::default_liquid(),
                         )
                         .unwrap();
 
@@ -156,7 +156,7 @@ fn liquid_v2_submarine() {
                         let swap_tx = LBtcSwapTxV2::new_refund(
                             swap_script.clone(),
                             &refund_address,
-                            &ElectrumConfig::default_bitcoin(),
+                            &ElectrumConfig::default_liquid(),
                         )
                         .unwrap();
 
@@ -167,7 +167,7 @@ fn liquid_v2_submarine() {
                         ) {
                             Ok(tx) => {
                                 let txid = swap_tx
-                                    .broadcast(&tx, &ElectrumConfig::default_bitcoin(), None)
+                                    .broadcast(&tx, &ElectrumConfig::default_liquid(), None)
                                     .unwrap();
                                 log::info!("Cooperative Refund Successfully broadcasted: {}", txid);
                             }
@@ -179,7 +179,7 @@ fn liquid_v2_submarine() {
                                     .sign_refund(&our_keys, Amount::from_sat(1000), None)
                                     .unwrap();
                                 let txid = swap_tx
-                                    .broadcast(&tx, &ElectrumConfig::default_bitcoin(), None)
+                                    .broadcast(&tx, &ElectrumConfig::default_liquid(), None)
                                     .unwrap();
                                 log::info!(
                                     "Non-cooperative Refund Successfully broadcasted: {}",
@@ -305,7 +305,7 @@ fn liquid_v2_reverse() {
                         let claim_tx = LBtcSwapTxV2::new_claim(
                             swap_script.clone(),
                             claim_address.clone(),
-                            &ElectrumConfig::default_bitcoin(),
+                            &ElectrumConfig::default_liquid(),
                         )
                         .unwrap();
 
@@ -319,14 +319,14 @@ fn liquid_v2_reverse() {
                             .unwrap();
 
                         claim_tx
-                            .broadcast(&tx, &ElectrumConfig::default_bitcoin(), None)
+                            .broadcast(&tx, &ElectrumConfig::default_liquid(), None)
                             .unwrap();
 
                         // To test Lowball broadcast uncomment below line
                         // claim_tx
                         //     .broadcast(
                         //         &tx,
-                        //         &ElectrumConfig::default_bitcoin(),
+                        //         &ElectrumConfig::default_liquid(),
                         //         Some((&boltz_api_v2, boltz_client::network::Chain::LiquidTestnet)),
                         //     )
                         //     .unwrap();

--- a/tests/regtest_v2.rs
+++ b/tests/regtest_v2.rs
@@ -179,7 +179,7 @@ fn btc_submarine_refund() {
         utxo,
     };
 
-    let refund_tx = swap_tx.sign_refund(&sender_keypair, 1000).unwrap();
+    let refund_tx = swap_tx.sign_refund(&sender_keypair, 1000, None).unwrap();
 
     // Make the timelock matured and broadcast the spend
     test_framework.generate_blocks(100);
@@ -316,7 +316,7 @@ fn lbtc_submarine_refund() {
     };
 
     let refund_tx = swap_tx
-        .sign_refund(&sender_keypair, Amount::from_sat(1000))
+        .sign_refund(&sender_keypair, Amount::from_sat(1000), None)
         .unwrap();
 
     // Make the timelock matured and broadcast the spend


### PR DESCRIPTION
This PR adds the Cooperative Refund for submarine swaps and Lowball transaction broadcasting. 

Both of these can be tested using the test functions and extra test codes have been added to existing sites. 

The lowball test code is commented out, as testing that requires manually changing the hard-coded tx fee to 0.01 sats/vb.  