### PR TITLE
Webhooks

### DIFF
--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -589,6 +589,13 @@ pub struct MrhResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct Webhook {
+    pub url: String,
+    pub hash_swap_id: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateSubmarineRequest {
     pub from: String,
     pub to: String,
@@ -598,6 +605,8 @@ pub struct CreateSubmarineRequest {
     pub pair_hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub referral_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub webhook: Option<Webhook>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -693,6 +702,8 @@ pub struct CreateReverseRequest {
     pub address_signature: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub referral_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub webhook: Option<Webhook>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -780,6 +791,8 @@ pub struct CreateChainRequest {
     pub pair_hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub referral_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub webhook: Option<Webhook>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -591,7 +591,8 @@ pub struct MrhResponse {
 #[serde(rename_all = "camelCase")]
 pub struct Webhook {
     pub url: String,
-    pub hash_swap_id: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash_swap_id: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -57,6 +57,7 @@ fn bitcoin_v2_submarine() {
         refund_public_key,
         pair_hash: None,
         referral_id: None,
+        webhook: None,
     };
 
     let create_swap_response = boltz_api_v2.post_swap_req(&create_swap_req).unwrap();
@@ -267,6 +268,7 @@ fn bitcoin_v2_reverse() {
         address: Some(claim_address.clone()),
         claim_public_key,
         referral_id: None, // Add address signature here.
+        webhook: None,
     };
 
     let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL_V2);

--- a/tests/chain_swaps.rs
+++ b/tests/chain_swaps.rs
@@ -45,6 +45,7 @@ fn bitcoin_liquid_v2_chain() {
         user_lock_amount: Some(1000000),
         server_lock_amount: None,
         pair_hash: None, // Add address signature here.
+        webhook: None,
     };
 
     let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL_V2);
@@ -280,6 +281,7 @@ fn liquid_bitcoin_v2_chain() {
         user_lock_amount: Some(1000000),
         server_lock_amount: None,
         pair_hash: None, // Add address signature here.
+        webhook: None,
     };
 
     let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_TESTNET_URL_V2);

--- a/tests/liquid.rs
+++ b/tests/liquid.rs
@@ -61,6 +61,7 @@ fn liquid_v2_submarine() {
         refund_public_key,
         pair_hash: None,
         referral_id: None,
+        webhook: None,
     };
 
     let create_swap_response = boltz_api_v2.post_swap_req(&create_swap_req).unwrap();
@@ -284,6 +285,7 @@ fn liquid_v2_reverse() {
         address: Some(claim_address.clone()),
         claim_public_key,
         referral_id: None,
+        webhook: None,
     };
 
     let reverse_resp = boltz_api_v2.post_reverse_req(create_reverse_req).unwrap();


### PR DESCRIPTION
This PR adds the optional `webhook` param to the `CreateSubmarineRequest`, `CreateReverseRequest` and `CreateChainRequest `. See https://docs.boltz.exchange/v/api/webhooks