### PR TITLE
DiscountCT compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "boltz-client"
 description = "a boltz exchange client for swaps between BTC/LBTC & LN"
 authors = ["i5hi <ishi@satoshiportal.com>", "Rajarshi Maitra <raj@bitshala.org>"]
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 license="MIT"
 
@@ -24,10 +24,10 @@ serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
 ureq = { version = "2.5.0", features = ["json", "native-tls"] }
 bip39 = "2.0.0"
-electrum-client = "0.19.0"
-bitcoin = {version = "0.31.2", features = ["rand", "base64", "rand-std"]}
-elements = { version = "0.24.0", features = ["serde"] }
-lightning-invoice = "0.30.0"
+electrum-client = { version = "0.21.0", default-features=false, features = ["use-rustls-ring", "proxy"] }
+bitcoin = {version = "0.32.2", features = ["rand", "base64", "rand-std"]}
+elements = { version = "0.25.0", features = ["serde"] }
+lightning-invoice = "0.32.0"
 tungstenite = { version = "0.21.0", features = ["native-tls-vendored"] }
 url = "2.5.0"
 log = "^0.4"
@@ -37,11 +37,11 @@ hex = "0.4"
 lnurl-rs = { version = "0.8.0", optional = true }
 
 [patch.crates-io]
-secp256k1-zkp = {git = "https://github.com/BlockstreamResearch/rust-secp256k1-zkp.git", rev = "60e631c24588a0c9e271badd61959294848c665d"}
+secp256k1-zkp = { git = "https://github.com/dangeross/rust-secp256k1-zkp.git", rev = "57d29b15269ca2ce3c3b118b6a72b66c1169e7b1" }
 
 [dev-dependencies]
-bitcoind = {version = "0.34.1", features = ["25_0"] }
-elementsd = {version  = "0.9.1", features = ["22_1_1"] }
+bitcoind = {version = "0.36.0", features = ["25_0"] }
+elementsd = {version  = "0.11.0", features = ["22_1_1"] }
 
 #Empty default feature set, (helpful to generalise in github actions)
 [features]

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,9 +4,9 @@ pub enum Error {
     Electrum(electrum_client::Error),
     Hex(String),
     Protocol(String),
-    Key(bitcoin::key::Error),
+    Key(bitcoin::key::ParsePublicKeyError),
     Address(String),
-    Sighash(bitcoin::sighash::Error),
+    Sighash(bitcoin::sighash::TaprootError),
     ElSighash(elements::sighash::Error),
     Secp(bitcoin::secp256k1::Error),
     HTTP(String),
@@ -40,8 +40,8 @@ impl From<bitcoin::hex::HexToBytesError> for Error {
     }
 }
 
-impl From<bitcoin::key::Error> for Error {
-    fn from(value: bitcoin::key::Error) -> Self {
+impl From<bitcoin::key::ParsePublicKeyError> for Error {
+    fn from(value: bitcoin::key::ParsePublicKeyError) -> Self {
         Self::Key(value)
     }
 }
@@ -70,14 +70,15 @@ impl From<elements::address::AddressError> for Error {
     }
 }
 
-impl From<bitcoin::sighash::Error> for Error {
-    fn from(value: bitcoin::sighash::Error) -> Self {
-        Self::Sighash(value)
-    }
-}
 impl From<elements::sighash::Error> for Error {
     fn from(value: elements::sighash::Error) -> Self {
         Self::ElSighash(value)
+    }
+}
+
+impl From<bitcoin::sighash::TaprootError> for Error {
+    fn from(value: bitcoin::sighash::TaprootError) -> Self {
+        Self::Sighash(value)
     }
 }
 
@@ -159,8 +160,8 @@ impl From<bip39::Error> for Error {
     }
 }
 
-impl From<bitcoin::absolute::Error> for Error {
-    fn from(value: bitcoin::absolute::Error) -> Self {
+impl From<bitcoin::absolute::ConversionError> for Error {
+    fn from(value: bitcoin::absolute::ConversionError) -> Self {
         Self::Locktime(value.to_string())
     }
 }

--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -1211,13 +1211,21 @@ impl LBtcSwapTx {
     /// Calculate the size of a transaction.
     /// Use this before calling drain to help calculate the absolute fees.
     /// Multiply the size by the fee_rate to get the absolute fees.
-    pub fn size(&self, keys: &Keypair, preimage: &Preimage) -> Result<usize, Error> {
+    pub fn size(
+        &self,
+        keys: &Keypair,
+        preimage: &Preimage,
+        is_discount_ct: bool,
+    ) -> Result<usize, Error> {
         let dummy_abs_fee = Amount::from_sat(0);
         let tx = match self.kind {
             SwapTxKind::Claim => self.sign_claim(keys, preimage, dummy_abs_fee, None)?, // TODO: Hardcode cooperative spend size
             SwapTxKind::Refund => self.sign_refund(keys, dummy_abs_fee, None)?,
         };
-        Ok(tx.vsize())
+        Ok(match is_discount_ct {
+            true => tx.discount_vsize(),
+            false => tx.vsize(),
+        })
     }
 
     /// Broadcast transaction to the network

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -1,4 +1,4 @@
-use std::{mem::swap, str::FromStr, time::Duration};
+use std::{str::FromStr, time::Duration};
 
 use boltz_client::{
     network::{electrum::ElectrumConfig, Chain},


### PR DESCRIPTION
This PR primarily:
- bumps the elements version to 0.25.0 to be inline with LWK's support of DiscountCT
- adds to the LBtcSwapTx size fn the option to calculate using the tx's discount_vsize
- bumps electrum-client, bitcoin and lightning-invoice dependencies
- updates the secp256k1-zkp patch [rebasing the original patch on 0.11.0](https://github.com/dangeross/rust-secp256k1-zkp/commit/57d29b15269ca2ce3c3b118b6a72b66c1169e7b1)

I've left in support of broadcasting via Boltz for lowball.

I also took the liberty to bump the crate version to 0.2.0 as major dependencies are updated. Let me know if you prefer to revert it.