### PR TITLE
Add webhook status include list

### DIFF
--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -589,12 +589,12 @@ pub struct MrhResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SubmarineWebhook {
+pub struct Webhook<T> {
     pub url: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hash_swap_id: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<Vec<SubSwapStates>>,
+    pub status: Option<Vec<T>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -609,7 +609,7 @@ pub struct CreateSubmarineRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub referral_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub webhook: Option<SubmarineWebhook>,
+    pub webhook: Option<Webhook<SubSwapStates>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -691,16 +691,6 @@ impl Subscription {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ReverseWebhook {
-    pub url: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hash_swap_id: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<Vec<RevSwapStates>>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct CreateReverseRequest {
     pub invoice_amount: u32,
     pub from: String,
@@ -716,7 +706,7 @@ pub struct CreateReverseRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub referral_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub webhook: Option<ReverseWebhook>,
+    pub webhook: Option<Webhook<RevSwapStates>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -788,16 +778,6 @@ pub struct ChainSwapDetails {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ChainWebhook {
-    pub url: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hash_swap_id: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<Vec<ChainSwapStates>>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct CreateChainRequest {
     pub from: String,
     pub to: String,
@@ -815,7 +795,7 @@ pub struct CreateChainRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub referral_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub webhook: Option<ChainWebhook>,
+    pub webhook: Option<Webhook<ChainSwapStates>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -589,10 +589,12 @@ pub struct MrhResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Webhook {
+pub struct SubmarineWebhook {
     pub url: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hash_swap_id: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<Vec<SubSwapStates>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -607,7 +609,7 @@ pub struct CreateSubmarineRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub referral_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub webhook: Option<Webhook>,
+    pub webhook: Option<SubmarineWebhook>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -689,6 +691,16 @@ impl Subscription {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ReverseWebhook {
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash_swap_id: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<Vec<RevSwapStates>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateReverseRequest {
     pub invoice_amount: u32,
     pub from: String,
@@ -704,7 +716,7 @@ pub struct CreateReverseRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub referral_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub webhook: Option<Webhook>,
+    pub webhook: Option<ReverseWebhook>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -776,6 +788,16 @@ pub struct ChainSwapDetails {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ChainWebhook {
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash_swap_id: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<Vec<ChainSwapStates>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateChainRequest {
     pub from: String,
     pub to: String,
@@ -793,7 +815,7 @@ pub struct CreateChainRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub referral_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub webhook: Option<Webhook>,
+    pub webhook: Option<ChainWebhook>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -963,39 +985,49 @@ pub enum SwapTxKind {
 /// States for a submarine swap.
 ///
 /// See <https://docs.boltz.exchange/v/api/lifecycle#normal-submarine-swaps>
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SubSwapStates {
     /// Initial state of the swap; optionally the initial state can also be `invoice.set` in case
     /// the invoice was already specified in the request that created the swap.
+    #[serde(rename = "swap.created")]
     Created,
     /// The lockup transaction was found in the mempool, meaning the user sent funds to the
     /// lockup address.
+    #[serde(rename = "transaction.mempool")]
     TransactionMempool,
     /// The lockup transaction was included in a block.
+    #[serde(rename = "transaction.confirmed")]
     TransactionConfirmed,
     /// The swap has an invoice that should be paid.
     /// Can be the initial state when the invoice was specified in the request that created the swap
+    #[serde(rename = "invoice.set")]
     InvoiceSet,
     /// Boltz successfully paid the invoice.
+    #[serde(rename = "invoice.paid")]
     InvoicePaid,
     /// Boltz started paying the invoice.
+    #[serde(rename = "invoice.pending")]
     InvoicePending,
     /// Boltz failed to pay the invoice. In this case the user needs to broadcast a refund
     /// transaction to reclaim the locked up onchain coins.
+    #[serde(rename = "invoice.failedToPay")]
     InvoiceFailedToPay,
     /// Indicates that after the invoice was successfully paid, the onchain were successfully
     /// claimed by Boltz. This is the final status of a successful Normal Submarine Swap.
+    #[serde(rename = "transaction.claimed")]
     TransactionClaimed,
     /// Indicates that Boltz is ready for the creation of a cooperative signature for a key path
     /// spend. Taproot Swaps are not claimed immediately by Boltz after the invoice has been paid,
     /// but instead Boltz waits for the API client to post a signature for a key path spend. If the
     /// API client does not cooperate in a key path spend, Boltz will eventually claim via the script path.
+    #[serde(rename = "transaction.claim.pending")]
     TransactionClaimPending,
     /// Indicates the lockup failed, which is usually because the user sent too little.
+    #[serde(rename = "transaction.lockupFailed")]
     TransactionLockupFailed,
     /// Indicates the user didn't send onchain (lockup) and the swap expired (approximately 24h).
     /// This means that it was cancelled and chain L-BTC shouldn't be sent anymore.
+    #[serde(rename = "swap.expired")]
     SwapExpired,
 }
 
@@ -1041,39 +1073,47 @@ impl FromStr for SubSwapStates {
 /// States for a reverse swap.
 ///
 /// See <https://docs.boltz.exchange/v/api/lifecycle#reverse-submarine-swaps>
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RevSwapStates {
     /// Initial state of a newly created Reverse Submarine Swap.
+    #[serde(rename = "swap.created")]
     Created,
     /// Optional and currently not enabled on Boltz. If Boltz requires prepaying miner fees via a
     /// separate Lightning invoice, this state is set when the miner fee invoice was successfully paid.
+    #[serde(rename = "minerfee.paid")]
     MinerFeePaid,
     /// Boltz's lockup transaction is found in the mempool which will only happen after the user
     /// paid the Lightning hold invoice.
+    #[serde(rename = "transaction.mempool")]
     TransactionMempool,
     /// The lockup transaction was included in a block. This state is skipped, if the client
     /// optionally accepts the transaction without confirmation. Boltz broadcasts chain transactions
     /// non-RBF only.
+    #[serde(rename = "transaction.confirmed")]
     TransactionConfirmed,
     /// The transaction claiming onchain was broadcast by the user's client and Boltz used the
     /// preimage of this transaction to settle the Lightning invoice. This is the final status of a
     /// successful Reverse Submarine Swap.
+    #[serde(rename = "invoice.settled")]
     InvoiceSettled,
     /// Set when the invoice of Boltz expired and pending HTLCs are cancelled. Boltz invoices
     /// currently expire after 50% of the swap timeout window.
+    #[serde(rename = "invoice.expired")]
     InvoiceExpired,
     /// This is the final status of a swap, if the swap expires without the lightning invoice being paid.
+    #[serde(rename = "swap.expired")]
     SwapExpired,
     /// Set in the unlikely event that Boltz is unable to send the agreed amount of onchain coins
     /// after the user set up the payment to the provided Lightning invoice. If this happens, the
     /// pending Lightning HTLC will also be cancelled. The Lightning bitcoin automatically bounce
     /// back to the user, no further action or refund is required and the user didn't pay any fees.
+    #[serde(rename = "transaction.failed")]
     TransactionFailed,
     /// This is the final status of a swap, if the user successfully set up the Lightning payment
     /// and Boltz successfully locked up coins onchain, but the Boltz API Client did not claim
     /// the locked oncahin coins before swap expiry. In this case, Boltz will also automatically refund
     /// its own locked onchain coins and the Lightning payment is cancelled.
+    #[serde(rename = "transaction.refunded")]
     TransactionRefunded,
 }
 
@@ -1112,19 +1152,45 @@ impl FromStr for RevSwapStates {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ChainSwapStates {
+    /// The initial state of the chain swap.
+    #[serde(rename = "swap.created")]
     Created,
+    /// The server has rejected a 0-conf transaction for this swap.
+    #[serde(rename = "transaction.zeroconf.rejected")]
     TransactionZeroConfRejected,
+    /// The lockup transaction of the client was found in the mempool.
+    #[serde(rename = "transaction.mempool")]
     TransactionMempool,
+    /// The lockup transaction of the client was confirmed in a block. When the server accepts 0-conf,
+    /// for the lockup transaction, this state is skipped.
+    #[serde(rename = "transaction.confirmed")]
     TransactionConfirmed,
+    /// The lockup transaction of the server has been broadcast.
+    #[serde(rename = "transaction.server.mempool")]
     TransactionServerMempool,
+    /// The lockup transaction of the server has been included in a block.
+    #[serde(rename = "transaction.server.confirmed")]
     TransactionServerConfirmed,
+    /// The server claimed the coins that the client locked.
+    #[serde(rename = "transaction.claimed")]
     TransactionClaimed,
+    /// Indicates the lockup failed, which is usually because the user sent too little.
+    #[serde(rename = "transaction.lockupFailed")]
     TransactionLockupFailed,
+    /// This is the final status of a swap, if the swap expires without a chain bitcoin transaction.
+    #[serde(rename = "swap.expired")]
     SwapExpired,
+    /// Set in the unlikely event that Boltz is unable to lock the agreed amount of chain bitcoin.
+    /// The user needs to submit a refund transaction to reclaim the chain bitcoin if bitcoin were
+    /// already sent.
+    #[serde(rename = "transaction.failed")]
     TransactionFailed,
+    /// If the user and Boltz both successfully locked up bitcoin on the chain, but the user did not
+    /// claim the locked chain bitcoin until swap expiry, Boltz will automatically refund its own locked
+    /// chain bitcoin.
+    #[serde(rename = "transaction.refunded")]
     TransactionRefunded,
 }
 


### PR DESCRIPTION
This PR implements changes to the swap requests to add the optional webhook status include list. 

See https://github.com/BoltzExchange/boltz-backend/pull/632