### PR TITLE
`BtcSwapTx`: update refund tx to consider all utxos

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ pub mod swaps;
 /// utilities (key, preimage, error)
 pub mod util;
 
-
 // Re-export common libs, so callers can make use of them and avoid version conflicts
 pub use bitcoin;
 pub use electrum_client;

--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -1081,9 +1081,12 @@ impl BtcSwapTx {
                     "Control block calculation failed".to_string(),
                 ))?;
 
+            // Input sequence has to be set for all inputs before signing
             for input_index in 0..refund_tx.input.len() {
                 refund_tx.input[input_index].sequence = Sequence::ZERO;
+            }
 
+            for input_index in 0..refund_tx.input.len() {
                 let sighash = SighashCache::new(refund_tx.clone())
                     .taproot_script_spend_signature_hash(
                         input_index,

--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -995,12 +995,18 @@ impl BtcSwapTx {
                 // Step 7: Get boltz's partial sig
                 let refund_tx_hex = serialize(&refund_tx).to_lower_hex_string();
                 let partial_sig_resp = match self.swap_script.swap_type {
-                    SwapType::Chain => {
-                        boltz_api.get_chain_partial_sig(&swap_id, &pub_nonce, &refund_tx_hex)
-                    }
-                    SwapType::Submarine => {
-                        boltz_api.get_submarine_partial_sig(&swap_id, &pub_nonce, &refund_tx_hex)
-                    }
+                    SwapType::Chain => boltz_api.get_chain_partial_sig(
+                        &swap_id,
+                        input_index,
+                        &pub_nonce,
+                        &refund_tx_hex,
+                    ),
+                    SwapType::Submarine => boltz_api.get_submarine_partial_sig(
+                        &swap_id,
+                        input_index,
+                        &pub_nonce,
+                        &refund_tx_hex,
+                    ),
                     _ => Err(Error::Protocol(format!(
                         "Cannot get partial sig for {:?} Swap",
                         self.swap_script.swap_type

--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -422,16 +422,6 @@ impl BtcSwapScript {
         Ok(utxo_pairs)
     }
 
-    /// Fetch the first (utxo,amount) pair for the script_pubkey of this swap, which is typically
-    /// the lockup utxo. Returns None if no utxo for the script_pubkey is found.
-    pub fn fetch_utxo(
-        &self,
-        network_config: &ElectrumConfig,
-    ) -> Result<Option<(OutPoint, TxOut)>, Error> {
-        let utxo_pairs = self.fetch_utxos(network_config)?;
-        Ok(utxo_pairs.first().cloned())
-    }
-
     /// Fetch utxo for script from BoltzApi
     pub fn fetch_lockup_utxo_boltz(
         &self,
@@ -531,8 +521,8 @@ impl BtcSwapTx {
 
         address.is_valid_for_network(network);
 
-        let utxo_info = match swap_script.fetch_utxo(&network_config) {
-            Ok(r) => r,
+        let utxo_info = match swap_script.fetch_utxos(&network_config) {
+            Ok(v) => v.first().cloned(),
             Err(_) => swap_script.fetch_lockup_utxo_boltz(
                 &network_config,
                 &boltz_url,

--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -570,9 +570,9 @@ impl BtcSwapTx {
             return Err(Error::Address("Address validation failed".to_string()));
         };
 
-        let utxos_temp = swap_script.fetch_utxos(&network_config)?;
-        let utxos_final = match utxos_temp.is_empty() {
-            true => {
+        let utxos = match swap_script.fetch_utxos(&network_config) {
+            Ok(r) => r,
+            Err(_) => {
                 let lockup_utxo_info = swap_script.fetch_lockup_utxo_boltz(
                     &network_config,
                     &boltz_url,
@@ -585,10 +585,9 @@ impl BtcSwapTx {
                     None => vec![],
                 }
             }
-            false => utxos_temp,
         };
 
-        match utxos_final.is_empty() {
+        match utxos.is_empty() {
             true => Err(Error::Protocol(
                 "No Bitcoin UTXO detected for this script".to_string(),
             )),
@@ -596,7 +595,7 @@ impl BtcSwapTx {
                 kind: SwapTxKind::Refund,
                 swap_script,
                 output_address: address.assume_checked(),
-                utxos: utxos_final,
+                utxos,
             }),
         }
     }

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -509,6 +509,7 @@ impl BoltzApiClientV2 {
     pub fn get_submarine_partial_sig(
         &self,
         id: &String,
+        input_index: usize,
         pub_nonce: &MusigPubNonce,
         refund_tx_hex: &String,
     ) -> Result<PartialSig, Error> {
@@ -516,7 +517,7 @@ impl BoltzApiClientV2 {
             {
                 "pubNonce": pub_nonce.serialize().to_lower_hex_string(),
                 "transaction": refund_tx_hex,
-                "index": 0
+                "index": input_index
             }
         );
 
@@ -527,6 +528,7 @@ impl BoltzApiClientV2 {
     pub fn get_chain_partial_sig(
         &self,
         id: &String,
+        input_index: usize,
         pub_nonce: &MusigPubNonce,
         refund_tx_hex: &String,
     ) -> Result<PartialSig, Error> {
@@ -534,7 +536,7 @@ impl BoltzApiClientV2 {
             {
                 "pubNonce": pub_nonce.serialize().to_lower_hex_string(),
                 "transaction": refund_tx_hex,
-                "index": 0
+                "index": input_index
             }
         );
 

--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -1097,10 +1097,10 @@ impl LBtcSwapTx {
             let refund_tx_hex = serialize(&refund_tx).to_lower_hex_string();
             let partial_sig_resp = match self.swap_script.swap_type {
                 SwapType::Chain => {
-                    boltz_api.get_chain_partial_sig(&swap_id, &pub_nonce, &refund_tx_hex)
+                    boltz_api.get_chain_partial_sig(&swap_id, 0, &pub_nonce, &refund_tx_hex)
                 }
                 SwapType::Submarine => {
-                    boltz_api.get_submarine_partial_sig(&swap_id, &pub_nonce, &refund_tx_hex)
+                    boltz_api.get_submarine_partial_sig(&swap_id, 0, &pub_nonce, &refund_tx_hex)
                 }
                 _ => Err(Error::Protocol(format!(
                     "Cannot get partial sig for {:?} Swap",

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,9 +8,9 @@ use lightning_invoice::{Bolt11Invoice, RouteHintHop};
 use crate::{error::Error, network::electrum::ElectrumConfig};
 
 pub mod ec;
-pub mod secrets;
 #[cfg(feature = "lnurl")]
 pub mod lnurl;
+pub mod secrets;
 /// Setup function that will only run once, even if called multiple times.
 
 pub fn liquid_genesis_hash(electrum_config: &ElectrumConfig) -> Result<elements::BlockHash, Error> {

--- a/tests/regtest.rs
+++ b/tests/regtest.rs
@@ -60,7 +60,7 @@ fn btc_reverse_claim() {
     assert_eq!(scan_result.total_amount, Amount::from_sat(10000));
 
     // Create a refund spending transaction from the swap
-    let utxo = scan_result
+    let utxos: Vec<(OutPoint, TxOut)> = scan_result
         .unspents
         .iter()
         .map(|utxo| {
@@ -71,8 +71,7 @@ fn btc_reverse_claim() {
             };
             (outpoint, txout)
         })
-        .last()
-        .expect("value expected");
+        .collect();
 
     let test_wallet = test_framework.get_test_wallet();
     let refund_addrs = test_wallet
@@ -84,7 +83,7 @@ fn btc_reverse_claim() {
         kind: SwapTxKind::Claim,
         swap_script,
         output_address: refund_addrs,
-        utxo,
+        utxos,
     };
 
     let claim_tx = swap_tx
@@ -154,7 +153,7 @@ fn btc_submarine_refund() {
     assert_eq!(scan_result.total_amount, Amount::from_sat(10000));
 
     // Create a refund spending transaction from the swap
-    let utxo = scan_result
+    let utxos: Vec<(OutPoint, TxOut)> = scan_result
         .unspents
         .iter()
         .map(|utxo| {
@@ -165,8 +164,7 @@ fn btc_submarine_refund() {
             };
             (outpoint, txout)
         })
-        .last()
-        .expect("value expected");
+        .collect();
 
     let test_wallet = test_framework.get_test_wallet();
     let refund_addrs = test_wallet
@@ -178,7 +176,7 @@ fn btc_submarine_refund() {
         kind: SwapTxKind::Refund,
         swap_script,
         output_address: refund_addrs,
-        utxo,
+        utxos,
     };
 
     let refund_tx = swap_tx.sign_refund(&sender_keypair, 1000, None).unwrap();


### PR DESCRIPTION
This PR updates `BtcSwapTx` and its `new_refund` method to consider all available utxos.

Fixes #72