### PR TITLE
Add missing SubSwapStates and rustdocs for each state

### DIFF
--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -334,7 +334,7 @@ pub enum SubSwapStates {
     /// Boltz failed to pay the invoice. In this case the user needs to broadcast a refund
     /// transaction to reclaim the locked up onchain coins.
     InvoiceFailedToPay,
-    /// Indicates that after the invoice was successfully paid, the chain L-BTC were successfully
+    /// Indicates that after the invoice was successfully paid, the onchain were successfully
     /// claimed by Boltz. This is the final status of a successful Normal Submarine Swap.
     TransactionClaimed,
     /// Indicates that Boltz is ready for the creation of a cooperative signature for a keypath

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -421,7 +421,7 @@ pub enum RevSwapStates {
     /// back to the user, no further action or refund is required and the user didn't pay any fees.
     TransactionFailed,
     /// This is the final status of a swap, if the user successfully set up the Lightning payment
-    /// and Boltz successfully locked up L-BTC on the chain, but the Boltz API Client did not claim
+    /// and Boltz successfully locked up coins onchain, but the Boltz API Client did not claim
     /// the locked oncahin coins before swap expiry. In this case, Boltz will also automatically refund
     /// its own locked onchain coins and the Lightning payment is cancelled.
     TransactionRefunded,

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -406,7 +406,7 @@ pub enum RevSwapStates {
     /// optionally accepts the transaction without confirmation. Boltz broadcasts chain transactions
     /// non-RBF only.
     TransactionConfirmed,
-    /// The transaction claiming chain L-BTC was broadcast by the user's client and Boltz used the
+    /// The transaction claiming onchain was broadcast by the user's client and Boltz used the
     /// preimage of this transaction to settle the Lightning invoice. This is the final status of a
     /// successful Reverse Submarine Swap.
     InvoiceSettled,

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -319,7 +319,7 @@ pub enum SubSwapStates {
     /// Initial state of the swap; optionally the initial state can also be `invoice.set` in case
     /// the invoice was already specified in the request that created the swap.
     Created,
-    /// The lockup transaction waas found in the mempool, meaning the user sent funds to the
+    /// The lockup transaction was found in the mempool, meaning the user sent funds to the
     /// lockup address.
     TransactionMempool,
     /// The lockup transaction was included in a block.

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -324,8 +324,8 @@ pub enum SubSwapStates {
     TransactionMempool,
     /// The lockup transaction was included in a block.
     TransactionConfirmed,
-    /// If the invoice was _not_ set as part of the `/createswap` request, this state confirms that
-    /// an invoice with the correct amount and hash was set.
+    /// The swap has an invoice that should be paid.
+    /// Can be the initial state when the invoice was specified in the request that created the swap
     InvoiceSet,
     /// Boltz successfully paid the invoice.
     InvoicePaid,

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -317,7 +317,7 @@ impl Fees {
 #[serde(rename_all = "snake_case")]
 pub enum SubSwapStates {
     /// Initial state of the swap; optionally the initial state can also be `invoice.set` in case
-    /// the invoice was already specified in the `/createswap` request.
+    /// the invoice was already specified in the request that created the swap.
     Created,
     /// The lockup transaction is found in the mempool, meaning the user is sending funds to the
     /// lockup chain address.

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -310,16 +310,42 @@ impl Fees {
     }
 }
 
+/// States for a submarine swap.
+///
+/// See <https://docs.boltz.exchange/v/api/lifecycle#normal-submarine-swaps>
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum SubSwapStates {
+    /// Initial state of the swap; optionally the initial state can also be `invoice.set` in case
+    /// the invoice was already specified in the `/createswap` request.
     Created,
+    /// The lockup transaction is found in the mempool, meaning the user is sending funds to the
+    /// lockup chain address.
     TransactionMempool,
+    /// The lockup transaction was included in a block.
     TransactionConfirmed,
+    /// If the invoice was _not_ set as part of the `/createswap` request, this state confirms that
+    /// an invoice with the correct amount and hash was set.
     InvoiceSet,
+    /// Boltz successfully paid the invoice.
     InvoicePaid,
+    /// Boltz started paying the invoice.
+    InvoicePending,
+    /// Boltz failed to pay the invoice. In this case the user needs to broadcast a refund
+    /// transaction to reclaim the locked up chain L-BTC.
     InvoiceFailedToPay,
+    /// Indicates that after the invoice was successfully paid, the chain L-BTC were successfully
+    /// claimed by Boltz. This is the final status of a successful Normal Submarine Swap.
     TransactionClaimed,
+    /// Indicates that Boltz is ready for the creation of a cooperative signature for a keypath
+    /// spend. Taproot Swaps are not claimed immediately by Boltz after the invoice has been paid,
+    /// but instead Boltz waits for the API client to post a signature for a key path spend. If the
+    /// API client does not cooperate in a key path spend, Boltz will eventually claim via the script path.
+    TransactionClaimPending,
+    /// Indicates the lockup failed, which is usually because the user sent too little.
+    TransactionLockupFailed,
+    /// Indicates the user didn't send chain L-BTC (lockup) and the swap expired (approximately 24h).
+    /// This means that it was cancelled and chain L-BTC shouldn't be sent anymore.
     SwapExpired,
 }
 
@@ -331,8 +357,11 @@ impl ToString for SubSwapStates {
             SubSwapStates::TransactionConfirmed => "transaction.confirmed".to_string(),
             SubSwapStates::InvoiceSet => "invoice.set".to_string(),
             SubSwapStates::InvoicePaid => "invoice.paid".to_string(),
+            SubSwapStates::InvoicePending => "invoice.pending".to_string(),
             SubSwapStates::InvoiceFailedToPay => "invoice.failedToPay".to_string(),
             SubSwapStates::TransactionClaimed => "transaction.claimed".to_string(),
+            SubSwapStates::TransactionClaimPending => "transaction.claim.pending".to_string(),
+            SubSwapStates::TransactionLockupFailed => "transaction.lockupFailed".to_string(),
             SubSwapStates::SwapExpired => "swap.expired".to_string(),
         }
     }
@@ -348,25 +377,53 @@ impl FromStr for SubSwapStates {
             "transaction.confirmed" => Ok(SubSwapStates::TransactionConfirmed),
             "invoice.set" => Ok(SubSwapStates::InvoiceSet),
             "invoice.paid" => Ok(SubSwapStates::InvoicePaid),
+            "invoice.pending" => Ok(SubSwapStates::InvoicePending),
             "invoice.failedToPay" => Ok(SubSwapStates::InvoiceFailedToPay),
             "transaction.claimed" => Ok(SubSwapStates::TransactionClaimed),
+            "transaction.claim.pending" => Ok(SubSwapStates::TransactionClaimPending),
+            "transaction.lockupFailed" => Ok(SubSwapStates::TransactionLockupFailed),
             "swap.expired" => Ok(SubSwapStates::SwapExpired),
             _ => Err(()),
         }
     }
 }
 
+/// States for a reverse swap.
+///
+/// See <https://docs.boltz.exchange/v/api/lifecycle#reverse-submarine-swaps>
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum RevSwapStates {
+    /// Initial state of a newly created Reverse Submarine Swap.
     Created,
+    /// Optional and currently not enabled on Boltz. If Boltz requires prepaying miner fees via a
+    /// separate Lightning invoice, this state is set when the miner fee invoice was successfully paid.
     MinerFeePaid,
+    /// Boltz's lockup transaction is found in the mempool which will only happen after the user
+    /// paid the Lightning hold invoice.
     TransactionMempool,
+    /// The lockup transaction was included in a block. This state is skipped, if the client
+    /// optionally accepts the transaction without confirmation. Boltz broadcasts chain transactions
+    /// non-RBF only.
     TransactionConfirmed,
+    /// The transaction claiming chain L-BTC was broadcast by the user's client and Boltz used the
+    /// preimage of this transaction to settle the Lightning invoice. This is the final status of a
+    /// successful Reverse Submarine Swap.
     InvoiceSettled,
+    /// Set when the invoice of Boltz expired and pending HTLCs are cancelled. Boltz invoices
+    /// currently expire after 50% of the swap timeout window.
     InvoiceExpired,
+    /// This is the final status of a swap, if the swap expires without the lightning invoice being paid.
     SwapExpired,
+    /// Set in the unlikely event that Boltz is unable to send the agreed amount of chain bitcoin
+    /// after the user set up the payment to the provided Lightning invoice. If this happens, the
+    /// pending Lightning HTLC will also be cancelled. The Lightning bitcoin automatically bounce
+    /// back to the user, no further action or refund is required and the user didn't pay any fees.
     TransactionFailed,
+    /// This is the final status of a swap, if the user successfully set up the Lightning payment
+    /// and Boltz successfully locked up L-BTC on the chain, but the Boltz API Client did not claim
+    /// the locked chain L-BTC until swap expiry. In this case, Boltz will also automatically refund
+    /// its own locked chain L-BTC.
     TransactionRefunded,
 }
 

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -415,7 +415,7 @@ pub enum RevSwapStates {
     InvoiceExpired,
     /// This is the final status of a swap, if the swap expires without the lightning invoice being paid.
     SwapExpired,
-    /// Set in the unlikely event that Boltz is unable to send the agreed amount of chain bitcoin
+    /// Set in the unlikely event that Boltz is unable to send the agreed amount of onchain coins
     /// after the user set up the payment to the provided Lightning invoice. If this happens, the
     /// pending Lightning HTLC will also be cancelled. The Lightning bitcoin automatically bounce
     /// back to the user, no further action or refund is required and the user didn't pay any fees.

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -319,8 +319,8 @@ pub enum SubSwapStates {
     /// Initial state of the swap; optionally the initial state can also be `invoice.set` in case
     /// the invoice was already specified in the request that created the swap.
     Created,
-    /// The lockup transaction is found in the mempool, meaning the user is sending funds to the
-    /// lockup chain address.
+    /// The lockup transaction waas found in the mempool, meaning the user sent funds to the
+    /// lockup address.
     TransactionMempool,
     /// The lockup transaction was included in a block.
     TransactionConfirmed,

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -344,7 +344,7 @@ pub enum SubSwapStates {
     TransactionClaimPending,
     /// Indicates the lockup failed, which is usually because the user sent too little.
     TransactionLockupFailed,
-    /// Indicates the user didn't send chain L-BTC (lockup) and the swap expired (approximately 24h).
+    /// Indicates the user didn't send onchain (lockup) and the swap expired (approximately 24h).
     /// This means that it was cancelled and chain L-BTC shouldn't be sent anymore.
     SwapExpired,
 }

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -332,7 +332,7 @@ pub enum SubSwapStates {
     /// Boltz started paying the invoice.
     InvoicePending,
     /// Boltz failed to pay the invoice. In this case the user needs to broadcast a refund
-    /// transaction to reclaim the locked up chain L-BTC.
+    /// transaction to reclaim the locked up onchain coins.
     InvoiceFailedToPay,
     /// Indicates that after the invoice was successfully paid, the chain L-BTC were successfully
     /// claimed by Boltz. This is the final status of a successful Normal Submarine Swap.

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -422,7 +422,7 @@ pub enum RevSwapStates {
     TransactionFailed,
     /// This is the final status of a swap, if the user successfully set up the Lightning payment
     /// and Boltz successfully locked up L-BTC on the chain, but the Boltz API Client did not claim
-    /// the locked chain L-BTC until swap expiry. In this case, Boltz will also automatically refund
+    /// the locked oncahin coins before swap expiry. In this case, Boltz will also automatically refund
     /// its own locked onchain coins and the Lightning payment is cancelled.
     TransactionRefunded,
 }

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -337,7 +337,7 @@ pub enum SubSwapStates {
     /// Indicates that after the invoice was successfully paid, the onchain were successfully
     /// claimed by Boltz. This is the final status of a successful Normal Submarine Swap.
     TransactionClaimed,
-    /// Indicates that Boltz is ready for the creation of a cooperative signature for a keypath
+    /// Indicates that Boltz is ready for the creation of a cooperative signature for a key path
     /// spend. Taproot Swaps are not claimed immediately by Boltz after the invoice has been paid,
     /// but instead Boltz waits for the API client to post a signature for a key path spend. If the
     /// API client does not cooperate in a key path spend, Boltz will eventually claim via the script path.

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -423,7 +423,7 @@ pub enum RevSwapStates {
     /// This is the final status of a swap, if the user successfully set up the Lightning payment
     /// and Boltz successfully locked up L-BTC on the chain, but the Boltz API Client did not claim
     /// the locked chain L-BTC until swap expiry. In this case, Boltz will also automatically refund
-    /// its own locked chain L-BTC.
+    /// its own locked onchain coins and the Lightning payment is cancelled.
     TransactionRefunded,
 }
 

--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -122,7 +122,7 @@ impl BoltzApiClientV2 {
                     Ok(r) => {
                         println!("{:#?}", r);
                         r.into_string()?
-                    },
+                    }
                     Err(ureq::Error::Status(code, response)) => {
                         print!("{:#?}", response);
                         let error: Value = serde_json::from_str(&response.into_string()?)?;

--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -291,9 +291,9 @@ pub struct CreateSubmarineRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateSubmarineResponse {
-    accept_zero_conf: bool,
+    pub accept_zero_conf: bool,
     pub address: String,
-    bip21: String,
+    pub bip21: String,
     pub claim_public_key: PublicKey,
     pub expected_amount: u64,
     pub id: String,

--- a/src/swaps/liquidv2.rs
+++ b/src/swaps/liquidv2.rs
@@ -383,9 +383,10 @@ impl LBtcSwapScriptV2 {
     ) -> Result<(OutPoint, TxOut), Error> {
         let boltz_client = BoltzApiClientV2::new(boltz_url);
         let hex = if self.swap_type == SwapType::ReverseSubmarine {
-            boltz_client.get_reverse_tx(swap_id)?.hex}else{
-                boltz_client.get_submarine_tx(swap_id)?.hex
-            };
+            boltz_client.get_reverse_tx(swap_id)?.hex
+        } else {
+            boltz_client.get_submarine_tx(swap_id)?.hex
+        };
 
         let address = self.to_address(network_config.network())?;
         let tx: Transaction = elements::encode::deserialize(&hex_to_bytes(&hex)?)?;
@@ -748,7 +749,6 @@ impl LBtcSwapTxV2 {
             };
 
             claim_tx.input[0].witness = witness;
-
         } else {
             // If Non-Cooperative claim use the Script Path spending
 

--- a/tests/liquid_v2.rs
+++ b/tests/liquid_v2.rs
@@ -4,9 +4,8 @@ use boltz_client::{
     network::{electrum::ElectrumConfig, Chain},
     swaps::{
         boltzv2::{
-            BoltzApiClientV2, CreateReverseRequest, CreateSubmarineRequest,
-            CreateSubmarineResponse, Subscription, SwapUpdate, BOLTZ_MAINNET_URL_V2,
-            BOLTZ_TESTNET_URL_V2,
+            BoltzApiClientV2, CreateReverseRequest, CreateSubmarineRequest, Subscription,
+            SwapUpdate, BOLTZ_MAINNET_URL_V2, BOLTZ_TESTNET_URL_V2,
         },
         magic_routing::{check_for_mrh, sign_address},
     },
@@ -17,11 +16,11 @@ use boltz_client::{
 use bitcoin::{
     hashes::{sha256, Hash},
     hex::{DisplayHex, FromHex},
-    key::{self, rand::thread_rng},
+    key::rand::thread_rng,
     secp256k1::Keypair,
     Amount, PublicKey,
 };
-use elements::{encode::serialize, Address};
+use elements::encode::serialize;
 
 pub mod test_utils;
 
@@ -424,7 +423,7 @@ fn test_recover_liquidv2_refund() {
         "1b581bed3300b146c61bdb3e5b58413f85299b71ab36401a8e02ec38d57925aa".to_string();
     let absolute_fees = 1_200;
     let network_config = ElectrumConfig::default(Chain::Liquid, None).unwrap();
-    let swap_script: LBtcSwapScriptV2 = createSwapScriptV2(
+    let swap_script: LBtcSwapScriptV2 = create_swap_script_v2(
         script_address,
         preimage.hash160.to_string(),
         boltz_pubkey,
@@ -455,7 +454,7 @@ fn test_recover_liquidv2_refund() {
     println!("{}", txid);
 }
 
-fn createSwapScriptV2(
+fn create_swap_script_v2(
     address: String,
     hashlock: String,
     receiver_pub: String,

--- a/tests/liquid_v2.rs
+++ b/tests/liquid_v2.rs
@@ -161,7 +161,11 @@ fn liquid_v2_submarine() {
                             .submarine_partial_sig(&our_keys, &claim_tx_response)
                             .unwrap();
                         boltz_api_v2
-                            .post_claim_tx_details(&create_swap_response.clone().id, pub_nonce, partial_sig)
+                            .post_claim_tx_details(
+                                &create_swap_response.clone().id,
+                                pub_nonce,
+                                partial_sig,
+                            )
                             .unwrap();
                         log::info!("Successfully Sent partial signature");
                     }
@@ -177,7 +181,6 @@ fn liquid_v2_submarine() {
                             &ElectrumConfig::default_liquid(),
                             boltz_url.to_string(),
                             create_swap_response.clone().id,
-
                         )
                         .unwrap();
 
@@ -430,9 +433,14 @@ fn test_recover_liquidv2_refund() {
         blinding_key,
     );
 
-    let rev_swap_tx =
-        LBtcSwapTxV2::new_refund(swap_script, &RETURN_ADDRESS.to_string(), &network_config, BOLTZ_MAINNET_URL_V2.to_string(), id.clone())
-            .unwrap();
+    let rev_swap_tx = LBtcSwapTxV2::new_refund(
+        swap_script,
+        &RETURN_ADDRESS.to_string(),
+        &network_config,
+        BOLTZ_MAINNET_URL_V2.to_string(),
+        id.clone(),
+    )
+    .unwrap();
     let client = BoltzApiClientV2::new(BOLTZ_MAINNET_URL_V2);
     let coop = Some((&client, &id));
     let signed_tx = rev_swap_tx


### PR DESCRIPTION
Based on some previous work from @hydra-yse , I added the missing `RevSwapStates`.

I also included descriptions for each submarine and reverse swap state from the Boltz Docs.