### PR TITLE
Chain swaps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ url = "2.5.0"
 log = "^0.4"
 env_logger = "0.7"
 native-tls = "0.2.11"
+hex = "0.4"
 
 [patch.crates-io]
 secp256k1-zkp = {git = "https://github.com/BlockstreamResearch/rust-secp256k1-zkp.git", rev = "60e631c24588a0c9e271badd61959294848c665d"}

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,12 @@ impl From<bitcoin::hex::HexToArrayError> for Error {
     }
 }
 
+impl From<hex::FromHexError> for Error {
+    fn from(value: hex::FromHexError) -> Self {
+        Self::Hex(value.to_string())
+    }
+}
+
 impl From<bitcoin::address::ParseError> for Error {
     fn from(value: bitcoin::address::ParseError) -> Self {
         Self::Address(value.to_string())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,5 +37,6 @@ pub use swaps::boltz::{SwapTxKind, SwapType};
 pub use swaps::{
     bitcoin::{BtcSwapScript, BtcSwapTx},
     bitcoinv2::{BtcSwapScriptV2, BtcSwapTxV2},
+    boltzv2,
     liquidv2::{LBtcSwapScriptV2, LBtcSwapTxV2},
 };

--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -228,6 +228,10 @@ impl BtcSwapScript {
 
                 Ok(script)
             }
+            SwapType::Chain => Err(Error::Protocol(format!(
+                "Invalid SwapType: {:?}",
+                self.swap_type
+            ))),
         }
     }
 
@@ -248,6 +252,10 @@ impl BtcSwapScript {
         match self.swap_type {
             SwapType::Submarine => Ok(Address::p2shwsh(&script, network)),
             SwapType::ReverseSubmarine => Ok(Address::p2wsh(&script, network)),
+            SwapType::Chain => Err(Error::Protocol(format!(
+                "Invalid SwapType: {:?}",
+                self.swap_type
+            ))),
         }
     }
     /// Get the balance of the script

--- a/src/swaps/bitcoinv2.rs
+++ b/src/swaps/bitcoinv2.rs
@@ -1009,12 +1009,7 @@ impl BtcSwapTxV2 {
     /// Calculate the size of a transaction.
     /// Use this before calling drain to help calculate the absolute fees.
     /// Multiply the size by the fee_rate to get the absolute fees.
-    pub fn size(
-        &self,
-        keys: &Keypair,
-        preimage: &Preimage,
-        refund_tx: Option<LBtcSwapTxV2>,
-    ) -> Result<usize, Error> {
+    pub fn size(&self, keys: &Keypair, preimage: &Preimage) -> Result<usize, Error> {
         let dummy_abs_fee = 5_000;
         // Can only calculate non-coperative claims
         let tx = match self.kind {

--- a/src/swaps/bitcoinv2.rs
+++ b/src/swaps/bitcoinv2.rs
@@ -127,7 +127,7 @@ impl BtcSwapScriptV2 {
 
     pub fn musig_keyagg_cache(&self) -> MusigKeyAggCache {
         match (self.swap_type, self.side.clone()) {
-            (SwapType::ReverseSubmarine, _) | (SwapType::Chain, Some(Side::To)) => {
+            (SwapType::ReverseSubmarine, _) | (SwapType::Chain, Some(Side::Claim)) => {
                 let pubkeys = [self.sender_pubkey.inner, self.receiver_pubkey.inner];
                 MusigKeyAggCache::new(&Secp256k1::new(), &pubkeys)
             }
@@ -257,8 +257,8 @@ impl BtcSwapScriptV2 {
         let funding_addrs = Address::from_str(&chain_swap_details.lockup_address)?.assume_checked();
 
         let (sender_pubkey, receiver_pubkey) = match side {
-            Side::From => (our_pubkey, chain_swap_details.server_public_key),
-            Side::To => (chain_swap_details.server_public_key, our_pubkey),
+            Side::Lockup => (our_pubkey, chain_swap_details.server_public_key),
+            Side::Claim => (chain_swap_details.server_public_key, our_pubkey),
         };
 
         Ok(BtcSwapScriptV2 {

--- a/src/swaps/bitcoinv2.rs
+++ b/src/swaps/bitcoinv2.rs
@@ -525,7 +525,7 @@ impl BtcSwapTxV2 {
 
     /// Compute the Musig partial signature.
     /// This is used to cooperatively settle a Submarine or Chain Swap.
-    pub fn partial_sig(
+    pub fn partial_sign(
         &self,
         keys: &Keypair,
         pub_nonce: &String,

--- a/src/swaps/bitcoinv2.rs
+++ b/src/swaps/bitcoinv2.rs
@@ -574,7 +574,7 @@ impl BtcSwapTxV2 {
     }
 
     /// Sign a claim transaction.
-    /// Panics if called on a Submarine Swap or Refund Tx.
+    /// Errors if called on a Submarine Swap or Refund Tx.
     /// If the claim is cooperative, provide the other party's partial sigs.
     /// If this is None, transaction will be claimed via taproot script path.
     pub fn sign_claim(

--- a/src/swaps/bitcoinv2.rs
+++ b/src/swaps/bitcoinv2.rs
@@ -4,7 +4,7 @@ use bitcoin::hex::{DisplayHex, FromHex};
 use bitcoin::key::rand::rngs::OsRng;
 use bitcoin::key::rand::{thread_rng, RngCore};
 use bitcoin::script::{PushBytes, PushBytesBuf};
-use bitcoin::secp256k1::{Keypair, Message, Secp256k1, SecretKey};
+use bitcoin::secp256k1::{All, Keypair, Message, Secp256k1, SecretKey};
 use bitcoin::sighash::Prevouts;
 use bitcoin::taproot::{LeafVersion, Signature, TaprootBuilder, TaprootSpendInfo};
 use bitcoin::transaction::Version;
@@ -28,16 +28,19 @@ use crate::{
     swaps::boltz::SwapTxKind,
     util::secrets::Preimage,
 };
+use crate::{LBtcSwapScriptV2, LBtcSwapTxV2};
 
 use bitcoin::{blockdata::locktime::absolute::LockTime, hashes::hash160};
 
 use super::boltz::SwapType;
 use super::boltzv2::{
-    BoltzApiClientV2, ClaimTxResponse, CreateReverseResponse, CreateSubmarineResponse,
+    BoltzApiClientV2, ChainClaimTxResponse, ChainSwapDetails, Cooperative, CreateChainResponse,
+    CreateReverseResponse, CreateSubmarineResponse, PartialSig, Side, SubmarineClaimTxResponse,
+    ToSign,
 };
 
 use elements::secp256k1_zkp::{
-    MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
+    musig, MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
     MusigSessionId,
 };
 
@@ -127,7 +130,7 @@ impl BtcSwapScriptV2 {
                 MusigKeyAggCache::new(&Secp256k1::new(), &pubkeys)
             }
 
-            SwapType::ReverseSubmarine => {
+            SwapType::ReverseSubmarine | SwapType::Chain => {
                 let pubkeys = [self.sender_pubkey.inner, self.receiver_pubkey.inner];
                 MusigKeyAggCache::new(&Secp256k1::new(), &pubkeys)
             }
@@ -197,6 +200,75 @@ impl BtcSwapScriptV2 {
         })
     }
 
+    /// Create the struct for a chain swap from a boltz create response.
+    pub fn chain_from_swap_resp(
+        side: Side,
+        chain_swap_details: ChainSwapDetails,
+        our_pubkey: PublicKey,
+    ) -> Result<Self, Error> {
+        let claim_script = ScriptBuf::from_hex(&chain_swap_details.swap_tree.claim_leaf.output)?;
+        let refund_script = ScriptBuf::from_hex(&chain_swap_details.swap_tree.refund_leaf.output)?;
+
+        let claim_instructions = claim_script.instructions();
+        let refund_instructions = refund_script.instructions();
+
+        let mut last_op = OP_0;
+        let mut hashlock = None;
+        let mut timelock = None;
+
+        for instruction in claim_instructions {
+            match instruction {
+                Ok(Instruction::PushBytes(bytes)) => {
+                    if bytes.len() == 20 {
+                        hashlock = Some(hash160::Hash::from_slice(bytes.as_bytes())?);
+                    } else {
+                        continue;
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        for instruction in refund_instructions {
+            match instruction {
+                Ok(Instruction::Op(opcode)) => last_op = opcode,
+                Ok(Instruction::PushBytes(bytes)) => {
+                    if last_op == OP_CHECKSIGVERIFY {
+                        timelock = Some(LockTime::from_consensus(bytes_to_u32_little_endian(
+                            &bytes.as_bytes(),
+                        )));
+                    } else {
+                        continue;
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        let hashlock =
+            hashlock.ok_or_else(|| Error::Protocol("No hashlock provided".to_string()))?;
+
+        let timelock =
+            timelock.ok_or_else(|| Error::Protocol("No timelock provided".to_string()))?;
+
+        let funding_addrs = Address::from_str(&chain_swap_details.lockup_address)?.assume_checked();
+
+        let (sender_pubkey, receiver_pubkey) = match side {
+            Side::From => (our_pubkey, chain_swap_details.server_public_key),
+            Side::To => (chain_swap_details.server_public_key, our_pubkey),
+        };
+
+        Ok(BtcSwapScriptV2 {
+            swap_type: SwapType::Chain,
+            // swap_id: reverse_response.id.clone(),
+            funding_addrs: Some(funding_addrs),
+            hashlock,
+            receiver_pubkey,
+            locktime: timelock,
+            sender_pubkey,
+        })
+    }
+
     fn claim_script(&self) -> ScriptBuf {
         match self.swap_type {
             SwapType::Submarine => Builder::new()
@@ -207,7 +279,7 @@ impl BtcSwapScriptV2 {
                 .push_opcode(OP_CHECKSIG)
                 .into_script(),
 
-            SwapType::ReverseSubmarine => Builder::new()
+            SwapType::ReverseSubmarine | SwapType::Chain => Builder::new()
                 .push_opcode(OP_SIZE)
                 .push_int(32)
                 .push_opcode(OP_EQUALVERIFY)
@@ -310,6 +382,15 @@ impl BtcSwapScriptV2 {
         Ok(Address::p2tr_tweaked(output_key, network))
     }
 
+    pub fn validate_address(&self, chain: Chain, address: String) -> Result<(), Error> {
+        let to_address = self.to_address(chain)?;
+        if to_address.to_string() == address {
+            Ok(())
+        } else {
+            Err(Error::Protocol("Script/LockupAddress Mismatch".to_string()))
+        }
+    }
+
     /// Get the balance of the script
     pub fn get_balance(&self, network_config: &ElectrumConfig) -> Result<(u64, i64), Error> {
         let electrum_client = network_config.build_client()?;
@@ -352,6 +433,7 @@ pub fn bytes_to_u32_little_endian(bytes: &[u8]) -> u32 {
 
 /// A structure representing either a Claim or a Refund Tx.
 /// This Tx spends from the HTLC.
+#[derive(Debug, Clone)]
 pub struct BtcSwapTxV2 {
     pub kind: SwapTxKind, // These fields needs to be public to do manual creation in IT.
     pub swap_script: BtcSwapScriptV2,
@@ -361,7 +443,7 @@ pub struct BtcSwapTxV2 {
 }
 
 impl BtcSwapTxV2 {
-    /// Craft a new ClaimTx. Only works for Reverse Swaps.
+    /// Craft a new ClaimTx. Only works for Reverse and Chain Swaps.
     /// Returns None, if the HTLC utxo doesn't exist for the swap.
     pub fn new_claim(
         swap_script: BtcSwapScriptV2,
@@ -370,7 +452,7 @@ impl BtcSwapTxV2 {
     ) -> Result<BtcSwapTxV2, Error> {
         if swap_script.swap_type == SwapType::Submarine {
             return Err(Error::Protocol(
-                "Claim transactions can only be constructed for Reverse swaps.".to_string(),
+                "Claim transactions cannot be constructed for Submarine swaps.".to_string(),
             ));
         }
 
@@ -398,7 +480,7 @@ impl BtcSwapTxV2 {
         }
     }
 
-    /// Construct a RefundTX corresponding to the swap_script. Only works for Normal Swaps.
+    /// Construct a RefundTX corresponding to the swap_script. Only works for Submarine and Chain Swaps.
     /// Returns None, if the HTLC UTXO for the swap doesn't exist in blockhcian.
     pub fn new_refund(
         swap_script: BtcSwapScriptV2,
@@ -407,7 +489,7 @@ impl BtcSwapTxV2 {
     ) -> Result<BtcSwapTxV2, Error> {
         if swap_script.swap_type == SwapType::ReverseSubmarine {
             return Err(Error::Protocol(
-                "Refund Txs can only be constructed for Submarine Swaps.".to_string(),
+                "Refund Txs cannot be constructed for Reverse Submarine Swaps.".to_string(),
             ));
         }
 
@@ -437,12 +519,13 @@ impl BtcSwapTxV2 {
         }
     }
 
-    /// Compute the Musig partial signature for Submarine Swap.
-    /// This is used to cooperatively close a submarine swap.
-    pub fn submarine_partial_sig(
+    /// Compute the Musig partial signature.
+    /// This is used to cooperatively close a Submarine or Chain Swap.
+    pub fn partial_sig(
         &self,
         keys: &Keypair,
-        claim_tx_response: &ClaimTxResponse,
+        pub_nonce: &String,
+        transaction_hash: &String,
     ) -> Result<(MusigPartialSignature, MusigPubNonce), Error> {
         // Step 1: Start with a Musig KeyAgg Cache
         let secp = Secp256k1::new();
@@ -465,28 +548,29 @@ impl BtcSwapTxV2 {
 
         let session_id = MusigSessionId::new(&mut thread_rng());
 
-        let msg = Message::from_digest_slice(&Vec::from_hex(&claim_tx_response.transaction_hash)?)?;
+        let msg = Message::from_digest_slice(&Vec::from_hex(transaction_hash)?)?;
 
         // Step 4: Start the Musig2 Signing session
         let mut extra_rand = [0u8; 32];
         OsRng.fill_bytes(&mut extra_rand);
 
-        let (sec_nonce, pub_nonce) =
+        let (gen_sec_nonce, gen_pub_nonce) =
             key_agg_cache.nonce_gen(&secp, session_id, keys.public_key(), msg, Some(extra_rand))?;
 
-        let boltz_nonce = MusigPubNonce::from_slice(&Vec::from_hex(&claim_tx_response.pub_nonce)?)?;
+        let boltz_nonce = MusigPubNonce::from_slice(&Vec::from_hex(pub_nonce)?)?;
 
-        let agg_nonce = MusigAggNonce::new(&secp, &[boltz_nonce, pub_nonce]);
+        let agg_nonce = MusigAggNonce::new(&secp, &[boltz_nonce, gen_pub_nonce]);
 
         let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
 
-        let partial_sig = musig_session.partial_sign(&secp, sec_nonce, &keys, &key_agg_cache)?;
+        let partial_sig =
+            musig_session.partial_sign(&secp, gen_sec_nonce, &keys, &key_agg_cache)?;
 
-        Ok((partial_sig, pub_nonce))
+        Ok((partial_sig, gen_pub_nonce))
     }
 
-    /// Sign a reverse swap claim transaction.
-    /// Panics if called on a Normal Swap or Refund Tx.
+    /// Sign a claim transaction.
+    /// Panics if called on a Submarine Swap or Refund Tx.
     /// If the claim is cooperative, provide the other party's partial sigs.
     /// If this is None, transaction will be claimed via taproot script path.
     pub fn sign_claim(
@@ -494,17 +578,17 @@ impl BtcSwapTxV2 {
         keys: &Keypair,
         preimage: &Preimage,
         absolute_fees: u64,
-        is_cooperative: Option<(&BoltzApiClientV2, String)>,
+        is_cooperative: Option<Cooperative>,
     ) -> Result<Transaction, Error> {
         if self.swap_script.swap_type == SwapType::Submarine {
             return Err(Error::Protocol(
-                "Claim Tx signing is only applicable for Reverse Swap Type".to_string(),
+                "Claim Tx signing is not applicable for Submarine Swaps".to_string(),
             ));
         }
 
         if self.kind == SwapTxKind::Refund {
             return Err(Error::Protocol(
-                "Cannot sign claim with Refund type BTCSwapTx".to_string(),
+                "Cannot sign claim with refund-type BtcSwapTx".to_string(),
             ));
         }
 
@@ -540,9 +624,14 @@ impl BtcSwapTxV2 {
         let secp = Secp256k1::new();
 
         // If its a cooperative claim, compute the Musig2 Aggregate Signature and use Keypath spending
-        if let Some((boltz_api, swap_id)) = is_cooperative {
+        if let Some(Cooperative {
+            boltz_api,
+            swap_id,
+            pub_nonce,
+            partial_sig,
+        }) = is_cooperative
+        {
             // Start the Musig session
-
             // Step 1: Get the sighash
             let claim_tx_taproot_hash = SighashCache::new(claim_tx.clone())
                 .taproot_key_spend_signature_hash(
@@ -554,7 +643,6 @@ impl BtcSwapTxV2 {
             let msg = Message::from_digest_slice(claim_tx_taproot_hash.as_byte_array())?;
 
             // Step 2: Get the Public and Secret nonces
-
             let mut key_agg_cache = self.swap_script.musig_keyagg_cache();
 
             let tweak = SecretKey::from_slice(
@@ -571,7 +659,7 @@ impl BtcSwapTxV2 {
             let mut extra_rand = [0u8; 32];
             OsRng.fill_bytes(&mut extra_rand);
 
-            let (sec_nonce, pub_nonce) = key_agg_cache.nonce_gen(
+            let (claim_sec_nonce, claim_pub_nonce) = key_agg_cache.nonce_gen(
                 &secp,
                 session_id,
                 keys.public_key(),
@@ -581,12 +669,34 @@ impl BtcSwapTxV2 {
 
             // Step 7: Get boltz's partial sig
             let claim_tx_hex = serialize(&claim_tx).to_lower_hex_string();
-            let partial_sig_resp = boltz_api.get_reverse_partial_sig(
-                &swap_id,
-                &preimage,
-                &pub_nonce,
-                &claim_tx_hex,
-            )?;
+            let partial_sig_resp = match self.swap_script.swap_type {
+                SwapType::Chain => match (pub_nonce, partial_sig) {
+                    (Some(pub_nonce), Some(partial_sig)) => boltz_api.post_chain_claim_tx_details(
+                        &swap_id,
+                        preimage,
+                        pub_nonce,
+                        partial_sig,
+                        ToSign {
+                            pub_nonce: claim_pub_nonce.serialize().to_lower_hex_string(),
+                            transaction: claim_tx_hex,
+                            index: 0,
+                        },
+                    ),
+                    _ => Err(Error::Protocol(
+                        "Chain swap claim needs a partial_sig".to_string(),
+                    )),
+                },
+                SwapType::ReverseSubmarine => boltz_api.get_reverse_partial_sig(
+                    &swap_id,
+                    &preimage,
+                    &claim_pub_nonce,
+                    &claim_tx_hex,
+                ),
+                _ => Err(Error::Protocol(format!(
+                    "Cannot get partial sig for {:?} Swap",
+                    self.swap_script.swap_type
+                ))),
+            }?;
 
             let boltz_public_nonce =
                 MusigPubNonce::from_slice(&Vec::from_hex(&partial_sig_resp.pub_nonce)?)?;
@@ -596,7 +706,7 @@ impl BtcSwapTxV2 {
             )?)?;
 
             // Aggregate Our's and Other's Nonce and start the Musig session.
-            let agg_nonce = MusigAggNonce::new(&secp, &[boltz_public_nonce, pub_nonce]);
+            let agg_nonce = MusigAggNonce::new(&secp, &[boltz_public_nonce, claim_pub_nonce]);
 
             let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
 
@@ -616,7 +726,7 @@ impl BtcSwapTxV2 {
             }
 
             let our_partial_sig =
-                musig_session.partial_sign(&secp, sec_nonce, &keys, &key_agg_cache)?;
+                musig_session.partial_sign(&secp, claim_sec_nonce, &keys, &key_agg_cache)?;
 
             let schnorr_sig = musig_session.partial_sig_agg(&[boltz_partial_sig, our_partial_sig]);
 
@@ -673,17 +783,17 @@ impl BtcSwapTxV2 {
         Ok(claim_tx)
     }
 
-    /// Sign a submarine swap refund transaction.
-    /// Panics if called on Reverse Swap, Claim type.
+    /// Sign a refund transaction.
+    /// Panics if called on a Reverse Swap or Claim Tx.
     pub fn sign_refund(
         &self,
         keys: &Keypair,
         absolute_fees: u64,
-        is_cooperative: Option<(&BoltzApiClientV2, &String)>,
+        is_cooperative: Option<Cooperative>,
     ) -> Result<Transaction, Error> {
         if self.swap_script.swap_type == SwapType::ReverseSubmarine {
             return Err(Error::Protocol(
-                "Cannot sign refund tx, for a reverse-swap".to_string(),
+                "Refund Tx signing is not applicable for Reverse Submarine Swaps".to_string(),
             ));
         }
 
@@ -749,7 +859,10 @@ impl BtcSwapTxV2 {
 
         let secp = Secp256k1::new();
 
-        if let Some((boltz_api, swap_id)) = is_cooperative {
+        if let Some(Cooperative {
+            boltz_api, swap_id, ..
+        }) = is_cooperative
+        {
             // Start the Musig session
             refund_tx.lock_time = LockTime::ZERO; // No locktime for cooperative spend
 
@@ -791,8 +904,18 @@ impl BtcSwapTxV2 {
 
             // Step 7: Get boltz's partial sig
             let refund_tx_hex = serialize(&refund_tx).to_lower_hex_string();
-            let partial_sig_resp =
-                boltz_api.get_submarine_partial_sig(&swap_id, &pub_nonce, &refund_tx_hex)?;
+            let partial_sig_resp = match self.swap_script.swap_type {
+                SwapType::Chain => {
+                    boltz_api.get_chain_partial_sig(&swap_id, &pub_nonce, &refund_tx_hex)
+                }
+                SwapType::Submarine => {
+                    boltz_api.get_submarine_partial_sig(&swap_id, &pub_nonce, &refund_tx_hex)
+                }
+                _ => Err(Error::Protocol(format!(
+                    "Cannot get partial sig for {:?} Swap",
+                    self.swap_script.swap_type
+                ))),
+            }?;
 
             let boltz_public_nonce =
                 MusigPubNonce::from_slice(&Vec::from_hex(&partial_sig_resp.pub_nonce)?)?;
@@ -886,10 +1009,16 @@ impl BtcSwapTxV2 {
     /// Calculate the size of a transaction.
     /// Use this before calling drain to help calculate the absolute fees.
     /// Multiply the size by the fee_rate to get the absolute fees.
-    pub fn size(&self, keys: &Keypair, preimage: &Preimage) -> Result<usize, Error> {
+    pub fn size(
+        &self,
+        keys: &Keypair,
+        preimage: &Preimage,
+        refund_tx: Option<LBtcSwapTxV2>,
+    ) -> Result<usize, Error> {
         let dummy_abs_fee = 5_000;
+        // Can only calculate non-coperative claims
         let tx = match self.kind {
-            SwapTxKind::Claim => self.sign_claim(keys, preimage, dummy_abs_fee, None)?, // Can only calculate non-coperative claims
+            SwapTxKind::Claim => self.sign_claim(keys, preimage, dummy_abs_fee, None)?,
             SwapTxKind::Refund => self.sign_refund(keys, dummy_abs_fee, None)?,
         };
         Ok(tx.vsize())

--- a/src/swaps/bitcoinv2.rs
+++ b/src/swaps/bitcoinv2.rs
@@ -524,7 +524,7 @@ impl BtcSwapTxV2 {
     }
 
     /// Compute the Musig partial signature.
-    /// This is used to cooperatively close a Submarine or Chain Swap.
+    /// This is used to cooperatively settle a Submarine or Chain Swap.
     pub fn partial_sig(
         &self,
         keys: &Keypair,

--- a/src/swaps/bitcoinv2.rs
+++ b/src/swaps/bitcoinv2.rs
@@ -788,7 +788,7 @@ impl BtcSwapTxV2 {
     }
 
     /// Sign a refund transaction.
-    /// Panics if called on a Reverse Swap or Claim Tx.
+    /// Errors if called for a Reverse Swap.
     pub fn sign_refund(
         &self,
         keys: &Keypair,

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -462,11 +462,74 @@ impl FromStr for RevSwapStates {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum ChainSwapStates {
+    Created,
+    TransactionZeroConfRejected,
+    TransactionMempool,
+    TransactionConfirmed,
+    TransactionServerMempool,
+    TransactionServerConfirmed,
+    TransactionClaimed,
+    TransactionClaimPending,
+    TransactionLockupFailed,
+    SwapExpired,
+    TransactionFailed,
+    TransactionRefunded,
+}
+
+impl ToString for ChainSwapStates {
+    fn to_string(&self) -> String {
+        match self {
+            ChainSwapStates::Created => "swap.created".to_string(),
+            ChainSwapStates::TransactionZeroConfRejected => {
+                "transaction.zeroconf.rejected".to_string()
+            }
+            ChainSwapStates::TransactionMempool => "transaction.mempool".to_string(),
+            ChainSwapStates::TransactionConfirmed => "transaction.confirmed".to_string(),
+            ChainSwapStates::TransactionServerMempool => "transaction.server.mempool".to_string(),
+            ChainSwapStates::TransactionServerConfirmed => {
+                "transaction.server.confirmed".to_string()
+            }
+            ChainSwapStates::TransactionClaimed => "transaction.claimed".to_string(),
+            ChainSwapStates::TransactionClaimPending => "transaction.claim.pending".to_string(),
+            ChainSwapStates::TransactionLockupFailed => "transaction.lockupFailed".to_string(),
+            ChainSwapStates::SwapExpired => "swap.expired".to_string(),
+            ChainSwapStates::TransactionFailed => "transaction.failed".to_string(),
+            ChainSwapStates::TransactionRefunded => "transaction.refunded".to_string(),
+        }
+    }
+}
+
+impl FromStr for ChainSwapStates {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "swap.created" => Ok(ChainSwapStates::Created),
+            "transaction.zeroconf.rejected" => Ok(ChainSwapStates::TransactionZeroConfRejected),
+            "transaction.mempool" => Ok(ChainSwapStates::TransactionMempool),
+            "transaction.confirmed" => Ok(ChainSwapStates::TransactionConfirmed),
+            "transaction.server.mempool" => Ok(ChainSwapStates::TransactionServerMempool),
+            "transaction.server.confirmed" => Ok(ChainSwapStates::TransactionServerConfirmed),
+            "transaction.claimed" => Ok(ChainSwapStates::TransactionClaimed),
+            "transaction.claim.pending" => Ok(ChainSwapStates::TransactionClaimPending),
+            "transaction.lockupFailed" => Ok(ChainSwapStates::TransactionLockupFailed),
+            "swap.expired" => Ok(ChainSwapStates::SwapExpired),
+            "transaction.failed" => Ok(ChainSwapStates::TransactionFailed),
+            "transaction.refunded" => Ok(ChainSwapStates::TransactionRefunded),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 pub enum SwapType {
     Submarine,
     ReverseSubmarine,
+    Chain,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -472,7 +472,6 @@ pub enum ChainSwapStates {
     TransactionServerMempool,
     TransactionServerConfirmed,
     TransactionClaimed,
-    TransactionClaimPending,
     TransactionLockupFailed,
     SwapExpired,
     TransactionFailed,
@@ -493,7 +492,6 @@ impl ToString for ChainSwapStates {
                 "transaction.server.confirmed".to_string()
             }
             ChainSwapStates::TransactionClaimed => "transaction.claimed".to_string(),
-            ChainSwapStates::TransactionClaimPending => "transaction.claim.pending".to_string(),
             ChainSwapStates::TransactionLockupFailed => "transaction.lockupFailed".to_string(),
             ChainSwapStates::SwapExpired => "swap.expired".to_string(),
             ChainSwapStates::TransactionFailed => "transaction.failed".to_string(),
@@ -514,7 +512,6 @@ impl FromStr for ChainSwapStates {
             "transaction.server.mempool" => Ok(ChainSwapStates::TransactionServerMempool),
             "transaction.server.confirmed" => Ok(ChainSwapStates::TransactionServerConfirmed),
             "transaction.claimed" => Ok(ChainSwapStates::TransactionClaimed),
-            "transaction.claim.pending" => Ok(ChainSwapStates::TransactionClaimPending),
             "transaction.lockupFailed" => Ok(ChainSwapStates::TransactionLockupFailed),
             "swap.expired" => Ok(ChainSwapStates::SwapExpired),
             "transaction.failed" => Ok(ChainSwapStates::TransactionFailed),

--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -720,7 +720,7 @@ impl CreateReverseResponse {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Side {
     From,
     To,

--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -36,10 +36,26 @@ pub struct HeightResponse {
     pub lbtc: u32,
 }
 
+fn check_limits_within(maximal: u64, minimal: u64, output_amount: u64) -> Result<(), Error> {
+    if output_amount < minimal as u64 {
+        return Err(Error::Protocol(format!(
+            "Output amount is below minimum {}",
+            minimal
+        )));
+    }
+    if output_amount > maximal as u64 {
+        return Err(Error::Protocol(format!(
+            "Output amount is above maximum {}",
+            maximal
+        )));
+    }
+    Ok(())
+}
+
 /// Various limits of swap parameters
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct Limits {
+pub struct PairLimits {
     /// Maximum swap amount
     pub maximal: u64,
     /// Minimum swap amount
@@ -48,35 +64,231 @@ pub struct Limits {
     pub maximal_zero_conf: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Fees {
-    /// The percentage of the "send amount" that is charged by Boltz as "Boltz Fee".
-    percentage: f64,
-    /// The network fees charged for locking up and claiming funds onchain. These values are absolute, denominated in 10 ** -8 of the quote asset.
-    miner_fees: u64,
+impl PairLimits {
+    /// Check whether the output amount intended is within the Limits
+    pub fn within(&self, output_amount: u64) -> Result<(), Error> {
+        check_limits_within(self.maximal, self.minimal, output_amount)
+    }
 }
 
-/// Various swap parameters associated with different assets.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct SwapParams {
+pub struct ReverseLimits {
+    /// Maximum swap amount
+    pub maximal: u64,
+    /// Minimum swap amount
+    pub minimal: u64,
+}
+
+impl ReverseLimits {
+    /// Check whether the output amount intended is within the Limits
+    pub fn within(&self, output_amount: u64) -> Result<(), Error> {
+        check_limits_within(self.maximal, self.minimal, output_amount)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PairMinerFees {
+    lockup: u64,
+    claim: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainMinerFees {
+    server: u64,
+    user: PairMinerFees,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainFees {
+    pub percentage: f64,
+    pub miner_fees: ChainMinerFees,
+}
+
+impl ChainFees {
+    pub fn total(&self, amount_sat: u64) -> u64 {
+        self.boltz(amount_sat) + self.claim_estimate() + self.lockup()
+    }
+
+    pub fn boltz(&self, amount_sat: u64) -> u64 {
+        ((self.percentage / 100.0) * amount_sat as f64).ceil() as u64
+    }
+
+    pub fn claim_estimate(&self) -> u64 {
+        self.miner_fees.user.claim
+    }
+
+    pub fn lockup(&self) -> u64 {
+        self.miner_fees.user.lockup
+    }
+
+    pub fn server(&self) -> u64 {
+        self.miner_fees.server
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ReverseFees {
+    pub percentage: f64,
+    pub miner_fees: PairMinerFees,
+}
+
+impl ReverseFees {
+    pub fn total(&self, invoice_amount_sat: u64) -> u64 {
+        self.boltz(invoice_amount_sat) + self.claim_estimate() + self.lockup()
+    }
+
+    pub fn boltz(&self, invoice_amount_sat: u64) -> u64 {
+        ((self.percentage / 100.0) * invoice_amount_sat as f64).ceil() as u64
+    }
+
+    pub fn claim_estimate(&self) -> u64 {
+        self.miner_fees.claim
+    }
+
+    pub fn lockup(&self) -> u64 {
+        self.miner_fees.lockup
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmarineFees {
+    pub percentage: f64,
+    pub miner_fees: u64,
+}
+
+impl SubmarineFees {
+    pub fn total(&self, invoice_amount_sat: u64) -> u64 {
+        self.boltz(invoice_amount_sat) + self.network()
+    }
+
+    pub fn boltz(&self, invoice_amount_sat: u64) -> u64 {
+        ((self.percentage / 100.0) * invoice_amount_sat as f64).ceil() as u64
+    }
+
+    pub fn network(&self) -> u64 {
+        self.miner_fees
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainPair {
     /// Pair hash, representing an id for an asset-pair swap
     pub hash: String,
     /// The exchange rate of the pair
     pub rate: f64,
     /// The swap limits
-    pub limits: Limits,
+    pub limits: PairLimits,
     /// Total fees required for the swap
-    pub fees: Fees,
+    pub fees: ChainFees,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ReversePair {
+    /// Pair hash, representing an id for an asset-pair swap
+    pub hash: String,
+    /// The exchange rate of the pair
+    pub rate: f64,
+    /// The swap limits
+    pub limits: ReverseLimits,
+    /// Total fees required for the swap
+    pub fees: ReverseFees,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmarinePair {
+    /// Pair hash, representing an id for an asset-pair swap
+    pub hash: String,
+    /// The exchange rate of the pair
+    pub rate: f64,
+    /// The swap limits
+    pub limits: PairLimits,
+    /// Total fees required for the swap
+    pub fees: SubmarineFees,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SwapResponse {
+pub struct GetSubmarinePairsResponse {
     #[serde(rename = "BTC")]
-    pub btc: HashMap<String, SwapParams>,
+    btc: HashMap<String, SubmarinePair>,
     #[serde(rename = "L-BTC")]
-    pub lbtc: HashMap<String, SwapParams>,
+    lbtc: HashMap<String, SubmarinePair>,
+}
+
+impl GetSubmarinePairsResponse {
+    /// Get the BtcBtc Pair data from the response.
+    /// Returns None if not found.
+    pub fn get_btc_to_btc_pair(&self) -> Option<SubmarinePair> {
+        self.btc.get("BTC").cloned()
+    }
+
+    /// Get the BtcLBtc Pair data from the response.
+    /// Returns None if not found.
+    pub fn get_btc_to_lbtc_pair(&self) -> Option<SubmarinePair> {
+        self.btc.get("L-BTC").cloned()
+    }
+
+    /// Get the LBtcBtc Pair data from the response.
+    /// Returns None if not found.
+    pub fn get_lbtc_to_btc_pair(&self) -> Option<SubmarinePair> {
+        self.lbtc.get("BTC").cloned()
+    }
+
+    /// Get the LBtcLBtc Pair data from the response.
+    /// Returns None if not found.
+    pub fn get_lbtc_to_lbtc_pair(&self) -> Option<SubmarinePair> {
+        self.lbtc.get("L-BTC").cloned()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetReversePairsResponse {
+    #[serde(rename = "BTC")]
+    pub btc: HashMap<String, ReversePair>,
+}
+
+impl GetReversePairsResponse {
+    /// Get the BtcBtc Pair data from the response.
+    /// Returns None if not found.
+    pub fn get_btc_to_btc_pair(&self) -> Option<ReversePair> {
+        self.btc.get("BTC").cloned()
+    }
+
+    /// Get the BtcLBtc Pair data from the response.
+    /// Returns None if not found.
+    pub fn get_btc_to_lbtc_pair(&self) -> Option<ReversePair> {
+        self.btc.get("L-BTC").cloned()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetChainPairsResponse {
+    #[serde(rename = "BTC")]
+    pub btc: HashMap<String, ChainPair>,
+    #[serde(rename = "L-BTC")]
+    lbtc: HashMap<String, ChainPair>,
+}
+
+impl GetChainPairsResponse {
+    /// Get the BtcLBtc Pair data from the response.
+    /// Returns None if not found.
+    pub fn get_btc_to_lbtc_pair(&self) -> Option<ChainPair> {
+        self.btc.get("L-BTC").cloned()
+    }
+
+    /// Get the LBtcBtc Pair data from the response.
+    /// Returns None if not found.
+    pub fn get_lbtc_to_btc_pair(&self) -> Option<ChainPair> {
+        self.lbtc.get("BTC").cloned()
+    }
 }
 
 /// Reference Documnetation: https://api.boltz.exchange/swagger
@@ -154,8 +366,16 @@ impl BoltzApiClientV2 {
         Ok(serde_json::from_str(&self.get("chain/heights")?)?)
     }
 
-    pub fn get_pairs(&self) -> Result<SwapResponse, Error> {
+    pub fn get_submarine_pairs(&self) -> Result<GetSubmarinePairsResponse, Error> {
         Ok(serde_json::from_str(&self.get("swap/submarine")?)?)
+    }
+
+    pub fn get_reverse_pairs(&self) -> Result<GetReversePairsResponse, Error> {
+        Ok(serde_json::from_str(&self.get("swap/reverse")?)?)
+    }
+
+    pub fn get_chain_pairs(&self) -> Result<GetChainPairsResponse, Error> {
+        Ok(serde_json::from_str(&self.get("swap/chain")?)?)
     }
 
     pub fn post_swap_req(
@@ -166,12 +386,31 @@ impl BoltzApiClientV2 {
         Ok(serde_json::from_str(&self.post("swap/submarine", data)?)?)
     }
 
-    pub fn get_claim_tx_details(&self, id: &String) -> Result<ClaimTxResponse, Error> {
+    pub fn post_reverse_req(
+        &self,
+        req: CreateReverseRequest,
+    ) -> Result<CreateReverseResponse, Error> {
+        Ok(serde_json::from_str(&self.post("swap/reverse", req)?)?)
+    }
+
+    pub fn post_chain_req(&self, req: CreateChainRequest) -> Result<CreateChainResponse, Error> {
+        Ok(serde_json::from_str(&self.post("swap/chain", req)?)?)
+    }
+
+    pub fn get_submarine_claim_tx_details(
+        &self,
+        id: &String,
+    ) -> Result<SubmarineClaimTxResponse, Error> {
         let endpoint = format!("swap/submarine/{}/claim", id);
         Ok(serde_json::from_str(&self.get(&endpoint)?)?)
     }
 
-    pub fn post_claim_tx_details(
+    pub fn get_chain_claim_tx_details(&self, id: &String) -> Result<ChainClaimTxResponse, Error> {
+        let endpoint = format!("swap/chain/{}/claim", id);
+        Ok(serde_json::from_str(&self.get(&endpoint)?)?)
+    }
+
+    pub fn post_submarine_claim_tx_details(
         &self,
         id: &String,
         pub_nonce: MusigPubNonce,
@@ -187,11 +426,26 @@ impl BoltzApiClientV2 {
         Ok(serde_json::from_str(&self.post(&endpoint, data)?)?)
     }
 
-    pub fn post_reverse_req(
+    pub fn post_chain_claim_tx_details(
         &self,
-        req: CreateReverseRequest,
-    ) -> Result<CreateReverseResponse, Error> {
-        Ok(serde_json::from_str(&self.post("swap/reverse", req)?)?)
+        id: &String,
+        preimage: &Preimage,
+        pub_nonce: MusigPubNonce,
+        partial_sig: MusigPartialSignature,
+        to_sign: ToSign,
+    ) -> Result<PartialSig, Error> {
+        let data = json!(
+            {
+                "preimage": preimage.bytes.expect("expected").to_lower_hex_string(),
+                "signature": PartialSig {
+                    pub_nonce: pub_nonce.serialize().to_lower_hex_string(),
+                    partial_signature: partial_sig.serialize().to_lower_hex_string(),
+                },
+                "toSign": to_sign,
+            }
+        );
+        let endpoint = format!("swap/chain/{}/claim", id);
+        Ok(serde_json::from_str(&self.post(&endpoint, data)?)?)
     }
 
     pub fn get_reverse_tx(&self, id: &str) -> Result<ReverseSwapTxResp, Error> {
@@ -206,13 +460,19 @@ impl BoltzApiClientV2 {
         )?)
     }
 
+    pub fn get_chain_txs(&self, id: &str) -> Result<ChainSwapTxResp, Error> {
+        Ok(serde_json::from_str(
+            &self.get(&format!("swap/chain/{}/transactions", id))?,
+        )?)
+    }
+
     pub fn get_reverse_partial_sig(
         &self,
         id: &String,
         preimage: &Preimage,
         pub_nonce: &MusigPubNonce,
         claim_tx_hex: &String,
-    ) -> Result<ReversePartialSig, Error> {
+    ) -> Result<PartialSig, Error> {
         let data = json!(
             {
                 "preimage": preimage.bytes.expect("expected").to_lower_hex_string(),
@@ -231,7 +491,7 @@ impl BoltzApiClientV2 {
         id: &String,
         pub_nonce: &MusigPubNonce,
         refund_tx_hex: &String,
-    ) -> Result<ReversePartialSig, Error> {
+    ) -> Result<PartialSig, Error> {
         let data = json!(
             {
                 "pubNonce": pub_nonce.serialize().to_lower_hex_string(),
@@ -241,6 +501,24 @@ impl BoltzApiClientV2 {
         );
 
         let endpoint = format!("swap/submarine/{}/refund", id);
+        Ok(serde_json::from_str(&self.post(&endpoint, data)?)?)
+    }
+
+    pub fn get_chain_partial_sig(
+        &self,
+        id: &String,
+        pub_nonce: &MusigPubNonce,
+        refund_tx_hex: &String,
+    ) -> Result<PartialSig, Error> {
+        let data = json!(
+            {
+                "pubNonce": pub_nonce.serialize().to_lower_hex_string(),
+                "transaction": refund_tx_hex,
+                "index": 0
+            }
+        );
+
+        let endpoint = format!("swap/chain/{}/refund", id);
         Ok(serde_json::from_str(&self.post(&endpoint, data)?)?)
     }
 
@@ -268,7 +546,15 @@ impl BoltzApiClientV2 {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ClaimTxResponse {
+pub struct ChainClaimTxResponse {
+    pub pub_nonce: String,
+    pub public_key: PublicKey,
+    pub transaction_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmarineClaimTxResponse {
     pub preimage: String,
     pub pub_nonce: String,
     pub public_key: PublicKey,
@@ -289,6 +575,7 @@ pub struct CreateSubmarineRequest {
     pub to: String,
     pub invoice: String,
     pub refund_public_key: PublicKey,
+    pub pair_hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub referral_id: Option<String>,
 }
@@ -319,15 +606,7 @@ impl CreateSubmarineResponse {
             Chain::Bitcoin | Chain::BitcoinTestnet | Chain::BitcoinRegtest => {
                 let boltz_sub_script =
                     BtcSwapScriptV2::submarine_from_swap_resp(&self, *our_pubkey)?;
-
-                let address = boltz_sub_script.to_address(chain)?;
-                if address.to_string() == self.address {
-                    Ok(())
-                } else {
-                    Err(Error::Protocol(
-                        "Script/FundingAddress Mismatch".to_string(),
-                    ))
-                }
+                boltz_sub_script.validate_address(chain, self.address.clone())
             }
             Chain::Liquid | Chain::LiquidTestnet | Chain::LiquidRegtest => {
                 let blinding_key = self.blinding_key.as_ref().unwrap();
@@ -341,15 +620,7 @@ impl CreateSubmarineResponse {
                     )));
                 }
 
-                let address = boltz_sub_script.to_address(chain)?;
-
-                if address.to_string() == self.address {
-                    Ok(())
-                } else {
-                    Err(Error::Protocol(
-                        "Script/FundingAddress Mismatch".to_string(),
-                    ))
-                }
+                boltz_sub_script.validate_address(chain, self.address.clone())
             }
         }
     }
@@ -437,28 +708,129 @@ impl CreateReverseResponse {
         match chain {
             Chain::Bitcoin | Chain::BitcoinTestnet | Chain::BitcoinRegtest => {
                 let boltz_rev_script = BtcSwapScriptV2::reverse_from_swap_resp(&self, *our_pubkey)?;
-                let address = boltz_rev_script.to_address(chain)?;
-                if address.to_string() == self.lockup_address {
-                    Ok(())
-                } else {
-                    Err(Error::Protocol("Script/LockupAddress Mismatch".to_string()))
-                }
+                boltz_rev_script.validate_address(chain, self.lockup_address.clone())
             }
             Chain::Liquid | Chain::LiquidTestnet | Chain::LiquidRegtest => {
                 let blinding_key = self.blinding_key.as_ref().unwrap();
                 let boltz_rev_script =
                     LBtcSwapScriptV2::reverse_from_swap_resp(&self, *our_pubkey)?;
-
-                let address = boltz_rev_script.to_address(chain)?;
-                if address.to_string() == self.lockup_address {
-                    Ok(())
-                } else {
-                    Err(Error::Protocol("Script/LockupAddress Mismatch".to_string()))
-                }
+                boltz_rev_script.validate_address(chain, self.lockup_address.clone())
             }
         }
     }
 }
+
+#[derive(Debug)]
+pub enum Side {
+    From,
+    To,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainSwapDetails {
+    pub swap_tree: SwapTree,
+    pub lockup_address: String,
+    pub server_public_key: PublicKey,
+    pub timeout_block_height: u32,
+    pub amount: u32,
+    pub blinding_key: Option<String>,
+    pub refund_address: Option<String>,
+    pub claim_address: Option<String>,
+    pub bip21: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateChainRequest {
+    pub from: String,
+    pub to: String,
+    pub preimage_hash: sha256::Hash,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claim_public_key: Option<PublicKey>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refund_public_key: Option<PublicKey>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_lock_amount: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_lock_amount: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pair_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub referral_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateChainResponse {
+    pub id: String,
+    pub claim_details: ChainSwapDetails,
+    pub lockup_details: ChainSwapDetails,
+}
+impl CreateChainResponse {
+    /// Validate chain swap response
+    pub fn validate(
+        &self,
+        claim_pubkey: &PublicKey,
+        refund_pubkey: &PublicKey,
+        from_chain: Chain,
+        to_chain: Chain,
+    ) -> Result<(), Error> {
+        self.validate_side(Side::From, from_chain, &self.lockup_details, refund_pubkey)?;
+        self.validate_side(Side::To, to_chain, &self.claim_details, claim_pubkey)
+    }
+
+    fn validate_side(
+        &self,
+        side: Side,
+        chain: Chain,
+        details: &ChainSwapDetails,
+        our_pubkey: &PublicKey,
+    ) -> Result<(), Error> {
+        match chain {
+            Chain::Bitcoin | Chain::BitcoinTestnet | Chain::BitcoinRegtest => {
+                let boltz_chain_script =
+                    BtcSwapScriptV2::chain_from_swap_resp(side, details.clone(), *our_pubkey)?;
+                boltz_chain_script.validate_address(chain, details.lockup_address.clone())
+            }
+            Chain::Liquid | Chain::LiquidTestnet | Chain::LiquidRegtest => {
+                let blinding_key = details.blinding_key.as_ref().unwrap();
+                let boltz_chain_script =
+                    LBtcSwapScriptV2::chain_from_swap_resp(side, details.clone(), *our_pubkey)?;
+                boltz_chain_script.validate_address(chain, details.lockup_address.clone())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainSwapTx {
+    pub id: String,
+    pub hex: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainSwapTxTimeout {
+    pub block_height: u32,
+    pub eta: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainSwapTxLock {
+    pub transaction: ChainSwapTx,
+    pub timeout: ChainSwapTxTimeout,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainSwapTxResp {
+    pub user_lock: Option<ChainSwapTxLock>,
+    pub server_lock: Option<ChainSwapTxLock>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReverseSwapTxResp {
@@ -478,15 +850,41 @@ pub struct SubmarineSwapTxResp {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ReversePartialSig {
+pub struct PartialSig {
     pub pub_nonce: String,
     pub partial_signature: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToSign {
+    pub pub_nonce: String,
+    pub transaction: String,
+    pub index: u32,
+}
+
+pub struct Cooperative<'a> {
+    pub boltz_api: &'a BoltzApiClientV2,
+    pub swap_id: String,
+    /// The pub_nonce is needed to post the claim tx details of the Chain swap
+    pub pub_nonce: Option<MusigPubNonce>,
+    /// The partial_sig is needed to post the claim tx details of the Chain swap
+    pub partial_sig: Option<MusigPartialSignature>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwapUpdateTxDetails {
+    pub id: String,
+    pub hex: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Update {
     pub id: String,
     pub status: String,
+    pub transaction: Option<SwapUpdateTxDetails>,
+    pub zero_conf_rejected: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/swaps/boltzv2.rs
+++ b/src/swaps/boltzv2.rs
@@ -724,8 +724,8 @@ impl CreateReverseResponse {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Side {
-    From,
-    To,
+    Lockup,
+    Claim,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -778,8 +778,13 @@ impl CreateChainResponse {
         from_chain: Chain,
         to_chain: Chain,
     ) -> Result<(), Error> {
-        self.validate_side(Side::From, from_chain, &self.lockup_details, refund_pubkey)?;
-        self.validate_side(Side::To, to_chain, &self.claim_details, claim_pubkey)
+        self.validate_side(
+            Side::Lockup,
+            from_chain,
+            &self.lockup_details,
+            refund_pubkey,
+        )?;
+        self.validate_side(Side::Claim, to_chain, &self.claim_details, claim_pubkey)
     }
 
     fn validate_side(

--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -234,6 +234,10 @@ impl LBtcSwapScript {
 
                 Ok(script)
             }
+            SwapType::Chain => Err(Error::Protocol(format!(
+                "Invalid SwapType: {:?}",
+                self.swap_type
+            ))),
         }
     }
 
@@ -258,6 +262,10 @@ impl LBtcSwapScript {
                 Some(self.blinding_key.public_key()),
                 address_params,
             )),
+            SwapType::Chain => Err(Error::Protocol(format!(
+                "Invalid SwapType: {:?}",
+                self.swap_type
+            ))),
         }
     }
 

--- a/src/swaps/liquidv2.rs
+++ b/src/swaps/liquidv2.rs
@@ -262,7 +262,7 @@ impl LBtcSwapScriptV2 {
         let blinding_str = chain_swap_details
             .blinding_key
             .as_ref()
-            .expect("No blinding key provided in CreateSwapResp");
+            .expect("No blinding key provided in ChainSwapDetails");
         let blinding_key = ZKKeyPair::from_seckey_str(&Secp256k1::new(), blinding_str)?;
 
         Ok(Self {

--- a/src/swaps/liquidv2.rs
+++ b/src/swaps/liquidv2.rs
@@ -461,7 +461,7 @@ impl LBtcSwapScriptV2 {
         };
 
         let address = self.to_address(network_config.network())?;
-        let tx: Transaction = elements::encode::deserialize(&hex_to_bytes(&hex)?)?;
+        let tx: Transaction = elements::encode::deserialize(&hex::decode(&hex)?)?;
         let mut vout = 0;
         for output in tx.clone().output {
             if output.script_pubkey == address.script_pubkey() {

--- a/tests/chain_swaps.rs
+++ b/tests/chain_swaps.rs
@@ -54,7 +54,7 @@ fn bitcoin_liquid_v2_chain() {
     let lockup_details: ChainSwapDetails = create_chain_response.clone().lockup_details;
 
     let lockup_script = BtcSwapScriptV2::chain_from_swap_resp(
-        Side::From,
+        Side::Lockup,
         lockup_details.clone(),
         refund_public_key,
     )
@@ -78,9 +78,12 @@ fn bitcoin_liquid_v2_chain() {
 
     let claim_details: ChainSwapDetails = create_chain_response.claim_details;
 
-    let claim_script =
-        LBtcSwapScriptV2::chain_from_swap_resp(Side::To, claim_details.clone(), claim_public_key)
-            .unwrap();
+    let claim_script = LBtcSwapScriptV2::chain_from_swap_resp(
+        Side::Claim,
+        claim_details.clone(),
+        claim_public_key,
+    )
+    .unwrap();
 
     let claim_address = "tlq1qq0y3xudhc909fur3ktaws0yrhjv3ld9c2fk5hqzjfmgqurl0cy4z8yc8d9h54lj7ddwatzegwamyqhp4vttxj26wml4s9vecx".to_string();
     let lq_address = EAddress::from_str(&claim_address).unwrap();
@@ -289,7 +292,7 @@ fn liquid_bitcoin_v2_chain() {
     let lockup_details: ChainSwapDetails = create_chain_response.clone().lockup_details;
 
     let lockup_script = LBtcSwapScriptV2::chain_from_swap_resp(
-        Side::From,
+        Side::Lockup,
         lockup_details.clone(),
         refund_public_key,
     )
@@ -318,7 +321,7 @@ fn liquid_bitcoin_v2_chain() {
     let claim_details: ChainSwapDetails = create_chain_response.claim_details;
 
     let claim_script =
-        BtcSwapScriptV2::chain_from_swap_resp(Side::To, claim_details.clone(), claim_public_key)
+        BtcSwapScriptV2::chain_from_swap_resp(Side::Claim, claim_details.clone(), claim_public_key)
             .unwrap();
 
     let claim_address = "tb1qra2cdypld3hyq3f84630cvj9d0lmzv66vn4k28".to_string();

--- a/tests/chain_swaps.rs
+++ b/tests/chain_swaps.rs
@@ -1,0 +1,485 @@
+use std::time::Duration;
+
+use bitcoin::{key::rand::thread_rng, Amount, PublicKey};
+use boltz_client::boltzv2::{
+    BoltzApiClientV2, ChainSwapDetails, Cooperative, CreateChainRequest, Side, Subscription,
+    SwapUpdate, BOLTZ_TESTNET_URL_V2,
+};
+use boltz_client::{
+    network::{electrum::ElectrumConfig, Chain},
+    util::{liquid_genesis_hash, secrets::Preimage, setup_logger},
+    BtcSwapScriptV2, BtcSwapTxV2, Keypair, LBtcSwapScriptV2, LBtcSwapTxV2, Secp256k1,
+};
+use elements::Address as EAddress;
+use std::str::FromStr;
+
+#[test]
+#[ignore]
+fn bitcoin_liquid_v2_chain() {
+    setup_logger();
+    let network = Chain::BitcoinTestnet;
+    let secp = Secp256k1::new();
+    let preimage = Preimage::new();
+    log::info!("{:#?}", preimage);
+    let our_claim_keys = Keypair::new(&secp, &mut thread_rng());
+    let claim_public_key = PublicKey {
+        compressed: true,
+        inner: our_claim_keys.public_key(),
+    };
+
+    let our_refund_keys = Keypair::new(&secp, &mut thread_rng());
+    log::info!("Refund: {:#?}", our_refund_keys.display_secret());
+
+    let refund_public_key = PublicKey {
+        inner: our_refund_keys.public_key(),
+        compressed: true,
+    };
+
+    let create_chain_req = CreateChainRequest {
+        from: "BTC".to_string(),
+        to: "L-BTC".to_string(),
+        preimage_hash: preimage.sha256,
+        claim_public_key: Some(claim_public_key),
+        refund_public_key: Some(refund_public_key),
+        referral_id: None,
+        user_lock_amount: Some(1000000),
+        server_lock_amount: None,
+        pair_hash: None, // Add address signature here.
+    };
+
+    let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL_V2);
+
+    let create_chain_response = boltz_api_v2.post_chain_req(create_chain_req).unwrap();
+    let swap_id = create_chain_response.clone().id;
+    let lockup_details: ChainSwapDetails = create_chain_response.clone().lockup_details;
+
+    let lockup_script = BtcSwapScriptV2::chain_from_swap_resp(
+        Side::From,
+        lockup_details.clone(),
+        refund_public_key,
+    )
+    .unwrap();
+    log::debug!("Lockup Script: {:#?}", lockup_script);
+    log::debug!(
+        "Lockup Sender Pubkey: {:#?}",
+        lockup_script.sender_pubkey.to_string()
+    );
+    log::debug!(
+        "Lockup Receiver Pubkey: {:#?}",
+        lockup_script.receiver_pubkey.to_string()
+    );
+
+    let lockup_address = lockup_script.clone().to_address(network).unwrap();
+    assert_eq!(
+        lockup_address.clone().to_string(),
+        lockup_details.clone().lockup_address.to_string()
+    );
+    let refund_address = "tb1qra2cdypld3hyq3f84630cvj9d0lmzv66vn4k28".to_string();
+
+    let claim_details: ChainSwapDetails = create_chain_response.claim_details;
+
+    let claim_script =
+        LBtcSwapScriptV2::chain_from_swap_resp(Side::To, claim_details.clone(), claim_public_key)
+            .unwrap();
+
+    let claim_address = "tlq1qq0y3xudhc909fur3ktaws0yrhjv3ld9c2fk5hqzjfmgqurl0cy4z8yc8d9h54lj7ddwatzegwamyqhp4vttxj26wml4s9vecx".to_string();
+    let lq_address = EAddress::from_str(&claim_address).unwrap();
+    log::debug!("{:#?}", lq_address);
+    // let claim_address = claim_script.to_address(network).unwrap();
+    // assert_eq!(claim_address.to_string(), claim_details.claim_address.unwrap());
+    let liquid_genesis_hash = liquid_genesis_hash(&ElectrumConfig::default_liquid()).unwrap();
+    log::debug!("{:#?}", liquid_genesis_hash);
+    let mut socket = boltz_api_v2.connect_ws().unwrap();
+
+    socket
+        .send(tungstenite::Message::Text(
+            serde_json::to_string(&Subscription::new(&create_chain_response.id)).unwrap(),
+        ))
+        .unwrap();
+    loop {
+        let response = serde_json::from_str(&socket.read().unwrap().to_string());
+
+        if response.is_err() {
+            if response.err().expect("Error in websocket respo").is_eof() {
+                continue;
+            }
+        } else {
+            match response.unwrap() {
+                SwapUpdate::Subscription {
+                    event,
+                    channel,
+                    args,
+                } => {
+                    assert!(event == "subscribe");
+                    assert!(channel == "swap.update");
+                    assert!(args.get(0).expect("expected") == &create_chain_response.id);
+                    log::info!(
+                        "Successfully subscribed for Swap updates. Swap ID : {}",
+                        create_chain_response.id
+                    );
+                }
+
+                SwapUpdate::Update {
+                    event,
+                    channel,
+                    args,
+                } => {
+                    assert!(event == "update");
+                    assert!(channel == "swap.update");
+                    let update = args.get(0).expect("expected");
+                    assert!(update.id == swap_id);
+                    log::info!("Got Update from server: {}", update.status);
+
+                    if update.status == "swap.created" {
+                        log::info!(
+                            "Send {} sats to BTC address {}",
+                            create_chain_response.lockup_details.clone().amount,
+                            create_chain_response.lockup_details.clone().lockup_address
+                        );
+                        log::info!(
+                            "TO TRIGGER REFUND: Send 50,000 sats to BTC address {}",
+                            create_chain_response.lockup_details.clone().lockup_address
+                        );
+                    }
+
+                    if update.status == "transaction.server.confirmed" {
+                        log::info!("Server lockup tx is confirmed!");
+
+                        std::thread::sleep(Duration::from_secs(10));
+                        log::info!("Claiming!");
+
+                        let claim_tx = LBtcSwapTxV2::new_claim(
+                            claim_script.clone(),
+                            claim_address.clone(),
+                            &ElectrumConfig::default_liquid(),
+                            BOLTZ_TESTNET_URL_V2.to_string(),
+                            swap_id.clone(),
+                        )
+                        .unwrap();
+                        let refund_tx = BtcSwapTxV2::new_refund(
+                            lockup_script.clone(),
+                            &refund_address,
+                            &ElectrumConfig::default_bitcoin(),
+                        )
+                        .unwrap();
+                        let claim_tx_response =
+                            boltz_api_v2.get_chain_claim_tx_details(&swap_id).unwrap();
+                        let (partial_sig, pub_nonce) = refund_tx
+                            .partial_sig(
+                                &our_refund_keys,
+                                &claim_tx_response.pub_nonce,
+                                &claim_tx_response.transaction_hash,
+                            )
+                            .unwrap();
+                        let tx = claim_tx
+                            .sign_claim(
+                                &our_claim_keys,
+                                &preimage,
+                                Amount::from_sat(1000),
+                                Some(Cooperative {
+                                    boltz_api: &boltz_api_v2,
+                                    swap_id: swap_id.clone(),
+                                    pub_nonce: Some(pub_nonce),
+                                    partial_sig: Some(partial_sig),
+                                }),
+                            )
+                            .unwrap();
+
+                        claim_tx
+                            .broadcast(&tx, &ElectrumConfig::default_liquid(), None)
+                            .unwrap();
+
+                        log::info!("Succesfully broadcasted claim tx!");
+                    }
+
+                    if update.status == "transaction.claimed" {
+                        log::info!("Successfully completed chain swap");
+                        break;
+                    }
+
+                    // This means the funding transaction was rejected by Boltz for whatever reason, and we need to get
+                    // fund back via refund.
+                    if update.status == "transaction.lockupFailed" {
+                        log::info!("REFUNDING!");
+                        let refund_tx = BtcSwapTxV2::new_refund(
+                            lockup_script.clone(),
+                            &refund_address,
+                            &ElectrumConfig::default_bitcoin(),
+                        )
+                        .unwrap();
+                        let tx = refund_tx
+                            .sign_refund(
+                                &our_refund_keys,
+                                1000,
+                                Some(Cooperative {
+                                    boltz_api: &boltz_api_v2,
+                                    swap_id: swap_id.clone(),
+                                    pub_nonce: None,
+                                    partial_sig: None,
+                                }),
+                            )
+                            .unwrap();
+
+                        refund_tx
+                            .broadcast(&tx, &ElectrumConfig::default_bitcoin())
+                            .unwrap();
+
+                        log::info!("Succesfully broadcasted claim tx!");
+                        log::debug!("Claim Tx {:?}", tx);
+                    }
+                }
+
+                SwapUpdate::Error {
+                    event,
+                    channel,
+                    args,
+                } => {
+                    assert!(event == "update");
+                    assert!(channel == "swap.update");
+                    let error = args.get(0).expect("expected");
+                    log::error!(
+                        "Got Boltz response error : {} for swap: {}",
+                        error.error,
+                        error.id
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn liquid_bitcoin_v2_chain() {
+    setup_logger();
+    let network = Chain::LiquidTestnet;
+    let secp = Secp256k1::new();
+    let preimage = Preimage::new();
+    log::info!("{:#?}", preimage);
+    let our_claim_keys = Keypair::new(&secp, &mut thread_rng());
+    let claim_public_key = PublicKey {
+        compressed: true,
+        inner: our_claim_keys.public_key(),
+    };
+
+    let our_refund_keys = Keypair::new(&secp, &mut thread_rng());
+    log::info!("Refund: {:#?}", our_refund_keys.display_secret());
+
+    let refund_public_key = PublicKey {
+        inner: our_refund_keys.public_key(),
+        compressed: true,
+    };
+
+    let create_chain_req = CreateChainRequest {
+        from: "L-BTC".to_string(),
+        to: "BTC".to_string(),
+        preimage_hash: preimage.sha256,
+        claim_public_key: Some(claim_public_key),
+        refund_public_key: Some(refund_public_key),
+        referral_id: None,
+        user_lock_amount: Some(1000000),
+        server_lock_amount: None,
+        pair_hash: None, // Add address signature here.
+    };
+
+    let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL_V2);
+
+    let create_chain_response = boltz_api_v2.post_chain_req(create_chain_req).unwrap();
+    let swap_id = create_chain_response.clone().id;
+    let lockup_details: ChainSwapDetails = create_chain_response.clone().lockup_details;
+
+    let lockup_script = LBtcSwapScriptV2::chain_from_swap_resp(
+        Side::From,
+        lockup_details.clone(),
+        refund_public_key,
+    )
+    .unwrap();
+    log::debug!("Lockup Script: {:#?}", lockup_script);
+    log::debug!(
+        "Lockup Sender Pubkey: {:#?}",
+        lockup_script.sender_pubkey.to_string()
+    );
+    log::debug!(
+        "Lockup Receiver Pubkey: {:#?}",
+        lockup_script.receiver_pubkey.to_string()
+    );
+    log::debug!(
+        "Lockup Blinding Key: {:#?}",
+        lockup_script.blinding_key.display_secret()
+    );
+
+    let lockup_address = lockup_script.clone().to_address(network).unwrap();
+    assert_eq!(
+        lockup_address.clone().to_string(),
+        lockup_details.clone().lockup_address.to_string()
+    );
+    let refund_address = "tlq1qq0y3xudhc909fur3ktaws0yrhjv3ld9c2fk5hqzjfmgqurl0cy4z8yc8d9h54lj7ddwatzegwamyqhp4vttxj26wml4s9vecx".to_string();
+
+    let claim_details: ChainSwapDetails = create_chain_response.claim_details;
+
+    let claim_script =
+        BtcSwapScriptV2::chain_from_swap_resp(Side::To, claim_details.clone(), claim_public_key)
+            .unwrap();
+
+    let claim_address = "tb1qra2cdypld3hyq3f84630cvj9d0lmzv66vn4k28".to_string();
+
+    let mut socket = boltz_api_v2.connect_ws().unwrap();
+
+    socket
+        .send(tungstenite::Message::Text(
+            serde_json::to_string(&Subscription::new(&create_chain_response.id)).unwrap(),
+        ))
+        .unwrap();
+    loop {
+        let response = serde_json::from_str(&socket.read().unwrap().to_string());
+
+        if response.is_err() {
+            if response.err().expect("Error in websocket respo").is_eof() {
+                continue;
+            }
+        } else {
+            match response.unwrap() {
+                SwapUpdate::Subscription {
+                    event,
+                    channel,
+                    args,
+                } => {
+                    assert!(event == "subscribe");
+                    assert!(channel == "swap.update");
+                    assert!(args.get(0).expect("expected") == &create_chain_response.id);
+                    log::info!(
+                        "Successfully subscribed for Swap updates. Swap ID : {}",
+                        create_chain_response.id
+                    );
+                }
+
+                SwapUpdate::Update {
+                    event,
+                    channel,
+                    args,
+                } => {
+                    assert!(event == "update");
+                    assert!(channel == "swap.update");
+                    let update = args.get(0).expect("expected");
+                    assert!(update.id == swap_id);
+                    log::info!("Got Update from server: {}", update.status);
+
+                    if update.status == "swap.created" {
+                        log::info!(
+                            "Send {} sats to L-BTC address {}",
+                            create_chain_response.lockup_details.clone().amount,
+                            create_chain_response.lockup_details.clone().lockup_address
+                        );
+                        log::info!(
+                            "TO TRIGGER REFUND: Send 10,000 sats to L-BTC address {}",
+                            create_chain_response.lockup_details.clone().lockup_address
+                        );
+                    }
+
+                    if update.status == "transaction.server.confirmed" {
+                        log::info!("Server lockup tx is confirmed!");
+
+                        std::thread::sleep(Duration::from_secs(10));
+                        log::info!("Claiming!");
+
+                        let claim_tx = BtcSwapTxV2::new_claim(
+                            claim_script.clone(),
+                            claim_address.clone(),
+                            &ElectrumConfig::default_bitcoin(),
+                        )
+                        .unwrap();
+                        let refund_tx = LBtcSwapTxV2::new_refund(
+                            lockup_script.clone(),
+                            &refund_address,
+                            &ElectrumConfig::default_liquid(),
+                            BOLTZ_TESTNET_URL_V2.to_string(),
+                            swap_id.clone(),
+                        )
+                        .unwrap();
+                        let claim_tx_response =
+                            boltz_api_v2.get_chain_claim_tx_details(&swap_id).unwrap();
+                        let (partial_sig, pub_nonce) = refund_tx
+                            .partial_sig(
+                                &our_refund_keys,
+                                &claim_tx_response.pub_nonce,
+                                &claim_tx_response.transaction_hash,
+                            )
+                            .unwrap();
+                        let tx = claim_tx
+                            .sign_claim(
+                                &our_claim_keys,
+                                &preimage,
+                                1000,
+                                Some(Cooperative {
+                                    boltz_api: &boltz_api_v2,
+                                    swap_id: swap_id.clone(),
+                                    pub_nonce: Some(pub_nonce),
+                                    partial_sig: Some(partial_sig),
+                                }),
+                            )
+                            .unwrap();
+
+                        claim_tx
+                            .broadcast(&tx, &ElectrumConfig::default_bitcoin())
+                            .unwrap();
+
+                        log::info!("Succesfully broadcasted claim tx!");
+                    }
+
+                    if update.status == "transaction.claimed" {
+                        log::info!("Successfully completed chain swap");
+                        break;
+                    }
+
+                    // This means the funding transaction was rejected by Boltz for whatever reason, and we need to get
+                    // fund back via refund.
+                    if update.status == "transaction.lockupFailed" {
+                        log::info!("REFUNDING!");
+                        let refund_tx = LBtcSwapTxV2::new_refund(
+                            lockup_script.clone(),
+                            &refund_address,
+                            &ElectrumConfig::default_liquid(),
+                            BOLTZ_TESTNET_URL_V2.to_string(),
+                            swap_id.clone(),
+                        )
+                        .unwrap();
+                        let tx = refund_tx
+                            .sign_refund(
+                                &our_refund_keys,
+                                Amount::from_sat(1000),
+                                Some(Cooperative {
+                                    boltz_api: &boltz_api_v2,
+                                    swap_id: swap_id.clone(),
+                                    pub_nonce: None,
+                                    partial_sig: None,
+                                }),
+                            )
+                            .unwrap();
+
+                        refund_tx
+                            .broadcast(&tx, &ElectrumConfig::default_liquid(), None)
+                            .unwrap();
+
+                        log::info!("Succesfully broadcasted claim tx!");
+                        log::debug!("Claim Tx {:?}", tx);
+                    }
+                }
+
+                SwapUpdate::Error {
+                    event,
+                    channel,
+                    args,
+                } => {
+                    assert!(event == "update");
+                    assert!(channel == "swap.update");
+                    let error = args.get(0).expect("expected");
+                    log::error!(
+                        "Got Boltz response error : {} for swap: {}",
+                        error.error,
+                        error.id
+                    );
+                }
+            }
+        }
+    }
+}

--- a/tests/liquid_v2.rs
+++ b/tests/liquid_v2.rs
@@ -4,8 +4,8 @@ use boltz_client::{
     network::{electrum::ElectrumConfig, Chain},
     swaps::{
         boltzv2::{
-            BoltzApiClientV2, CreateReverseRequest, CreateSubmarineRequest, Subscription,
-            SwapUpdate, BOLTZ_MAINNET_URL_V2, BOLTZ_TESTNET_URL_V2,
+            BoltzApiClientV2, Cooperative, CreateReverseRequest, CreateSubmarineRequest,
+            Subscription, SwapUpdate, BOLTZ_MAINNET_URL_V2, BOLTZ_TESTNET_URL_V2,
         },
         magic_routing::{check_for_mrh, sign_address},
     },
@@ -59,6 +59,7 @@ fn liquid_v2_submarine() {
         to: "BTC".to_string(),
         invoice: invoice.to_string(),
         refund_public_key,
+        pair_hash: None,
         referral_id: None,
     };
 
@@ -146,7 +147,7 @@ fn liquid_v2_submarine() {
                         // why? ^^^s
 
                         let claim_tx_response = boltz_api_v2
-                            .get_claim_tx_details(&create_swap_response.clone().id)
+                            .get_submarine_claim_tx_details(&create_swap_response.clone().id)
                             .unwrap();
 
                         log::debug!("Received claim tx details : {:?}", claim_tx_response);
@@ -162,10 +163,14 @@ fn liquid_v2_submarine() {
 
                         // Compute and send Musig2 partial sig
                         let (partial_sig, pub_nonce) = swap_tx
-                            .submarine_partial_sig(&our_keys, &claim_tx_response)
+                            .partial_sig(
+                                &our_keys,
+                                &claim_tx_response.pub_nonce,
+                                &claim_tx_response.transaction_hash,
+                            )
                             .unwrap();
                         boltz_api_v2
-                            .post_claim_tx_details(
+                            .post_submarine_claim_tx_details(
                                 &create_swap_response.clone().id,
                                 pub_nonce,
                                 partial_sig,
@@ -191,7 +196,12 @@ fn liquid_v2_submarine() {
                         match swap_tx.sign_refund(
                             &our_keys,
                             Amount::from_sat(1000),
-                            Some((&boltz_api_v2, &create_swap_response.id)),
+                            Some(Cooperative {
+                                boltz_api: &boltz_api_v2,
+                                swap_id: create_swap_response.id.clone(),
+                                pub_nonce: None,
+                                partial_sig: None,
+                            }),
                         ) {
                             Ok(tx) => {
                                 println!("{}", tx.serialize().to_lower_hex_string());
@@ -361,7 +371,12 @@ fn liquid_v2_reverse() {
                                 &our_keys,
                                 &preimage,
                                 Amount::from_sat(1000),
-                                Some((&boltz_api_v2, swap_id.clone())),
+                                Some(Cooperative {
+                                    boltz_api: &boltz_api_v2,
+                                    swap_id: swap_id.clone(),
+                                    pub_nonce: None,
+                                    partial_sig: None,
+                                }),
                             )
                             .unwrap();
 
@@ -453,7 +468,12 @@ fn test_recover_liquidv2_refund() {
     )
     .unwrap();
     let client = BoltzApiClientV2::new(BOLTZ_MAINNET_URL_V2);
-    let coop = Some((&client, &id));
+    let coop = Some(Cooperative {
+        boltz_api: &client,
+        swap_id: id,
+        pub_nonce: None,
+        partial_sig: None,
+    });
     let signed_tx = rev_swap_tx
         .sign_refund(&keypair, Amount::from_sat(absolute_fees), coop)
         .unwrap();

--- a/tests/liquid_v2.rs
+++ b/tests/liquid_v2.rs
@@ -503,6 +503,7 @@ fn create_swap_script_v2(
 
     LBtcSwapScriptV2 {
         swap_type: SwapType::Submarine,
+        side: None,
         funding_addrs: Some(address),
         hashlock: hashlock,
         receiver_pubkey: receiver_pubkey,

--- a/tests/regtest_v2.rs
+++ b/tests/regtest_v2.rs
@@ -28,6 +28,7 @@ fn btc_reverse_claim() {
     // create a btc swap script.
     let swap_script = BtcSwapScriptV2 {
         swap_type: SwapType::ReverseSubmarine,
+        side: None,
         funding_addrs: None,
         hashlock: preimage.hash160,
         receiver_pubkey: PublicKey {
@@ -123,6 +124,7 @@ fn btc_submarine_refund() {
     // create a btc swap script.
     let swap_script = BtcSwapScriptV2 {
         swap_type: SwapType::Submarine,
+        side: None,
         funding_addrs: None,
         hashlock: preimage.hash160,
         receiver_pubkey: PublicKey {
@@ -219,6 +221,7 @@ fn lbtc_reverse_claim() {
     // create a btc swap script.
     let swap_script = LBtcSwapScriptV2 {
         swap_type: SwapType::ReverseSubmarine,
+        side: None,
         funding_addrs: None,
         hashlock: preimage.hash160,
         receiver_pubkey: PublicKey {
@@ -280,6 +283,7 @@ fn lbtc_submarine_refund() {
     // create a btc swap script.
     let swap_script = LBtcSwapScriptV2 {
         swap_type: SwapType::Submarine,
+        side: None,
         funding_addrs: None,
         hashlock: preimage.hash160,
         receiver_pubkey: PublicKey {


### PR DESCRIPTION
This PR adds Chain Swaps. It should include:
- Full Chain swap Boltz API.
- Claiming cooperatively / non-cooperatively, including posting the claim tx details to exchange partial signatures.
- Refunding cooperatively / non-cooperatively.

Tested:
- [x] LBTC-BTC claim cooperative flow
- [x] LBTC-BTC refund cooperative/non-cooperative flow
- [x] BTC-LBTC claim cooperative flow
- [x] BTC-LBTC refund cooperative/non-cooperative flow