### PR TITLE
Calculate cooperative tx sizes

### DIFF
--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -1205,16 +1205,24 @@ impl BtcSwapTx {
     }
 
     /// Calculate the size of a transaction.
+    /// The `preimage` is only required when calculating the claim tx size.
     /// Use this before calling drain to help calculate the absolute fees.
     /// Multiply the size by the fee_rate to get the absolute fees.
-    pub fn size(&self, keys: &Keypair, preimage: &Preimage) -> Result<usize, Error> {
-        let dummy_abs_fee = 0;
-        // Can only calculate non-coperative claims
+    pub fn size(
+        &self,
+        keys: &Keypair,
+        preimage: Option<&Preimage>,
+        is_cooperative: bool,
+    ) -> Result<usize, Error> {
+        let dummy_abs_fee = 1;
         let tx = match self.kind {
             SwapTxKind::Claim => {
-                self.sign_claim(keys, preimage, Fee::Absolute(dummy_abs_fee), None)?
+                let Some(preimage) = preimage else {
+                    return Err(Error::Protocol("No preimage provided.".to_string()));
+                };
+                self.create_claim(keys, preimage, dummy_abs_fee, is_cooperative)?
             }
-            SwapTxKind::Refund => self.sign_refund(keys, Fee::Absolute(dummy_abs_fee), None)?,
+            SwapTxKind::Refund => self.create_refund(keys, dummy_abs_fee, is_cooperative)?,
         };
         Ok(tx.vsize())
     }

--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -1208,19 +1208,12 @@ impl BtcSwapTx {
     /// The `preimage` is only required when calculating the claim tx size.
     /// Use this before calling drain to help calculate the absolute fees.
     /// Multiply the size by the fee_rate to get the absolute fees.
-    pub fn size(
-        &self,
-        keys: &Keypair,
-        preimage: Option<&Preimage>,
-        is_cooperative: bool,
-    ) -> Result<usize, Error> {
+    pub fn size(&self, keys: &Keypair, is_cooperative: bool) -> Result<usize, Error> {
         let dummy_abs_fee = 1;
         let tx = match self.kind {
             SwapTxKind::Claim => {
-                let Some(preimage) = preimage else {
-                    return Err(Error::Protocol("No preimage provided.".to_string()));
-                };
-                self.create_claim(keys, preimage, dummy_abs_fee, is_cooperative)?
+                let preimage = Preimage::from_vec([0; 32].to_vec())?;
+                self.create_claim(keys, &preimage, dummy_abs_fee, is_cooperative)?
             }
             SwapTxKind::Refund => self.create_refund(keys, dummy_abs_fee, is_cooperative)?,
         };

--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -1200,12 +1200,11 @@ impl BtcSwapTx {
         let mut witness = Witness::new();
         // Stub because we don't want to create cooperative signatures here
         // but still be able to have an accurate size estimation
-        witness.push([0, 64]);
+        witness.push([0; 64]);
         witness
     }
 
     /// Calculate the size of a transaction.
-    /// The `preimage` is only required when calculating the claim tx size.
     /// Use this before calling drain to help calculate the absolute fees.
     /// Multiply the size by the fee_rate to get the absolute fees.
     pub fn size(&self, keys: &Keypair, is_cooperative: bool) -> Result<usize, Error> {

--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -1268,17 +1268,14 @@ impl LBtcSwapTx {
     pub fn size(
         &self,
         keys: &Keypair,
-        preimage: Option<&Preimage>,
         is_cooperative: bool,
         is_discount_ct: bool,
     ) -> Result<usize, Error> {
         let dummy_abs_fee = 1;
         let tx = match self.kind {
             SwapTxKind::Claim => {
-                let Some(preimage) = preimage else {
-                    return Err(Error::Protocol("No preimage provided.".to_string()));
-                };
-                self.create_claim(keys, preimage, dummy_abs_fee, is_cooperative)?
+                let preimage = Preimage::from_vec([0; 32].to_vec())?;
+                self.create_claim(keys, &preimage, dummy_abs_fee, is_cooperative)?
             }
             SwapTxKind::Refund => self.create_refund(keys, dummy_abs_fee, is_cooperative)?,
         };

--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -1251,7 +1251,7 @@ impl LBtcSwapTx {
         let mut witness = Witness::new();
         // Stub because we don't want to create cooperative signatures here
         // but still be able to have an accurate size estimation
-        witness.push([0, 64]);
+        witness.push([0; 64]);
 
         TxInWitness {
             amount_rangeproof: None,
@@ -1262,7 +1262,6 @@ impl LBtcSwapTx {
     }
 
     /// Calculate the size of a transaction.
-    /// The `preimage` is only required when calculating the claim tx size.
     /// Use this before calling drain to help calculate the absolute fees.
     /// Multiply the size by the fee_rate to get the absolute fees.
     pub fn size(

--- a/tests/regtest.rs
+++ b/tests/regtest.rs
@@ -108,6 +108,20 @@ fn prepare_btc_claim() -> (
 }
 
 #[test]
+fn btc_reverse_claim_size() {
+    let (_test_framework, _scan_request, swap_tx, preimage, recvr_keypair, _utxos) =
+        prepare_btc_claim();
+
+    let coop_claim_tx_size = swap_tx.size(&recvr_keypair, Some(&preimage), true).unwrap();
+    assert_eq!(coop_claim_tx_size, 84);
+
+    let non_coop_claim_tx_size = swap_tx
+        .size(&recvr_keypair, Some(&preimage), false)
+        .unwrap();
+    assert_eq!(non_coop_claim_tx_size, 140);
+}
+
+#[test]
 fn btc_reverse_claim() {
     let (test_framework, scan_request, swap_tx, preimage, recvr_keypair, utxos) =
         prepare_btc_claim();
@@ -257,6 +271,17 @@ fn prepare_btc_refund() -> (
     };
 
     (test_framework, scan_request, swap_tx, sender_keypair, utxos)
+}
+
+#[test]
+fn btc_submarine_refund_size() {
+    let (_test_framework, _scan_request, swap_tx, sender_keypair, _utxos) = prepare_btc_refund();
+
+    let coop_refund_tx_size = swap_tx.size(&sender_keypair, None, true).unwrap();
+    assert_eq!(coop_refund_tx_size, 84);
+
+    let non_coop_refund_tx_size = swap_tx.size(&sender_keypair, None, false).unwrap();
+    assert_eq!(non_coop_refund_tx_size, 126);
 }
 
 #[test]
@@ -415,6 +440,22 @@ fn prepare_lbtc_claim() -> (
 }
 
 #[test]
+fn lbtc_reverse_claim_size() {
+    let (_test_framework, swap_tx, preimage, recvr_keypair, _blinding_keypair, _swap_addrs, _utxos) =
+        prepare_lbtc_claim();
+
+    let coop_claim_tx_size = swap_tx
+        .size(&recvr_keypair, Some(&preimage), true, true)
+        .unwrap();
+    assert_eq!(coop_claim_tx_size, 165);
+
+    let non_coop_claim_tx_size = swap_tx
+        .size(&recvr_keypair, Some(&preimage), false, true)
+        .unwrap();
+    assert_eq!(non_coop_claim_tx_size, 221);
+}
+
+#[test]
 fn lbtc_reverse_claim() {
     let (test_framework, swap_tx, preimage, recvr_keypair, blinding_keypair, swap_addrs, utxo) =
         prepare_lbtc_claim();
@@ -542,6 +583,18 @@ fn prepare_lbtc_refund() -> (
         swap_addrs,
         utxo,
     )
+}
+
+#[test]
+fn lbtc_submarine_refund_size() {
+    let (_test_framework, swap_tx, sender_keypair, _blinding_keypair, _swap_addrs, _utxos) =
+        prepare_lbtc_refund();
+
+    let coop_refund_tx_size = swap_tx.size(&sender_keypair, None, true, true).unwrap();
+    assert_eq!(coop_refund_tx_size, 165);
+
+    let non_coop_refund_tx_size = swap_tx.size(&sender_keypair, None, false, true).unwrap();
+    assert_eq!(non_coop_refund_tx_size, 207);
 }
 
 #[test]

--- a/tests/regtest.rs
+++ b/tests/regtest.rs
@@ -109,15 +109,13 @@ fn prepare_btc_claim() -> (
 
 #[test]
 fn btc_reverse_claim_size() {
-    let (_test_framework, _scan_request, swap_tx, preimage, recvr_keypair, _utxos) =
+    let (_test_framework, _scan_request, swap_tx, _preimage, recvr_keypair, _utxos) =
         prepare_btc_claim();
 
-    let coop_claim_tx_size = swap_tx.size(&recvr_keypair, Some(&preimage), true).unwrap();
+    let coop_claim_tx_size = swap_tx.size(&recvr_keypair, true).unwrap();
     assert_eq!(coop_claim_tx_size, 84);
 
-    let non_coop_claim_tx_size = swap_tx
-        .size(&recvr_keypair, Some(&preimage), false)
-        .unwrap();
+    let non_coop_claim_tx_size = swap_tx.size(&recvr_keypair, false).unwrap();
     assert_eq!(non_coop_claim_tx_size, 140);
 }
 
@@ -277,10 +275,10 @@ fn prepare_btc_refund() -> (
 fn btc_submarine_refund_size() {
     let (_test_framework, _scan_request, swap_tx, sender_keypair, _utxos) = prepare_btc_refund();
 
-    let coop_refund_tx_size = swap_tx.size(&sender_keypair, None, true).unwrap();
+    let coop_refund_tx_size = swap_tx.size(&sender_keypair, true).unwrap();
     assert_eq!(coop_refund_tx_size, 84);
 
-    let non_coop_refund_tx_size = swap_tx.size(&sender_keypair, None, false).unwrap();
+    let non_coop_refund_tx_size = swap_tx.size(&sender_keypair, false).unwrap();
     assert_eq!(non_coop_refund_tx_size, 126);
 }
 
@@ -441,17 +439,20 @@ fn prepare_lbtc_claim() -> (
 
 #[test]
 fn lbtc_reverse_claim_size() {
-    let (_test_framework, swap_tx, preimage, recvr_keypair, _blinding_keypair, _swap_addrs, _utxos) =
-        prepare_lbtc_claim();
+    let (
+        _test_framework,
+        swap_tx,
+        _preimage,
+        recvr_keypair,
+        _blinding_keypair,
+        _swap_addrs,
+        _utxos,
+    ) = prepare_lbtc_claim();
 
-    let coop_claim_tx_size = swap_tx
-        .size(&recvr_keypair, Some(&preimage), true, true)
-        .unwrap();
+    let coop_claim_tx_size = swap_tx.size(&recvr_keypair, true, true).unwrap();
     assert_eq!(coop_claim_tx_size, 165);
 
-    let non_coop_claim_tx_size = swap_tx
-        .size(&recvr_keypair, Some(&preimage), false, true)
-        .unwrap();
+    let non_coop_claim_tx_size = swap_tx.size(&recvr_keypair, false, true).unwrap();
     assert_eq!(non_coop_claim_tx_size, 221);
 }
 
@@ -590,10 +591,10 @@ fn lbtc_submarine_refund_size() {
     let (_test_framework, swap_tx, sender_keypair, _blinding_keypair, _swap_addrs, _utxos) =
         prepare_lbtc_refund();
 
-    let coop_refund_tx_size = swap_tx.size(&sender_keypair, None, true, true).unwrap();
+    let coop_refund_tx_size = swap_tx.size(&sender_keypair, true, true).unwrap();
     assert_eq!(coop_refund_tx_size, 165);
 
-    let non_coop_refund_tx_size = swap_tx.size(&sender_keypair, None, false, true).unwrap();
+    let non_coop_refund_tx_size = swap_tx.size(&sender_keypair, false, true).unwrap();
     assert_eq!(non_coop_refund_tx_size, 207);
 }
 

--- a/tests/regtest.rs
+++ b/tests/regtest.rs
@@ -3,7 +3,7 @@ use bitcoin::key::rand::thread_rng;
 use bitcoin::key::{Keypair, PublicKey};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::{Amount, OutPoint, TxOut};
-use bitcoind::bitcoincore_rpc::json::ScanTxOutRequest;
+use bitcoind::bitcoincore_rpc::json::{AddressType, ScanTxOutRequest};
 use bitcoind::bitcoincore_rpc::RpcApi;
 use boltz_client::boltz::{SwapTxKind, SwapType};
 use boltz_client::fees::Fee;
@@ -86,7 +86,7 @@ fn prepare_btc_claim() -> (
 
     let test_wallet = test_framework.get_test_wallet();
     let refund_addrs = test_wallet
-        .get_new_address(None, None)
+        .get_new_address(None, Some(AddressType::P2shSegwit))
         .unwrap()
         .assume_checked();
 
@@ -113,10 +113,10 @@ fn btc_reverse_claim_size() {
         prepare_btc_claim();
 
     let coop_claim_tx_size = swap_tx.size(&recvr_keypair, true).unwrap();
-    assert_eq!(coop_claim_tx_size, 84);
+    assert_eq!(coop_claim_tx_size, 100);
 
     let non_coop_claim_tx_size = swap_tx.size(&recvr_keypair, false).unwrap();
-    assert_eq!(non_coop_claim_tx_size, 140);
+    assert_eq!(non_coop_claim_tx_size, 141);
 }
 
 #[test]
@@ -170,7 +170,7 @@ fn btc_reverse_claim_relative_fee() {
         .fold(0, |acc, (_, out)| acc + out.value.to_sat())
         - claim_tx.output[0].value.to_sat();
     assert_eq!(relative_fee, claim_tx_fee as f64 / claim_tx.vsize() as f64);
-    assert_eq!(claim_tx_fee, 140);
+    assert_eq!(claim_tx_fee, 141);
 
     test_framework
         .as_ref()
@@ -257,7 +257,7 @@ fn prepare_btc_refund() -> (
 
     let test_wallet = test_framework.get_test_wallet();
     let refund_addrs = test_wallet
-        .get_new_address(None, None)
+        .get_new_address(None, Some(AddressType::P2shSegwit))
         .unwrap()
         .assume_checked();
 
@@ -276,10 +276,10 @@ fn btc_submarine_refund_size() {
     let (_test_framework, _scan_request, swap_tx, sender_keypair, _utxos) = prepare_btc_refund();
 
     let coop_refund_tx_size = swap_tx.size(&sender_keypair, true).unwrap();
-    assert_eq!(coop_refund_tx_size, 84);
+    assert_eq!(coop_refund_tx_size, 100);
 
     let non_coop_refund_tx_size = swap_tx.size(&sender_keypair, false).unwrap();
-    assert_eq!(non_coop_refund_tx_size, 126);
+    assert_eq!(non_coop_refund_tx_size, 127);
 }
 
 #[test]
@@ -340,7 +340,7 @@ fn btc_submarine_refund_relative_fee() {
         relative_fee,
         refund_tx_fee as f64 / refund_tx.vsize() as f64
     );
-    assert_eq!(refund_tx_fee, 126);
+    assert_eq!(refund_tx_fee, 127);
 
     // Make the timelock matured and broadcast the spend
     test_framework.generate_blocks(100);
@@ -450,7 +450,7 @@ fn lbtc_reverse_claim_size() {
     ) = prepare_lbtc_claim();
 
     let coop_claim_tx_size = swap_tx.size(&recvr_keypair, true, true).unwrap();
-    assert_eq!(coop_claim_tx_size, 165);
+    assert_eq!(coop_claim_tx_size, 181);
 
     let non_coop_claim_tx_size = swap_tx.size(&recvr_keypair, false, true).unwrap();
     assert_eq!(non_coop_claim_tx_size, 221);
@@ -592,7 +592,7 @@ fn lbtc_submarine_refund_size() {
         prepare_lbtc_refund();
 
     let coop_refund_tx_size = swap_tx.size(&sender_keypair, true, true).unwrap();
-    assert_eq!(coop_refund_tx_size, 165);
+    assert_eq!(coop_refund_tx_size, 181);
 
     let non_coop_refund_tx_size = swap_tx.size(&sender_keypair, false, true).unwrap();
     assert_eq!(non_coop_refund_tx_size, 207);


### PR DESCRIPTION
Now that the claim and refund txs are created with stubbed witness data, we should be able to calculate the cooperative tx size without performing a cooperate sign

Also fixes the stubbed witness data