### PR TITLE
Use `native-tls` for better `close_notify` handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,13 @@ panic = "abort"
 [dependencies]
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
-ureq = {version = "2.8.0", features = ["json"]}
+ureq = { version = "2.9.7", features = ["json", "native-tls"] }
 bip39 = "2.0.0"
 electrum-client = "0.19.0"
 bitcoin = {version = "0.31.1", features = ["rand", "base64", "rand-std"]}
 elements = { version = "0.24.0", features = ["serde"] }
 lightning-invoice = "0.26.0"
+native-tls = "0.2.11"
 tungstenite = { version = "0.21.0", features = ["native-tls-vendored"] }
 url = "2.5.0"
 log = "^0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,17 @@ pub mod swaps;
 /// utilities (key, preimage, error)
 pub mod util;
 
-pub use bitcoin::{PublicKey,secp256k1::{Keypair, Secp256k1}, Address,blockdata::locktime::absolute::LockTime,hashes::hash160::Hash, Amount};
-pub use elements::{secp256k1_zkp::{Keypair as ZKKeyPair, Secp256k1 as ZKSecp256k1}, address::Address as ElementsAddress, locktime::LockTime as ElementsLockTime};
+pub use bitcoin::{
+    blockdata::locktime::absolute::LockTime,
+    hashes::hash160::Hash,
+    secp256k1::{Keypair, Secp256k1},
+    Address, Amount, PublicKey,
+};
+pub use elements::{
+    address::Address as ElementsAddress,
+    locktime::LockTime as ElementsLockTime,
+    secp256k1_zkp::{Keypair as ZKKeyPair, Secp256k1 as ZKSecp256k1},
+};
 pub use lightning_invoice::Bolt11Invoice;
 
 pub use swaps::boltz::{SwapTxKind, SwapType};

--- a/src/network/electrum.rs
+++ b/src/network/electrum.rs
@@ -39,10 +39,13 @@ pub struct ElectrumConfig {
 }
 
 impl ElectrumConfig {
-    
     pub fn default(chain: Chain, regtest_url: Option<String>) -> Result<Self, Error> {
-        if (chain == Chain::LiquidRegtest || chain == Chain::BitcoinRegtest ) && regtest_url.is_none() {
-            return Err(Error::Electrum(electrum_client::Error::Message("Regtest requires using a custom url".to_string())))
+        if (chain == Chain::LiquidRegtest || chain == Chain::BitcoinRegtest)
+            && regtest_url.is_none()
+        {
+            return Err(Error::Electrum(electrum_client::Error::Message(
+                "Regtest requires using a custom url".to_string(),
+            )));
         }
         match chain {
             Chain::Bitcoin => Ok(ElectrumConfig::new(

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -34,6 +34,9 @@
 //! assert!((output_amount - base_fees) == response.onchain_amount?);
 
 //! ```
+use std::str::FromStr;
+use std::sync::Arc;
+
 use crate::error::Error;
 use crate::network::Chain;
 use bitcoin::absolute::LockTime;
@@ -51,7 +54,7 @@ use crate::util::secrets::Preimage;
 use serde::Serializer;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use std::str::FromStr;
+use ureq::{AgentBuilder, TlsConnector};
 
 pub const BOLTZ_TESTNET_URL: &str = "https://testnet.boltz.exchange/api";
 pub const BOLTZ_MAINNET_URL: &str = "https://api.boltz.exchange";
@@ -82,7 +85,21 @@ impl BoltzApiClient {
     /// Make a Post request. Returns the Response
     fn post(&self, end_point: &str, data: Value) -> Result<String, Error> {
         let url = format!("{}/{}", self.base_url, end_point);
-        Ok(ureq::post(&url).send_json(data)?.into_string()?)
+
+        let response = match native_tls::TlsConnector::new() {
+            // If native_tls is available, use that for TLS
+            // It has better handling of close_notify, which avoids some POST call failures
+            // See https://github.com/SatoshiPortal/boltz-rust/issues/39
+            Ok(tls_connector) => AgentBuilder::new()
+                .tls_connector(Arc::new(tls_connector))
+                .build()
+                .request("POST", &url)
+                .send_json(data)?
+                .into_string()?,
+            // If native_tls is not available, fallback to the default (rustls)
+            Err(_) => ureq::post(&url).send_json(data)?.into_string()?,
+        };
+        Ok(response)
     }
     /// In order to create a swap, one first has to know which pairs are supported and what kind of rates, limits and fees are applied when creating a new swap.
     /// The following call returns this information.

--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -148,7 +148,10 @@ impl BoltzApiClientV2 {
         Ok(serde_json::from_str(&self.post(&endpoint, data)?)?)
     }
 
-    pub fn post_reverse_req(&self, req: CreateReverseRequest) -> Result<CreateReverseResponse, Error> {
+    pub fn post_reverse_req(
+        &self,
+        req: CreateReverseRequest,
+    ) -> Result<CreateReverseResponse, Error> {
         Ok(serde_json::from_str(&self.post("swap/reverse", req)?)?)
     }
 

--- a/src/swaps/liquidv2.rs
+++ b/src/swaps/liquidv2.rs
@@ -44,7 +44,7 @@ use elements::{
 
 use super::{
     boltz::SwapType,
-    boltzv2::{BoltzApiClientV2, ClaimTxResponse, CreateSubmarineResponse, CreateReverseResponse},
+    boltzv2::{BoltzApiClientV2, ClaimTxResponse, CreateReverseResponse, CreateSubmarineResponse},
 };
 
 /// Liquid v2 swap script helper.
@@ -675,8 +675,10 @@ impl LBtcSwapTxV2 {
                 self.swap_script.sender_pubkey.inner,
             );
 
-            if (!boltz_partial_sig_verify){
-                return Err(Error::Taproot(("Unable to verify Partial Signature".to_string())))
+            if (!boltz_partial_sig_verify) {
+                return Err(Error::Taproot(
+                    ("Unable to verify Partial Signature".to_string()),
+                ));
             }
 
             let our_partial_sig =


### PR DESCRIPTION
This PR enables the `native-tls` feature of `ureq` as described here: https://docs.rs/ureq/latest/ureq/#https--tls--ssl

This brings better handling of TLS `close_notify` alerts. Before this change, the default `ureq` setup caused some POST calls (like `/swapstatus`) to fail.

Fixes #39