### PR TITLE
Use minimum possible dummy fees to estimate transaction size

### DIFF
--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -1086,7 +1086,7 @@ impl BtcSwapTx {
     /// Use this before calling drain to help calculate the absolute fees.
     /// Multiply the size by the fee_rate to get the absolute fees.
     pub fn size(&self, keys: &Keypair, preimage: &Preimage) -> Result<usize, Error> {
-        let dummy_abs_fee = 5_000;
+        let dummy_abs_fee = 0;
         // Can only calculate non-coperative claims
         let tx = match self.kind {
             SwapTxKind::Claim => self.sign_claim(keys, preimage, dummy_abs_fee, None)?,

--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -1212,7 +1212,7 @@ impl LBtcSwapTx {
     /// Use this before calling drain to help calculate the absolute fees.
     /// Multiply the size by the fee_rate to get the absolute fees.
     pub fn size(&self, keys: &Keypair, preimage: &Preimage) -> Result<usize, Error> {
-        let dummy_abs_fee = Amount::from_sat(5_000);
+        let dummy_abs_fee = Amount::from_sat(0);
         let tx = match self.kind {
             SwapTxKind::Claim => self.sign_claim(keys, preimage, dummy_abs_fee, None)?, // TODO: Hardcode cooperative spend size
             SwapTxKind::Refund => self.sign_refund(keys, dummy_abs_fee, None)?,


### PR DESCRIPTION
There's an issue when using the crate's helper method `Lbtc/BtcRefundTx.size()` when the output amount is less than 5000 sats (hard-coded dummy). This PR lowers the amount used for the calculations to 0, so it will always succeed no matter the output amount.