### PR TITLE
Change visibility of `SwapResponse` fields to public

### DIFF
--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -72,9 +72,9 @@ pub struct SwapParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SwapResponse {
     #[serde(rename = "BTC")]
-    btc: HashMap<String, SwapParams>,
+    pub btc: HashMap<String, SwapParams>,
     #[serde(rename = "L-BTC")]
-    lbtc: HashMap<String, SwapParams>,
+    pub lbtc: HashMap<String, SwapParams>,
 }
 
 /// Reference Documnetation: https://api.boltz.exchange/swagger


### PR DESCRIPTION
This PR aims to fix a minor issue where the data returned by the `get_pairs` method is inaccessible by external libraries. 