### PR TITLE
Rename LBtcSwapTxV2 partial_sign same as BtcSwapTxV2

### DIFF
--- a/src/swaps/liquidv2.rs
+++ b/src/swaps/liquidv2.rs
@@ -575,7 +575,7 @@ impl LBtcSwapTxV2 {
 
     /// Compute the Musig partial signature.
     /// This is used to cooperatively close a Submarine or Chain Swap.
-    pub fn partial_sig(
+    pub fn partial_sign(
         &self,
         keys: &Keypair,
         pub_nonce: &String,

--- a/tests/chain_swaps.rs
+++ b/tests/chain_swaps.rs
@@ -402,7 +402,7 @@ fn liquid_bitcoin_v2_chain() {
                         let claim_tx_response =
                             boltz_api_v2.get_chain_claim_tx_details(&swap_id).unwrap();
                         let (partial_sig, pub_nonce) = refund_tx
-                            .partial_sig(
+                            .partial_sign(
                                 &our_refund_keys,
                                 &claim_tx_response.pub_nonce,
                                 &claim_tx_response.transaction_hash,

--- a/tests/liquid_v2.rs
+++ b/tests/liquid_v2.rs
@@ -163,7 +163,7 @@ fn liquid_v2_submarine() {
 
                         // Compute and send Musig2 partial sig
                         let (partial_sig, pub_nonce) = swap_tx
-                            .partial_sig(
+                            .partial_sign(
                                 &our_keys,
                                 &claim_tx_response.pub_nonce,
                                 &claim_tx_response.transaction_hash,


### PR DESCRIPTION
Just a quick follow up PR to make the `LBtcSwapTxV2.partial_sig()` name consistent with `BtcSwapTxV2.partial_sign()`