### PR TITLE
bug: add missing attributes to `CreateSubmarineResponse`

### DIFF
--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -608,7 +608,9 @@ pub struct CreateSubmarineResponse {
     pub claim_public_key: PublicKey,
     pub expected_amount: u64,
     pub id: String,
+    pub referral_id: Option<String>,
     pub swap_tree: SwapTree,
+    pub timeout_block_height: u64,
     pub blinding_key: Option<String>,
 }
 impl CreateSubmarineResponse {


### PR DESCRIPTION
as seen in the swagger docs
https://api.boltz.exchange/swagger#/Submarine/post_swap_submarine there should be a `timeoutBlockHeight` and `referralId` attribute