### PR TITLE
Update amounts from u32 to u64 in create requests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ pub mod swaps;
 /// utilities (key, preimage, error)
 pub mod util;
 
-
 // Re-export common libs, so callers can make use of them and avoid version conflicts
 pub use bitcoin;
 pub use electrum_client;

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -695,7 +695,7 @@ impl Subscription {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateReverseRequest {
-    pub invoice_amount: u32,
+    pub invoice_amount: u64,
     pub from: String,
     pub to: String,
     pub preimage_hash: sha256::Hash,
@@ -723,7 +723,7 @@ pub struct CreateReverseResponse {
     pub lockup_address: String,
     pub refund_public_key: PublicKey,
     pub timeout_block_height: u32,
-    pub onchain_amount: u32,
+    pub onchain_amount: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blinding_key: Option<String>,
 }
@@ -775,7 +775,7 @@ pub struct ChainSwapDetails {
     pub lockup_address: String,
     pub server_public_key: PublicKey,
     pub timeout_block_height: u32,
-    pub amount: u32,
+    pub amount: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blinding_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -797,9 +797,9 @@ pub struct CreateChainRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refund_public_key: Option<PublicKey>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_lock_amount: Option<u32>,
+    pub user_lock_amount: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub server_lock_amount: Option<u32>,
+    pub server_lock_amount: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pair_hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,9 +8,9 @@ use lightning_invoice::{Bolt11Invoice, RouteHintHop};
 use crate::{error::Error, network::electrum::ElectrumConfig};
 
 pub mod ec;
-pub mod secrets;
 #[cfg(feature = "lnurl")]
 pub mod lnurl;
+pub mod secrets;
 /// Setup function that will only run once, even if called multiple times.
 
 pub fn liquid_genesis_hash(electrum_config: &ElectrumConfig) -> Result<elements::BlockHash, Error> {


### PR DESCRIPTION
Some amount fields in swap create requests were `u32`, while other relevant fields (fees, min/max in pair limits) were `u64`.

This meant conversion or typecasting was often necessary when interacting between the two.

To simplify this in callers, this PR updates the `u32` amount fields in Swap Create requests to `u64`.