### PR TITLE
Fix unused code warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 //! Refer to tests/ folder for usage
 //! THIS LIBRARY IS IN EARLY ALPHA. TEST AND REVIEW BEFORE USING IN PRODUCTION.
 
-#![allow(unused)]
 /// Error Module
 pub mod error;
 /// Blockchain Network module. Currently only contains electrum interface.

--- a/src/network/electrum.rs
+++ b/src/network/electrum.rs
@@ -2,10 +2,9 @@
 
 use super::{BitcoinChain, BitcoinClient, LiquidChain, LiquidClient};
 use crate::error::Error;
-use bitcoin::{Address, Network, ScriptBuf, Transaction, Txid};
+use bitcoin::{Address, ScriptBuf, Transaction, Txid};
 use electrum_client::{ElectrumApi, GetHistoryRes};
 use elements::encode::{serialize, Decodable};
-use elements::AddressParams;
 use std::collections::{HashMap, HashSet};
 
 pub const DEFAULT_MAINNET_NODE: &str = "wes.bullbitcoin.com:50002";
@@ -114,7 +113,7 @@ impl ElectrumBitcoinClient {
         let mut result = Vec::new();
         for tx in txs.into_iter() {
             let txid = tx.compute_txid();
-            for (vout, mut output) in tx.output.into_iter().enumerate() {
+            for (vout, output) in tx.output.into_iter().enumerate() {
                 if output.script_pubkey == *spk {
                     let outpoint = bitcoin::OutPoint::new(txid, vout as u32);
                     if !spent_outputs.contains(&outpoint) {
@@ -260,15 +259,12 @@ mod tests {
 
     use super::*;
     use crate::network::BitcoinChain::BitcoinTestnet;
-    use crate::BtcSwapScript;
     use bitcoin::absolute::LockTime;
     use bitcoin::blockdata::transaction::Transaction;
-    use bitcoin::blockdata::transaction::Txid;
     use bitcoin::transaction::Version;
-    use bitcoin::{Amount, OutPoint, Script, ScriptBuf, TxIn, TxOut};
+    use bitcoin::{Amount, OutPoint, ScriptBuf, TxIn, TxOut};
     use electrum_client::ElectrumApi;
     use electrum_client::GetHistoryRes;
-    use std::str::FromStr;
 
     #[test]
     fn test_electrum_default_clients() {

--- a/src/network/esplora.rs
+++ b/src/network/esplora.rs
@@ -5,8 +5,6 @@ use elements::hex::ToHex;
 use elements::pset::serialize::Serialize;
 use reqwest::Response;
 use serde::Deserialize;
-use std::collections::HashMap;
-use std::fmt::format;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -326,18 +324,14 @@ pub async fn async_sleep(millis: i32) {
 
 #[derive(Debug, Deserialize)]
 struct AddressInfo {
-    address: String,
     chain_stats: Stats,
     mempool_stats: Stats,
 }
 
 #[derive(Debug, Deserialize)]
 struct Stats {
-    funded_txo_count: u64,
     funded_txo_sum: u64,
-    spent_txo_count: u64,
     spent_txo_sum: u64,
-    tx_count: u64,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -1,41 +1,35 @@
-use bitcoin::consensus::{deserialize, Decodable};
+use bitcoin::consensus::deserialize;
 use bitcoin::hashes::Hash;
 use bitcoin::hex::{DisplayHex, FromHex};
 use bitcoin::key::rand::rngs::OsRng;
 use bitcoin::key::rand::{thread_rng, RngCore};
-use bitcoin::script::{PushBytes, PushBytesBuf};
-use bitcoin::secp256k1::{All, Keypair, Message, Secp256k1, SecretKey};
+use bitcoin::secp256k1::{Keypair, Message, Secp256k1, SecretKey};
 use bitcoin::sighash::Prevouts;
 use bitcoin::taproot::{LeafVersion, Signature, TaprootBuilder, TaprootSpendInfo};
 use bitcoin::transaction::Version;
 use bitcoin::{
-    blockdata::script::{Builder, Instruction, Script, ScriptBuf},
+    blockdata::script::{Builder, Instruction, ScriptBuf},
     opcodes::{all::*, OP_0},
     Address, OutPoint, PublicKey,
 };
 use bitcoin::{sighash::SighashCache, Network, Sequence, Transaction, TxIn, TxOut, Witness};
-use bitcoin::{Amount, EcdsaSighashType, TapLeafHash, TapSighashType, Txid, XOnlyPublicKey};
-use elements::encode::serialize;
+use bitcoin::{Amount, TapLeafHash, TapSighashType, Txid, XOnlyPublicKey};
 use elements::pset::serialize::Serialize;
-use std::collections::HashMap;
-use std::ops::{Add, Index};
 use std::str::FromStr;
 
 use crate::{error::Error, util::secrets::Preimage};
-use crate::{LBtcSwapScript, LBtcSwapTx};
 
 use bitcoin::{blockdata::locktime::absolute::LockTime, hashes::hash160};
 
 use super::boltz::{
-    BoltzApiClientV2, ChainClaimTxResponse, ChainSwapDetails, Cooperative, CreateChainResponse,
-    CreateReverseResponse, CreateSubmarineResponse, PartialSig, Side, SubmarineClaimTxResponse,
-    SwapTxKind, SwapType, ToSign,
+    BoltzApiClientV2, ChainSwapDetails, Cooperative, CreateReverseResponse,
+    CreateSubmarineResponse, Side, SwapTxKind, SwapType, ToSign,
 };
 
 use crate::network::{BitcoinChain, BitcoinClient};
 use crate::util::fees::{create_tx_with_fee, Fee};
 use elements::secp256k1_zkp::{
-    musig, MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
+    MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
     MusigSessionId,
 };
 
@@ -308,7 +302,7 @@ impl BtcSwapScript {
         // Setup Key Aggregation cache
         // let pubkeys = [self.receiver_pubkey.inner, self.sender_pubkey.inner];
 
-        let mut key_agg_cache = self.musig_keyagg_cache();
+        let key_agg_cache = self.musig_keyagg_cache();
 
         // Construct the Taproot
         let internal_key = key_agg_cache.agg_pk();
@@ -323,9 +317,9 @@ impl BtcSwapScript {
         let taproot_spend_info = match taproot_builder.finalize(&secp, internal_key) {
             Ok(r) => r,
             Err(e) => {
-                return Err(Error::Taproot(
-                    "Could not finalize taproot constructions".to_string(),
-                ))
+                return Err(Error::Taproot(format!(
+                    "Could not finalize taproot constructions: {e:?}"
+                )))
             }
         };
 
@@ -367,7 +361,7 @@ impl BtcSwapScript {
         let spend_info = self.taproot_spendinfo()?;
         let output_key = spend_info.output_key();
 
-        let mut network = match network {
+        let network = match network {
             BitcoinChain::Bitcoin => Network::Bitcoin,
             BitcoinChain::BitcoinRegtest => Network::Regtest,
             BitcoinChain::BitcoinTestnet => Network::Testnet,
@@ -440,7 +434,7 @@ impl BtcSwapScript {
             SwapType::ReverseSubmarine => boltz_client.get_reverse_tx(swap_id).await?.hex,
             SwapType::Submarine => boltz_client.get_submarine_tx(swap_id).await?.hex,
         };
-        if (hex.is_none()) {
+        if hex.is_none() {
             return Err(Error::Hex(
                 "No transaction hex found in boltz response".to_string(),
             ));
@@ -587,11 +581,6 @@ impl BtcSwapTx {
     ) -> Result<(MusigPartialSignature, MusigPubNonce), Error> {
         // Step 1: Start with a Musig KeyAgg Cache
         let secp = Secp256k1::new();
-
-        let pubkeys = [
-            self.swap_script.receiver_pubkey.inner,
-            self.swap_script.sender_pubkey.inner,
-        ];
 
         let mut key_agg_cache = self.swap_script.musig_keyagg_cache();
 
@@ -797,9 +786,7 @@ impl BtcSwapTx {
         absolute_fees: u64,
         is_cooperative: bool,
     ) -> Result<Transaction, Error> {
-        let preimage_bytes = if let Some(value) = preimage.bytes {
-            value
-        } else {
+        if preimage.bytes.is_none() {
             return Err(Error::Protocol(
                 "No preimage provided while signing.".to_string(),
             ));

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -17,17 +17,13 @@
 //!     output_amount - base_fees - claim_fee
 //! );
 
-use bitcoin::key;
-use bitcoin::{
-    hashes::sha256, hex::DisplayHex, taproot::TapLeaf, PublicKey, ScriptBuf, Transaction,
-};
+use bitcoin::{hashes::sha256, hex::DisplayHex, PublicKey};
 use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::fmt::{Display, Formatter, Write};
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
-use std::sync::Arc;
-use std::{collections::HashMap, fmt::format, net::TcpStream};
 
 use crate::{error::Error, network::Chain, util::secrets::Preimage};
 use crate::{BtcSwapScript, LBtcSwapScript};
@@ -36,12 +32,7 @@ pub const BOLTZ_TESTNET_URL_V2: &str = "https://api.testnet.boltz.exchange/v2";
 pub const BOLTZ_MAINNET_URL_V2: &str = "https://api.boltz.exchange/v2";
 pub const BOLTZ_REGTEST: &str = "http://localhost:9001/v2";
 
-use url::Url;
-
-use elements::secp256k1_zkp::{
-    MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
-    MusigSessionId,
-};
+use elements::secp256k1_zkp::{MusigPartialSignature, MusigPubNonce};
 pub use tokio_tungstenite_wasm;
 use tokio_tungstenite_wasm::{connect, WebSocketStream};
 
@@ -699,7 +690,6 @@ impl CreateSubmarineResponse {
                 boltz_sub_script.validate_address(bitcoin_chain, self.address.clone())
             }
             Chain::Liquid(liquid_chain) => {
-                let blinding_key = self.blinding_key.as_ref().unwrap();
                 let boltz_sub_script = LBtcSwapScript::submarine_from_swap_resp(self, *our_pubkey)?;
                 if boltz_sub_script.hashlock != preimage.hash160 {
                     return Err(Error::Protocol(format!(
@@ -904,7 +894,6 @@ impl CreateReverseResponse {
                 boltz_rev_script.validate_address(bitcoin_chain, self.lockup_address.clone())
             }
             Chain::Liquid(liquid_chain) => {
-                let blinding_key = self.blinding_key.as_ref().unwrap();
                 let boltz_rev_script = LBtcSwapScript::reverse_from_swap_resp(self, *our_pubkey)?;
                 boltz_rev_script.validate_address(liquid_chain, self.lockup_address.clone())
             }
@@ -997,7 +986,6 @@ impl CreateChainResponse {
                 boltz_chain_script.validate_address(bitcoin_chain, details.lockup_address.clone())
             }
             Chain::Liquid(liquid_chain) => {
-                let blinding_key = details.blinding_key.as_ref().unwrap();
                 let boltz_chain_script =
                     LBtcSwapScript::chain_from_swap_resp(side, details.clone(), *our_pubkey)?;
                 boltz_chain_script.validate_address(liquid_chain, details.lockup_address.clone())

--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -1,25 +1,23 @@
-use std::{hash, str::FromStr};
-
 use bitcoin::{
     hashes::{hash160, Hash},
     hex::DisplayHex,
     key::rand::{rngs::OsRng, thread_rng, RngCore},
-    script::Script as BitcoinScript,
     secp256k1::Keypair,
     Amount, Witness, XOnlyPublicKey,
 };
 use elements::{
-    confidential::{self, Asset, AssetBlindingFactor, Value, ValueBlindingFactor},
-    hex::{FromHex, ToHex},
+    confidential::{Asset, AssetBlindingFactor, ValueBlindingFactor},
+    hex::FromHex,
     secp256k1_zkp::{
-        self, MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
+        MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
         MusigSessionId, Secp256k1, SecretKey,
     },
     sighash::{Prevouts, SighashCache},
     taproot::{LeafVersion, TapLeafHash, TaprootBuilder, TaprootSpendInfo},
     Address, AssetIssuance, BlockHash, LockTime, OutPoint, SchnorrSig, SchnorrSighashType, Script,
-    Sequence, Transaction, TxIn, TxInWitness, TxOut, TxOutSecrets, TxOutWitness,
+    Sequence, Transaction, TxIn, TxInWitness, TxOut, TxOutWitness,
 };
+use std::str::FromStr;
 
 use elements::encode::serialize;
 use elements::secp256k1_zkp::Message;
@@ -29,18 +27,17 @@ use crate::util::secrets::Preimage;
 use crate::error::Error;
 
 use super::boltz::{
-    BoltzApiClientV2, ChainClaimTxResponse, ChainSwapDetails, Cooperative, CreateReverseResponse,
-    CreateSubmarineResponse, Side, SubmarineClaimTxResponse, SwapTxKind, SwapType, ToSign,
+    BoltzApiClientV2, ChainSwapDetails, Cooperative, CreateReverseResponse,
+    CreateSubmarineResponse, Side, SwapTxKind, SwapType, ToSign,
 };
 use crate::fees::{create_tx_with_fee, Fee};
-use crate::network::{BitcoinClient, Chain, LiquidChain, LiquidClient};
+use crate::network::{Chain, LiquidChain, LiquidClient};
 use elements::bitcoin::PublicKey;
 use elements::secp256k1_zkp::Keypair as ZKKeyPair;
 use elements::{
     address::Address as EAddress,
     opcodes::all::*,
-    script::{Builder as EBuilder, Instruction, Script as EScript},
-    AddressParams,
+    script::{Builder as EBuilder, Instruction},
 };
 
 /// Liquid v2 swap script helper.
@@ -322,7 +319,7 @@ impl LBtcSwapScript {
         let secp = Secp256k1::new();
 
         // Setup Key Aggregation cache
-        let mut key_agg_cache = self.musig_keyagg_cache();
+        let key_agg_cache = self.musig_keyagg_cache();
 
         // Construct the Taproot
         let internal_key = key_agg_cache.agg_pk();
@@ -436,7 +433,7 @@ impl LBtcSwapScript {
             SwapType::ReverseSubmarine => boltz_client.get_reverse_tx(swap_id).await?.hex,
             SwapType::Submarine => boltz_client.get_submarine_tx(swap_id).await?.hex,
         };
-        if (hex.is_none()) {
+        if hex.is_none() {
             return Err(Error::Hex(
                 "No transaction hex found in boltz response".to_string(),
             ));
@@ -746,7 +743,7 @@ impl LBtcSwapTx {
                 self.swap_script.sender_pubkey.inner, //boltz key
             );
 
-            if (!boltz_partial_sig_verify) {
+            if !boltz_partial_sig_verify {
                 return Err(Error::Taproot(
                     "Unable to verify Partial Signature".to_string(),
                 ));
@@ -789,9 +786,9 @@ impl LBtcSwapTx {
         absolute_fees: u64,
         is_cooperative: bool,
     ) -> Result<Transaction, Error> {
-        let preimage_bytes = preimage
-            .bytes
-            .ok_or(Error::Protocol("No preimage provided".to_string()))?;
+        if preimage.bytes.is_none() {
+            return Err(Error::Protocol("No preimage provided".to_string()));
+        }
 
         let claim_txin = TxIn {
             sequence: Sequence::MAX,
@@ -1033,7 +1030,7 @@ impl LBtcSwapTx {
                 self.swap_script.receiver_pubkey.inner, //boltz key
             );
 
-            if (!boltz_partial_sig_verify) {
+            if !boltz_partial_sig_verify {
                 return Err(Error::Taproot(
                     "Unable to verify Partial Signature".to_string(),
                 ));
@@ -1307,29 +1304,6 @@ fn tx_size(tx: &Transaction, is_discount_ct: bool) -> usize {
         true => tx.discount_vsize(),
         false => tx.vsize(),
     }
-}
-
-fn hex_to_bytes(hex_str: &str) -> Result<Vec<u8>, Error> {
-    if hex_str.len() % 2 != 0 {
-        return Err(Error::Hex(
-            "Hex string must have an even length".to_string(),
-        ));
-    }
-    let mut bytes = Vec::new();
-    for i in (0..hex_str.len()).step_by(2) {
-        let hex_pair = &hex_str[i..i + 2];
-        match u8::from_str_radix(hex_pair, 16) {
-            Ok(byte) => bytes.push(byte),
-            Err(_) => {
-                return Err(Error::Hex(format!(
-                    "Invalid hexadecimal pair: {}",
-                    hex_pair
-                )))
-            }
-        }
-    }
-
-    Ok(bytes)
 }
 
 #[cfg(test)]

--- a/src/swaps/magic_routing.rs
+++ b/src/swaps/magic_routing.rs
@@ -10,7 +10,6 @@ use bitcoin::{
     secp256k1::{schnorr::Signature, Message},
     PublicKey,
 };
-use elements::hex::ToHex;
 use lightning_invoice::{Bolt11Invoice, RouteHintHop};
 
 const MAGIC_ROUTING_HINT_CONSTANT: u64 = 596385002596073472;
@@ -68,9 +67,9 @@ pub fn parse_bip21(uri: &str) -> Result<(String, String, bitcoin::Amount, Option
                 {
                     Ok(r) => r,
                     Err(e) => {
-                        return Err(Error::Generic(
-                            "Unable to parse amount from string".to_string(),
-                        ))
+                        return Err(Error::Generic(format!(
+                            "Unable to parse amount from string: {e}"
+                        )))
                     }
                 }
             }
@@ -92,7 +91,7 @@ pub async fn check_for_mrh(
     if let Some(route_hint) = find_magic_routing_hint(invoice)? {
         let mrh_resp = boltz_api_v2.get_mrh_bip21(invoice).await?;
 
-        let (network_found, address, amount, assetid) = parse_bip21(&mrh_resp.bip21)?;
+        let (_, address, amount, assetid) = parse_bip21(&mrh_resp.bip21)?;
         let address_hash = sha256::Hash::hash(address.as_bytes());
         let msg = Message::from_digest_slice(address_hash.as_byte_array())?;
 

--- a/src/util/lnurl.rs
+++ b/src/util/lnurl.rs
@@ -1,21 +1,13 @@
 use crate::error::Error;
 use lightning_invoice::Bolt11Invoice;
 use lnurl::lightning_address::LightningAddress;
-use lnurl::pay::LnURLPayInvoice;
 use lnurl::withdraw::WithdrawalResponse;
 use lnurl::{lnurl::LnUrl, Builder, LnUrlResponse};
-use std::cmp::max;
 use std::str::FromStr;
 
 pub fn validate_lnurl(string: &str) -> bool {
     let string = string.to_lowercase();
-    match LnUrl::from_str(&string) {
-        Ok(lnurl) => true,
-        Err(_) => match LightningAddress::from_str(&string) {
-            Ok(lightning_address) => true,
-            Err(_) => false,
-        },
-    }
+    LnUrl::from_str(&string).is_ok() || LightningAddress::from_str(&string).is_ok()
 }
 
 pub async fn fetch_invoice(address: &str, amount_msats: u64) -> Result<String, Error> {
@@ -80,7 +72,7 @@ pub async fn process_withdrawal(withdraw: &WithdrawalResponse, invoice: &str) ->
         .build_async()
         .map_err(|e| Error::Generic(e.to_string()))?;
 
-    let withdraw_result = client
+    client
         .do_withdrawal(withdraw, invoice)
         .await
         .map_err(|e| Error::HTTP(e.to_string()))?;
@@ -116,12 +108,12 @@ mod tests {
         let lnurl = "lnurl1dp68gurn8ghj7um9wfmxjcm99e3k7mf0v9cxj0m385ekvcenxc6r2c35xvukxefcv5mkvv34x5ekzd3ev56nyd3hxqurzepexejxxepnxscrvwfnv9nxzcn9xq6xyefhvgcxxcmyxymnserxfq5fns";
         let uppercase_lnurl = lnurl.to_uppercase();
         assert!(validate_lnurl(lnurl));
-        test_address(lnurl, amount_msats, "LNURL");
-        test_address(&uppercase_lnurl, amount_msats, "LNURL");
+        test_address(lnurl, amount_msats, "LNURL").await;
+        test_address(&uppercase_lnurl, amount_msats, "LNURL").await;
 
         let email_lnurl = "drunksteel17@walletofsatoshi.com";
         assert!(validate_lnurl(email_lnurl));
-        test_address(email_lnurl, amount_msats, "Lightning Address");
+        test_address(email_lnurl, amount_msats, "Lightning Address").await;
     }
 
     #[ignore = "Requires using an new lnurl-w voucher and invoice to match the max_withdrawble amount"]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,18 +1,11 @@
-use std::{env, str::FromStr, sync::Once};
-
-use bitcoin::amount;
-use elements::{encode::Decodable, hex::ToHex};
-use lightning_invoice::{Bolt11Invoice, RouteHintHop};
-
-use crate::error::Error;
-
 pub mod ec;
 pub mod fees;
 #[cfg(feature = "lnurl")]
 pub mod lnurl;
 pub mod secrets;
 
-static INIT: Once = Once::new();
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+static INIT: std::sync::Once = std::sync::Once::new();
 
 /// Setup function that will only run once, even if called multiple times.
 pub fn setup_logger() {

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -104,12 +104,10 @@ impl AsRef<Client> for BtcTestFramework {
     }
 }
 
-#[allow(unused)]
 pub struct LbtcTestFramework {
     elementsd: ElementsD,
 }
 
-#[allow(unused)]
 impl LbtcTestFramework {
     pub fn init() -> Self {
         let mut conf = elementsd::Conf::default();

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use bitcoin::base64;
 use bitcoin::base64::Engine;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]


### PR DESCRIPTION
This PR removes the `#![allow(unused)]` from `lib.rs` and addresses all the resulting warnings.