### PR TITLE
Boltz: Add derive traits for `Cooperative` and `BoltzApiClient` structs

### DIFF
--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -311,6 +311,7 @@ impl GetChainPairsResponse {
 }
 
 /// Reference Documnetation: https://api.boltz.exchange/swagger
+#[derive(Debug, Clone)]
 pub struct BoltzApiClientV2 {
     base_url: String,
 }
@@ -923,6 +924,7 @@ pub struct ToSign {
     pub index: u32,
 }
 
+#[derive(Debug, Clone)]
 pub struct Cooperative<'a> {
     pub boltz_api: &'a BoltzApiClientV2,
     pub swap_id: String,


### PR DESCRIPTION
An small issue arose while developing our refund flow in breez/breez-liquid-sdk#407. The `Cooperative` struct is not cloneable and is required to be passed by value to the `sign_refund` method, while also being necessary in other parts of the code. Would it be possible to derive this trait (and while we're at it, `Debug` as well)?