### PR TITLE
Allow passing custom reqwest client on Esplora initialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub use elements;
 pub use lightning_invoice;
 #[cfg(feature = "lnurl")]
 pub use lnurl;
+pub use reqwest;
 
 // Re-export relevant structs under boltz_client::StructName for simplicity
 pub use bitcoin::{

--- a/src/network/esplora.rs
+++ b/src/network/esplora.rs
@@ -26,8 +26,15 @@ pub struct EsploraBitcoinClient {
 
 impl EsploraBitcoinClient {
     pub fn new(network: BitcoinChain, url: &str, timeout: u64) -> Self {
-        let client = reqwest::Client::new();
+        Self::with_client(reqwest::Client::new(), network, url, timeout)
+    }
 
+    pub fn with_client(
+        client: reqwest::Client,
+        network: BitcoinChain,
+        url: &str,
+        timeout: u64,
+    ) -> Self {
         Self {
             client,
             base_url: url.to_string(),
@@ -171,8 +178,15 @@ pub struct EsploraLiquidClient {
 
 impl EsploraLiquidClient {
     pub fn new(network: LiquidChain, url: &str, timeout: u64) -> Self {
-        let client = reqwest::Client::new();
+        Self::with_client(reqwest::Client::new(), network, url, timeout)
+    }
 
+    pub fn with_client(
+        client: reqwest::Client,
+        network: LiquidChain,
+        url: &str,
+        timeout: u64,
+    ) -> Self {
         Self {
             client,
             base_url: url.to_string(),


### PR DESCRIPTION
This PR:
- Allows the caller to pass a custom reqwest client via a new `with_client` method
- Exposes the `reqwest` crate to the user to avoid version conflicts