### PR TITLE
Re-export common libs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,12 @@ pub mod swaps;
 /// utilities (key, preimage, error)
 pub mod util;
 
+// Re-export common libs, so callers can make use of them and avoid version conflicts
+pub use bitcoin;
+pub use elements;
+pub use lightning_invoice;
+
+// Re-export relevant structs under boltz_client::StructName for simplicity
 pub use bitcoin::{
     blockdata::locktime::absolute::LockTime,
     hashes::hash160::Hash,


### PR DESCRIPTION
This PR re-exports common libs `bitcoin`, `elements` and `lightning_invoice`.

TLDR: This allows callers, if necessary, to use structs from these libs without having to worry about having an incompatible lib version.

For example, without this PR, a caller would have access to `lightning_invoice::Bolt11Invoice` as `boltz_client::Bolt11Invoice`, but not to `lightning_invoice::Bolt11InvoiceDescription` since this is not re-exported at the moment. If the caller would import the `lightning_invoice` dependency to get access to this, they may run into compatibility issues if they use e.g. `Bolt11Invoice::from_str(..)?.description()` with the import from `boltz_client` and `Bolt11InvoiceDescription` from their own dependency.

With the new re-exports, callers can access all structs from `boltz_client`'s specific versions of `bitcoin`, `elements` and `lightning_invoice`.