### PR TITLE
Remove lowball tx broadcast check of network type

### DIFF
--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -1200,25 +1200,26 @@ impl LBtcSwapTx {
         is_lowball: Option<(&BoltzApiClientV2, Chain)>,
     ) -> Result<String, Error> {
         if let Some((boltz_api, chain)) = is_lowball {
-            if chain == Chain::Liquid {
-                return Err(Error::Protocol(
-                    "Lowball broadcast is not active for main chain".to_string(),
-                ));
-            }
-            log::info!("Attempting lowball braodcast");
+            log::info!("Attempting lowball broadcast");
             let tx_hex = serialize(signed_tx).to_lower_hex_string();
             let response = boltz_api.broadcast_tx(chain, &tx_hex)?;
-            let txid = response
-                .as_object()
-                .unwrap()
-                .get("id")
-                .unwrap()
-                .as_str()
-                .unwrap()
-                .to_string();
-            log::info!("Broadcasted transaction via Boltz: {}", txid);
 
-            return Ok(txid);
+            match response.as_object() {
+                None => Err(Error::Protocol("Invalid broadcast reply".to_string())),
+                Some(response_map) => match response_map.get("id") {
+                    None => Err(Error::Protocol(
+                        "No txid found in broadcast reply".to_string(),
+                    )),
+                    Some(txid_val) => match txid_val.as_str() {
+                        None => Err(Error::Protocol("Returned txid is not a string".to_string())),
+                        Some(txid_str) => {
+                            let txid = txid_str.to_string();
+                            log::info!("Broadcasted transaction via Boltz: {txid}");
+                            Ok(txid)
+                        }
+                    },
+                },
+            }
         } else {
             let electrum_client = network_config.build_client()?;
             let serialized = serialize(signed_tx);


### PR DESCRIPTION
This PR removes the lowball broadcast limitation and replaces the txid response unwrapping with a non-panicking version