### PR TITLE
Add support for custom invoice descriptions

### DIFF
--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -686,6 +686,8 @@ pub struct CreateReverseRequest {
     pub preimage_hash: sha256::Hash,
     pub claim_public_key: PublicKey,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub address_signature: Option<String>,

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -262,6 +262,7 @@ fn bitcoin_v2_reverse() {
         from: "BTC".to_string(),
         to: "BTC".to_string(),
         preimage_hash: preimage.sha256,
+        description: None,
         address_signature: Some(addrs_sig.to_string()),
         address: Some(claim_address.clone()),
         claim_public_key,

--- a/tests/liquid.rs
+++ b/tests/liquid.rs
@@ -279,6 +279,7 @@ fn liquid_v2_reverse() {
         from: "BTC".to_string(),
         to: "L-BTC".to_string(),
         preimage_hash: preimage.sha256,
+        description: None,
         address_signature: Some(addrs_sig.to_string()),
         address: Some(claim_address.clone()),
         claim_public_key,


### PR DESCRIPTION
We recently added support for custom invoice descriptions of Reverse Swaps: https://github.com/BoltzExchange/boltz-backend/commit/d218794c6b93fefcb69da559acf2f5cacbbe1c16

Not deployed on mainnet yet, but once it is, the Rust library should support it.

Works nicely on testnet already:

![image](https://github.com/SatoshiPortal/boltz-rust/assets/8138838/3e8c50e5-9e9b-4e8e-9245-1e1a5ff3c3bf)
