### PR TITLE
fix: invalid unit comparison in `lnurl` tests

### DIFF
--- a/src/util/lnurl.rs
+++ b/src/util/lnurl.rs
@@ -124,8 +124,8 @@ mod tests {
     #[ignore = "Requires using an new lnurl-w voucher and invoice to match the max_withdrawble amount"]
     #[test]
     fn test_process_withdrawal() {
-        let invoice = "lnbc5m1pnszpmwpp5vdu4qrghzq4c3uzvll0d82aa8vw2xtywukwgq5jncwwk7av7rdcscqpjsp5pav6wyrk0zaqc6gyfr4048qmnfj7h7ydpul5ds4dmqj4xam679zq9q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqdqqmqz9gxqyjw5qrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glcllm8u4a8gvusysqqqqlgqqqqqeqqjq6g9v7ejekz6uxqqmjjuaaa2s63nzx3d4n9pu8m6h68nmh7rgprky4pn5qae9878q5wpg72p66djy7ywsa7v4mfecdmnyj38etln394cqqzhnzt";
-        let voucher = "LNURL1DP68GURN8GHJ7ER9D4HJUMRWVF5HGUEWVDHK6TMHD96XSERJV9MJ7CTSDYHHVVF0D3H82UNV9AZXY56N89F5CDFJW34K63N2GEJXK5N2VD2K6TMRWARKJVN8D565WCNNDFT85WR42FP5GUN2VSDZTX2W";
+        let voucher = "LNURL1DP68GURN8GHJ7ER9D4HJUMRWVF5HGUEWVDHK6TMHD96XSERJV9MJ7CTSDYHHVVF0D3H82UNV9AVYS6ZV899XS4J6WFYRV6Z9TQU4GUT9VF48SWY20AR";
+        let invoice = "lnbc4u1pnsywcypp5eamm4c3v42vlyr0asmt55muv02zusjp2dy7j6e3kuz5vv3cuyj6scqpjsp56hujjsj4r76gp9gk6y435rz99682uxjx924a06wwqm0av6ezxepq9q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqdqqmqz9gxqyjw5qrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glcllm8u4a8gvusysqqqqlgqqqqqeqqjqtgxt57vzea9xaygxu806xf7w5872n737ptuc6al0plf3544a2f5y2e42j9qv7gvkqkn9k2yxzmew6rr40z2gyq9nu8atj2yt4dlfm3gpjevcgu";
         assert!(validate_lnurl(voucher));
         let withdraw_response = match create_withdraw_response(voucher) {
             Ok(response) => response,
@@ -136,20 +136,24 @@ mod tests {
         };
 
         let invoice_amount = match Bolt11Invoice::from_str(invoice) {
-            Ok(invoice) => invoice.amount_milli_satoshis().unwrap() / 1000,
+            Ok(invoice) => invoice.amount_milli_satoshis(),
             Err(e) => {
                 println!("Failed to parse invoice: {:?}", e);
                 return;
             }
         };
 
-        assert!(
-            invoice_amount <= withdraw_response.max_withdrawable,
-            "Invoice of {} exceeds max withdrawable {} sats",
+        assert_eq!(
+            invoice_amount,
+            Option::from(withdraw_response.max_withdrawable),
+            "Invoice of {:?} doesn't match with withdrawable {} sats",
             invoice_amount,
             withdraw_response.max_withdrawable
         );
-        println!("Successfully created withdraw response");
+        println!(
+            "Successfully created withdraw response{:?}",
+            withdraw_response
+        );
         let result = process_withdrawal(&withdraw_response, invoice);
 
         assert!(result.is_ok(), "Withdrawal failed: {:?}", result.err());


### PR DESCRIPTION
https://github.com/SatoshiPortal/boltz-rust/blob/348a88136a5b5706a8964c44a2de2239ee0e7e31/src/util/lnurl.rs#L139

Here we were converting the amount from `milli_satoshi` to `satoshi`, but `max_withdrawable` returns us amount in `satoshi`. So it was fundamentally a wrong comparison.
https://github.com/SatoshiPortal/boltz-rust/blob/348a88136a5b5706a8964c44a2de2239ee0e7e31/src/util/lnurl.rs#L147


nit: Also includes minor change in error message.
 