### PR TITLE
ci: use regtest compose profile

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,8 @@ jobs:
         run: cargo install wasm-pack
       - name: Start regtest environment
         working-directory: regtest
+        env:
+          COMPOSE_PROFILES: ci, esplora
         run: sh start.sh
       - name: Run cargo regtest tests
         run: make cargo-regtest-test


### PR DESCRIPTION
removes containers which arent needed for CI, e.g. block explorer UIs.
