### PR TITLE
Only consider confirmed spending txs for utxo fetching

### DIFF
--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -408,13 +408,14 @@ impl BtcSwapScript {
     ) -> Result<Vec<(OutPoint, TxOut)>, Error> {
         let electrum_client = network_config.build_client()?;
         let spk = self.to_address(network_config.network())?.script_pubkey();
-        let history: Vec<_> = electrum_client
-            .script_get_history(spk.as_script())?
-            .into_iter()
-            .filter(|h| h.height > 0)
-            .collect();
-        let txs = electrum_client
-            .batch_transaction_get(&history.iter().map(|h| h.tx_hash).collect::<Vec<_>>())?;
+        let history: Vec<_> = electrum_client.script_get_history(spk.as_script())?;
+        let txs = electrum_client.batch_transaction_get(
+            &history
+                .iter()
+                .filter(|h| h.height > 0)
+                .map(|h| h.tx_hash)
+                .collect::<Vec<_>>(),
+        )?;
 
         let utxo_pairs = txs
             .iter()

--- a/tests/chain_swaps.rs
+++ b/tests/chain_swaps.rs
@@ -281,8 +281,8 @@ fn refund_bitcoin_liquid_v2_chain(
         .broadcast(&tx, &ElectrumConfig::default_bitcoin())
         .unwrap();
 
-    log::info!("Succesfully broadcasted claim tx!");
-    log::debug!("Claim Tx {:?}", tx);
+    log::info!("Successfully broadcasted refund tx!");
+    log::debug!("Refund Tx {:?}", tx);
 }
 
 #[test]


### PR DESCRIPTION
This PR proposes considering only confirmed spending txs when listing which of our script's outputs are unspent. The main goal is allowing fee bumping for refund txs. Without it, a new refund cannot be constructed because the outputs stop being considered unspent when there is a pending spend.