### PR TITLE
Magic Routing Hint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ ureq = { version = "2.9.7", features = ["json", "native-tls"] }
 bip39 = "2.0.0"
 electrum-client = "0.19.0"
 bitcoin = {version = "0.31.2", features = ["rand", "base64", "rand-std"]}
-bip21 = "0.4.0"
 elements = { version = "0.24.0", features = ["serde"] }
 lightning-invoice = "0.30.0"
 tungstenite = { version = "0.21.0", features = ["native-tls-vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,10 @@ serde_json = "1.0.0"
 ureq = { version = "2.9.7", features = ["json", "native-tls"] }
 bip39 = "2.0.0"
 electrum-client = "0.19.0"
-bitcoin = {version = "0.31.1", features = ["rand", "base64", "rand-std"]}
+bitcoin = {version = "0.31.2", features = ["rand", "base64", "rand-std"]}
+bip21 = "0.4.0"
 elements = { version = "0.24.0", features = ["serde"] }
-lightning-invoice = "0.26.0"
+lightning-invoice = "0.30.0"
 tungstenite = { version = "0.21.0", features = ["native-tls-vendored"] }
 url = "2.5.0"
 log = "^0.4"

--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -222,6 +222,11 @@ impl BoltzApiClientV2 {
         Ok(serde_json::from_str(&self.post(&endpoint, data)?)?)
     }
 
+    pub fn get_mrh_bip21(&self, invoice: &str) -> Result<MrhResponse, Error> {
+        let request = format!("swap/reverse/{}/bip21", invoice);
+        Ok(serde_json::from_str(&self.get(&request)?)?)
+    }
+
     pub fn broadcast_tx(&self, chain: Chain, tx_hex: &String) -> Result<Value, Error> {
         let data = json!(
             {
@@ -246,6 +251,13 @@ pub struct ClaimTxResponse {
     pub pub_nonce: String,
     pub public_key: PublicKey,
     pub transaction_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MrhResponse {
+    pub bip21: String,
+    pub signature: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -310,6 +322,7 @@ pub struct CreateReverseRequest {
     pub from: String,
     pub to: String,
     pub preimage_hash: sha256::Hash,
+    pub address_signature: String,
     pub claim_public_key: PublicKey,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub referral_id: Option<String>,

--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -322,6 +322,7 @@ pub struct CreateReverseRequest {
     pub from: String,
     pub to: String,
     pub preimage_hash: sha256::Hash,
+    pub address: String,
     pub address_signature: String,
     pub claim_public_key: PublicKey,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/swaps/magic_routing.rs
+++ b/src/swaps/magic_routing.rs
@@ -1,0 +1,131 @@
+use std::str::FromStr;
+
+use crate::{error::Error, network::Chain};
+use bitcoin::{
+    hashes::{sha256, Hash},
+    hex::FromHex,
+    key::Secp256k1,
+    secp256k1::Message,
+    PublicKey,
+};
+use elements::hex::ToHex;
+use lightning_invoice::{Bolt11Invoice, RouteHintHop};
+
+use super::boltzv2::BoltzApiClientV2;
+
+const MAGIC_ROUTING_HINT_CONSTANT: &str = "0846c900051c0000";
+const LBTC_TESTNET_ASSET_HASH: &str =
+    "144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49";
+const LBTC_MAINNET_ASSET_HASH: &str = "";
+
+/// Decodes the provided invoice to find the magic routing hint.
+pub fn find_magic_routing_hint(invoice: &str) -> Result<Option<RouteHintHop>, Error> {
+    let invoice = Bolt11Invoice::from_str(&invoice)?;
+    Ok(invoice
+        .private_routes()
+        .iter()
+        .map(|route| &route.0)
+        .flatten()
+        .find(|hint| hint.short_channel_id.to_hex() == MAGIC_ROUTING_HINT_CONSTANT)
+        .cloned())
+}
+
+/// Parse a BIP21 String and get the network, address, asset_id if present
+pub fn parse_bip21(uri: &str) -> (String, String, f64, Option<String>) {
+    let parts: Vec<&str> = uri.split('?').collect();
+
+    let (network_address, params) = (parts[0], parts[1]);
+
+    // Extract network and address
+    let mut network_address_parts = network_address.split(':');
+    let network = network_address_parts.next().unwrap().into();
+    let address = network_address_parts.next().unwrap().into();
+
+    // Parse URI parameters
+    let params: Vec<&str> = params.split('&').collect();
+    let mut amount = 0f64;
+    let mut assetid = None::<String>;
+
+    for param in params {
+        let pair: Vec<&str> = param.split('=').collect();
+        match pair[0] {
+            "amount" => amount = f64::from_str(pair[1]).unwrap(),
+            "assetid" => assetid = Some(pair[1].into()),
+            _ => {}
+        }
+    }
+
+    (network, address, amount, assetid)
+}
+
+/// Check for magic routing hint in invoice. If present, get the BIP21 from Boltz and verify it.
+pub fn check_for_mrh(
+    boltz_api_v2: &BoltzApiClientV2,
+    invoice: &str,
+    network: Chain,
+) -> Result<(), Error> {
+    if let Some(route_hint) = find_magic_routing_hint(&invoice).unwrap() {
+        let mrh_resp = boltz_api_v2.get_mrh_bip21(&invoice).unwrap();
+
+        let (network_found, address, amount, assetid) = parse_bip21(&mrh_resp.bip21);
+        let address_hash = sha256::Hash::hash(&Vec::from_hex(&address).unwrap());
+        let msg = Message::from_digest_slice(address_hash.as_byte_array()).unwrap();
+
+        let receiver_sig = bitcoin::secp256k1::schnorr::Signature::from_slice(
+            &Vec::from_hex(&mrh_resp.signature).unwrap(),
+        )
+        .unwrap();
+
+        let receiver_pubkey = PublicKey::from_str(&route_hint.src_node_id.to_string())
+            .unwrap()
+            .inner;
+
+        let secp = Secp256k1::new();
+        secp.verify_schnorr(&receiver_sig, &msg, &receiver_pubkey.x_only_public_key().0)
+            .unwrap();
+
+        match network {
+            Chain::LiquidTestnet => {
+                if assetid != Some(LBTC_TESTNET_ASSET_HASH.to_string()) {
+                    return Err(Error::Protocol(
+                        "Asset Id missmatch in Magic Routing Hint".to_string(),
+                    ));
+                } else {
+                    return Ok(());
+                }
+            }
+
+            Chain::Liquid => {
+                if assetid != Some(LBTC_MAINNET_ASSET_HASH.to_string()) {
+                    return Err(Error::Protocol(
+                        "Asset Id missmatch in Magic Routing Hint".to_string(),
+                    ));
+                } else {
+                    return Ok(());
+                }
+            }
+            _ => (),
+        }
+
+        log::info!("Magic Routing hint found and verification succeeded");
+
+        Ok(())
+    } else {
+        log::info!("No Magic Routing Hint in the invoice");
+        Ok(())
+    }
+}
+
+#[test]
+fn test_bip21_parsing() {
+    let uri = "liquidtestnet:tlq1qqt3sgky7zert7237tred5rqmmx0eargp625zkyhr2ldw6yqdvh5fusnm5xk0qfjpejvgm37q7mqtv5epfksv78jweytmqgpd8?amount=0.00005122&assetid=144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a4";
+    let (network, address, amount, assetid) = parse_bip21(uri);
+
+    assert_eq!(network, "liquidtestnet");
+    assert_eq!(address, "tlq1qqt3sgky7zert7237tred5rqmmx0eargp625zkyhr2ldw6yqdvh5fusnm5xk0qfjpejvgm37q7mqtv5epfksv78jweytmqgpd8");
+    assert_eq!(amount, 0.00005122);
+    assert_eq!(
+        assetid,
+        Some("144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a4".to_string())
+    );
+}

--- a/src/swaps/magic_routing.rs
+++ b/src/swaps/magic_routing.rs
@@ -4,8 +4,8 @@ use crate::{error::Error, network::Chain};
 use bitcoin::{
     hashes::{sha256, Hash},
     hex::FromHex,
-    key::Secp256k1,
-    secp256k1::Message,
+    key::{Keypair, Secp256k1},
+    secp256k1::{schnorr::Signature, Message},
     PublicKey,
 };
 use elements::hex::ToHex;
@@ -114,6 +114,13 @@ pub fn check_for_mrh(
         log::info!("No Magic Routing Hint in the invoice");
         Ok(())
     }
+}
+
+/// Sign the address signature by a priv key.
+pub fn sign_address(addr: &str, keys: &Keypair) -> Signature {
+    let address_hash = sha256::Hash::hash(&Vec::from_hex(&addr).unwrap());
+    let msg = Message::from_digest_slice(address_hash.as_byte_array()).unwrap();
+    Secp256k1::new().sign_schnorr(&msg, &keys)
 }
 
 #[test]

--- a/src/swaps/magic_routing.rs
+++ b/src/swaps/magic_routing.rs
@@ -59,11 +59,12 @@ pub fn parse_bip21(uri: &str) -> (String, String, f64, Option<String>) {
 }
 
 /// Check for magic routing hint in invoice. If present, get the BIP21 from Boltz and verify it.
+/// Returns the BIP21 (address, amount) tupple.
 pub fn check_for_mrh(
     boltz_api_v2: &BoltzApiClientV2,
     invoice: &str,
     network: Chain,
-) -> Result<(), Error> {
+) -> Result<Option<(String, f64)>, Error> {
     if let Some(route_hint) = find_magic_routing_hint(&invoice).unwrap() {
         let mrh_resp = boltz_api_v2.get_mrh_bip21(&invoice).unwrap();
 
@@ -90,8 +91,6 @@ pub fn check_for_mrh(
                     return Err(Error::Protocol(
                         "Asset Id missmatch in Magic Routing Hint".to_string(),
                     ));
-                } else {
-                    return Ok(());
                 }
             }
 
@@ -100,8 +99,6 @@ pub fn check_for_mrh(
                     return Err(Error::Protocol(
                         "Asset Id missmatch in Magic Routing Hint".to_string(),
                     ));
-                } else {
-                    return Ok(());
                 }
             }
             _ => (),
@@ -109,10 +106,10 @@ pub fn check_for_mrh(
 
         log::info!("Magic Routing hint found and verification succeeded");
 
-        Ok(())
+        Ok(Some((address, amount)))
     } else {
         log::info!("No Magic Routing Hint in the invoice");
-        Ok(())
+        Ok(None)
     }
 }
 

--- a/src/swaps/magic_routing.rs
+++ b/src/swaps/magic_routing.rs
@@ -118,7 +118,7 @@ pub fn check_for_mrh(
 
 /// Sign the address signature by a priv key.
 pub fn sign_address(addr: &str, keys: &Keypair) -> Signature {
-    let address_hash = sha256::Hash::hash(&Vec::from_hex(&addr).unwrap());
+    let address_hash = sha256::Hash::hash(addr.as_bytes());
     let msg = Message::from_digest_slice(address_hash.as_byte_array()).unwrap();
     Secp256k1::new().sign_schnorr(&msg, &keys)
 }

--- a/src/swaps/mod.rs
+++ b/src/swaps/mod.rs
@@ -4,3 +4,4 @@ pub mod boltz;
 pub mod boltzv2;
 pub mod liquid;
 pub mod liquidv2;
+pub mod magic_routing;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,6 @@
 use std::{env, str::FromStr, sync::Once};
 
+use bitcoin::amount;
 use electrum_client::ElectrumApi;
 use elements::{encode::Decodable, hex::ToHex};
 use lightning_invoice::{Bolt11Invoice, RouteHintHop};
@@ -9,9 +10,6 @@ use crate::{error::Error, network::electrum::ElectrumConfig};
 pub mod ec;
 pub mod secrets;
 
-const ENDPOINT: &str = "https://api.testnet.boltz.exchange";
-const MAGIC_ROUTING_HINT_CONSTANT: &str = "0846c900051c0000";
-const LBTC_ASSET_HASH: &str = "144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49";
 
 /// Setup function that will only run once, even if called multiple times.
 
@@ -41,14 +39,3 @@ pub fn setup_logger() {
     });
 }
 
-/// Decodes the provided invoice to find the magic routing hint.
-pub fn find_magic_routing_hint(invoice: &str) -> Result<Option<RouteHintHop>, Error> {
-    let invoice = Bolt11Invoice::from_str(&invoice)?;
-    Ok(invoice
-        .private_routes()
-        .iter()
-        .map(|route| &route.0)
-        .flatten()
-        .find(|hint| hint.short_channel_id.to_hex() == MAGIC_ROUTING_HINT_CONSTANT)
-        .cloned())
-}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -10,7 +10,6 @@ use crate::{error::Error, network::electrum::ElectrumConfig};
 pub mod ec;
 pub mod secrets;
 
-
 /// Setup function that will only run once, even if called multiple times.
 
 pub fn liquid_genesis_hash(electrum_config: &ElectrumConfig) -> Result<elements::BlockHash, Error> {
@@ -38,4 +37,3 @@ pub fn setup_logger() {
         .init();
     });
 }
-

--- a/tests/bitcoin_v2.rs
+++ b/tests/bitcoin_v2.rs
@@ -42,7 +42,14 @@ fn bitcoin_v2_submarine() {
 
     let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL_V2);
 
-    let _ = check_for_mrh(&boltz_api_v2, &invoice, Chain::BitcoinTestnet).unwrap();
+    // If there is MRH send directly to that address
+    if let Some((bip21_addrs, amount)) =
+        check_for_mrh(&boltz_api_v2, &invoice, Chain::BitcoinTestnet).unwrap()
+    {
+        log::info!("Found MRH in invoice");
+        log::info!("Send {} to {}", amount, bip21_addrs);
+        return;
+    }
 
     // Initiate the swap with Boltz
     let create_swap_req = CreateSubmarineRequest {
@@ -253,6 +260,8 @@ fn bitcoin_v2_reverse() {
     let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL_V2);
 
     let reverse_resp = boltz_api_v2.post_reverse_req(create_reverse_req).unwrap();
+
+    let _ = check_for_mrh(&boltz_api_v2, &reverse_resp.invoice, Chain::BitcoinTestnet).unwrap();
 
     log::debug!("Got Reverse swap response: {:?}", reverse_resp);
 

--- a/tests/bitcoin_v2.rs
+++ b/tests/bitcoin_v2.rs
@@ -1,13 +1,15 @@
 use std::{str::FromStr, time::Duration};
 
-use bip21::Uri;
 use boltz_client::{
-    network::electrum::ElectrumConfig,
-    swaps::boltzv2::{
-        BoltzApiClientV2, CreateReverseRequest, CreateSubmarineRequest, Subscription, SwapUpdate,
-        BOLTZ_TESTNET_URL_V2,
+    network::{electrum::ElectrumConfig, Chain},
+    swaps::{
+        boltzv2::{
+            BoltzApiClientV2, CreateReverseRequest, CreateSubmarineRequest, Subscription,
+            SwapUpdate, BOLTZ_TESTNET_URL_V2,
+        },
+        magic_routing::{check_for_mrh, sign_address},
     },
-    util::{find_magic_routing_hint, secrets::Preimage, setup_logger},
+    util::{secrets::Preimage, setup_logger},
     Bolt11Invoice, BtcSwapScriptV2, BtcSwapTxV2, Secp256k1,
 };
 
@@ -15,7 +17,7 @@ use bitcoin::{
     hashes::{sha256, Hash},
     hex::FromHex,
     key::rand::thread_rng,
-    secp256k1::{Keypair, Message},
+    secp256k1::Keypair,
     PublicKey,
 };
 
@@ -40,33 +42,7 @@ fn bitcoin_v2_submarine() {
 
     let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL_V2);
 
-    // Check for magic routing hint in invoice.
-    if let Some(route_hint) = find_magic_routing_hint(&invoice).unwrap() {
-        let mrh_resp = boltz_api_v2.get_mrh_bip21(&invoice).unwrap();
-
-        let bip21 = mrh_resp
-            .bip21
-            .parse::<Uri<'_, _>>()
-            .unwrap()
-            .require_network(bitcoin::Network::Testnet)
-            .unwrap();
-        let address_hash = sha256::Hash::hash(&Vec::from_hex(&bip21.address.to_string()).unwrap());
-        let msg = Message::from_digest_slice(address_hash.as_byte_array()).unwrap();
-
-        let receiver_sig = bitcoin::secp256k1::schnorr::Signature::from_slice(
-            &Vec::from_hex(&mrh_resp.signature).unwrap(),
-        )
-        .unwrap();
-
-        let receiver_pubkey = PublicKey::from_str(&route_hint.src_node_id.to_string())
-            .unwrap()
-            .inner;
-
-        secp.verify_schnorr(&receiver_sig, &msg, &receiver_pubkey.x_only_public_key().0)
-            .unwrap();
-
-        log::info!("Magic Routing hint found and verification succeeded");
-    }
+    let _ = check_for_mrh(&boltz_api_v2, &invoice, Chain::BitcoinTestnet).unwrap();
 
     // Initiate the swap with Boltz
     let create_swap_req = CreateSubmarineRequest {
@@ -262,17 +238,14 @@ fn bitcoin_v2_reverse() {
     // Give a valid claim address or else funds will be lost.
     let claim_address = "tb1qq20a7gqewc0un9mxxlqyqwn7ut7zjrj9y3d0mu".to_string();
 
-    // Sign the address signature by claim priv key.
-    let address_hash = sha256::Hash::hash(&Vec::from_hex(&claim_address).unwrap());
-    let msg = Message::from_digest_slice(address_hash.as_byte_array()).unwrap();
-    let addrs_sig = Secp256k1::new().sign_schnorr(&msg, &our_keys);
-
+    let addrs_sig = sign_address(&claim_address, &our_keys);
     let create_reverse_req = CreateReverseRequest {
         invoice_amount,
         from: "BTC".to_string(),
         to: "BTC".to_string(),
         preimage_hash: preimage.sha256,
         address_signature: addrs_sig.to_string(),
+        address: claim_address.clone(),
         claim_public_key,
         referral_id: None, // Add address signature here.
     };
@@ -282,14 +255,6 @@ fn bitcoin_v2_reverse() {
     let reverse_resp = boltz_api_v2.post_reverse_req(create_reverse_req).unwrap();
 
     log::debug!("Got Reverse swap response: {:?}", reverse_resp);
-
-    if let Some(route_hint) = find_magic_routing_hint(&reverse_resp.invoice).unwrap() {
-        assert_eq!(
-            route_hint.src_node_id.to_string(),
-            our_keys.public_key().to_string()
-        );
-        log::info!("Magic Routing Hint spotted in invoice {:?}", route_hint);
-    }
 
     let swap_script =
         BtcSwapScriptV2::reverse_from_swap_resp(&reverse_resp, claim_public_key).unwrap();

--- a/tests/liquid_v2.rs
+++ b/tests/liquid_v2.rs
@@ -5,7 +5,7 @@ use boltz_client::{
     swaps::{
         boltzv2::{
             BoltzApiClientV2, CreateReverseRequest, CreateSubmarineRequest, Subscription,
-            SwapUpdate, BOLTZ_MAINNET_URL_V2, BOLTZ_TESTNET_URL_V2,
+            SwapUpdate, BOLTZ_TESTNET_URL_V2,
         },
         magic_routing::{check_for_mrh, sign_address},
     },
@@ -37,8 +37,8 @@ fn liquid_v2_submarine() {
     };
 
     // Set a new invoice string and refund address for each test.
-    let invoice = "lnbc1pnr99axpp53a5yn6g08ual5e2c64z4v0zx9e2f5tkw3wd0lcpff7wnuvw2x0dqcqpjsp5zm36qn2xy2rdh63rzr626mmft2558fws0akg2fs7p3tttl200uzq9q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqdqqmqz9gxqyjw5qrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glcllard4vsfze0gsqqqqlgqqqqqeqqjqswnfqq25xjlwfk3lg4e82w5qkyusa84xhaztqa8sq7kcw35l5f7x9j4ju5z0gagh4kspddwd0r629qjla0rc40twdk9m2uyl9egc9tcq4ncwk6".to_string();
-    let refund_address = "tlq1qqv4z28utgwunvn62s3aw0qjuw3sqgfdq6q8r8fesnawwnuctl70kdyedxw6tmxgqpq83x6ldsyr4n6cj0dm875k8g9k85w2s7".to_string();
+    let invoice = "lntb1m1pnrv328pp5zymney8y48234em5lakrkuk8rfrftn5dkwfys7zghe2c40hxfmusdpz2djkuepqw3hjqnpdgf2yxgrpv3j8yetnwvcqz95xqyp2xqrzjqwyg6p2yhhqvq5d97kkwuk0mnrp3su6sn5fvtxn63gppms9fkegajzzxeyqq28qqqqqqqqqqqqqqq9gq2ysp5znw62my456pnzq7vyfgje2yjfat8gzgf88q8rl30dt3cgpmpk9eq9qyyssq55qds9y2vrtmqxq00fgrnartdhs0wwlt7u5uflzs5wnx8wad8y3y86y8lgre4qaszhvhesa6ts99g7m088j6dgjfe6hhtkfglqfqwjcp03v2nh".to_string();
+    let refund_address = "tlq1qq0aa3lhat3r4auhstr0fsevj70gcwvvlsannf0ymlytelya2ylak7e69hksrk42fnl26wyk460ehy3pncxagy0ck47grlta62".to_string();
 
     let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL_V2);
 
@@ -52,8 +52,6 @@ fn liquid_v2_submarine() {
         refund_public_key,
         referral_id: None,
     };
-
-    let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_MAINNET_URL_V2);
 
     let create_swap_response = boltz_api_v2.post_swap_req(&create_swap_req).unwrap();
 
@@ -237,7 +235,7 @@ fn liquid_v2_reverse() {
     };
 
     // Give a valid claim address or else funds will be lost.
-    let claim_address = "tlq1qqv4z28utgwunvn62s3aw0qjuw3sqgfdq6q8r8fesnawwnuctl70kdyedxw6tmxgqpq83x6ldsyr4n6cj0dm875k8g9k85w2s7".to_string();
+    let claim_address = "tlq1qqtzkefxathskcl5svkfwscd6eyhua8f8v9snpxdy7fe8lu3x6c0v93k3stc4e79avd4d9z76vm30yc3564z6wl5wcs2v409fl".to_string();
 
     let addrs_sig = sign_address(&claim_address, &our_keys);
 
@@ -252,7 +250,7 @@ fn liquid_v2_reverse() {
         referral_id: None,
     };
 
-    let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_MAINNET_URL_V2);
+    let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL_V2);
 
     let reverse_resp = boltz_api_v2.post_reverse_req(create_reverse_req).unwrap();
 

--- a/tests/liquid_v2.rs
+++ b/tests/liquid_v2.rs
@@ -42,7 +42,14 @@ fn liquid_v2_submarine() {
 
     let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL_V2);
 
-    let _ = check_for_mrh(&boltz_api_v2, &invoice, Chain::LiquidTestnet).unwrap();
+    // If there is MRH send directly to that address
+    if let Some((bip21_addrs, amount)) =
+        check_for_mrh(&boltz_api_v2, &invoice, Chain::BitcoinTestnet).unwrap()
+    {
+        log::info!("Found MRH in invoice");
+        log::info!("Send {} to {}", amount, bip21_addrs);
+        return;
+    }
 
     // Initiate the swap with Boltz
     let create_swap_req = CreateSubmarineRequest {
@@ -253,6 +260,8 @@ fn liquid_v2_reverse() {
     let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL_V2);
 
     let reverse_resp = boltz_api_v2.post_reverse_req(create_reverse_req).unwrap();
+
+    let _ = check_for_mrh(&boltz_api_v2, &reverse_resp.invoice, Chain::BitcoinTestnet).unwrap();
 
     log::debug!("Got Reverse swap response: {:?}", reverse_resp);
 


### PR DESCRIPTION
This code adds the Magic Routing Hint logic. As most of the logic is at the application layer, the code is added in the test cases of v2 swaps. 

No changes in the internals of the library is required.

This is untested. And to test it one has to perform the following.

- Initiate a reverse swap with Boltz.
- Use the invoice received in reverse swap and initiate a submarine swap with the same invoice. 
