### PR TITLE
Refactor to named parameters for format! macro

### DIFF
--- a/src/network/electrum.rs
+++ b/src/network/electrum.rs
@@ -28,9 +28,9 @@ impl ElectrumUrl {
         let builder = builder.timeout(Some(timeout));
         let (url, builder) = match self {
             ElectrumUrl::Tls(url, validate) => {
-                (format!("ssl://{}", url), builder.validate_domain(*validate))
+                (format!("ssl://{url}"), builder.validate_domain(*validate))
             }
-            ElectrumUrl::Plaintext(url) => (format!("tcp://{}", url), builder),
+            ElectrumUrl::Plaintext(url) => (format!("tcp://{url}"), builder),
         };
         Ok(electrum_client::Client::from_config(&url, builder.build())?)
     }
@@ -291,7 +291,7 @@ mod tests {
         let electrum_client = ElectrumLiquidClient::default(LiquidChain::Liquid, None).unwrap();
         let numblocks = "blockchain.numblocks.subscribe";
         let blockheight = electrum_client.inner.raw_call(numblocks, []).unwrap();
-        println!("blockheight: {}", blockheight);
+        println!("blockheight: {blockheight}");
     }
 
     #[test]

--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -345,8 +345,7 @@ impl BtcSwapScript {
 
             if lockup_xonly_pubkey != claim_key.to_inner() {
                 return Err(Error::Protocol(format!(
-                    "Taproot construction Failed. Lockup Pubkey: {}, Claim Pubkey {}",
-                    lockup_xonly_pubkey, claim_key
+                    "Taproot construction Failed. Lockup Pubkey: {lockup_xonly_pubkey}, Claim Pubkey {claim_key}"
                 )));
             }
 

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -52,14 +52,12 @@ pub struct HeightResponse {
 fn check_limits_within(maximal: u64, minimal: u64, output_amount: u64) -> Result<(), Error> {
     if output_amount < minimal {
         return Err(Error::Protocol(format!(
-            "Output amount is below minimum {}",
-            minimal
+            "Output amount is below minimum {minimal}"
         )));
     }
     if output_amount > maximal {
         return Err(Error::Protocol(format!(
-            "Output amount is above maximum {}",
-            maximal
+            "Output amount is above maximum {maximal}"
         )));
     }
     Ok(())
@@ -375,7 +373,7 @@ impl BoltzApiClientV2 {
         match req_builder.send().await {
             Ok(r) => {
                 if r.status().is_success() {
-                    log::debug!("POST response: {:#?}", r);
+                    log::debug!("POST response: {r:#?}");
                     Ok(r.text().await?)
                 } else {
                     log::error!("POST error: HTTP {}", r.status());
@@ -386,7 +384,7 @@ impl BoltzApiClientV2 {
                 }
             }
             Err(e) => {
-                log::error!("POST error: {:#?}", e);
+                log::error!("POST error: {e:#?}");
                 Err(e.into())
             }
         }
@@ -450,7 +448,7 @@ impl BoltzApiClientV2 {
         &self,
         id: &String,
     ) -> Result<SubmarineClaimTxResponse, Error> {
-        let endpoint = format!("swap/submarine/{}/claim", id);
+        let endpoint = format!("swap/submarine/{id}/claim");
         Ok(serde_json::from_str(&self.get(&endpoint).await?)?)
     }
 
@@ -458,7 +456,7 @@ impl BoltzApiClientV2 {
         &self,
         id: &String,
     ) -> Result<ChainClaimTxResponse, Error> {
-        let endpoint = format!("swap/chain/{}/claim", id);
+        let endpoint = format!("swap/chain/{id}/claim");
         Ok(serde_json::from_str(&self.get(&endpoint).await?)?)
     }
 
@@ -474,7 +472,7 @@ impl BoltzApiClientV2 {
                 "partialSignature": partial_sig.serialize().to_lower_hex_string()
             }
         );
-        let endpoint = format!("swap/submarine/{}/claim", id);
+        let endpoint = format!("swap/submarine/{id}/claim");
         Ok(serde_json::from_str(&self.post(&endpoint, data).await?)?)
     }
 
@@ -496,22 +494,20 @@ impl BoltzApiClientV2 {
                 "toSign": to_sign,
             }
         );
-        let endpoint = format!("swap/chain/{}/claim", id);
+        let endpoint = format!("swap/chain/{id}/claim");
         Ok(serde_json::from_str(&self.post(&endpoint, data).await?)?)
     }
 
     pub async fn get_reverse_tx(&self, id: &str) -> Result<ReverseSwapTxResp, Error> {
         Ok(serde_json::from_str(
-            &self
-                .get(&format!("swap/reverse/{}/transaction", id))
-                .await?,
+            &self.get(&format!("swap/reverse/{id}/transaction")).await?,
         )?)
     }
 
     pub async fn get_submarine_tx(&self, id: &str) -> Result<SubmarineSwapTxResp, Error> {
         Ok(serde_json::from_str(
             &self
-                .get(&format!("swap/submarine/{}/transaction", id))
+                .get(&format!("swap/submarine/{id}/transaction"))
                 .await?,
         )?)
     }
@@ -521,13 +517,13 @@ impl BoltzApiClientV2 {
         id: &str,
     ) -> Result<SubmarineSwapPreimageResp, Error> {
         Ok(serde_json::from_str(
-            &self.get(&format!("swap/submarine/{}/preimage", id)).await?,
+            &self.get(&format!("swap/submarine/{id}/preimage")).await?,
         )?)
     }
 
     pub async fn get_chain_txs(&self, id: &str) -> Result<ChainSwapTxResp, Error> {
         Ok(serde_json::from_str(
-            &self.get(&format!("swap/chain/{}/transactions", id)).await?,
+            &self.get(&format!("swap/chain/{id}/transactions")).await?,
         )?)
     }
 
@@ -547,7 +543,7 @@ impl BoltzApiClientV2 {
             }
         );
 
-        let endpoint = format!("swap/reverse/{}/claim", id);
+        let endpoint = format!("swap/reverse/{id}/claim");
         Ok(serde_json::from_str(&self.post(&endpoint, data).await?)?)
     }
 
@@ -566,7 +562,7 @@ impl BoltzApiClientV2 {
             }
         );
 
-        let endpoint = format!("swap/submarine/{}/refund", id);
+        let endpoint = format!("swap/submarine/{id}/refund");
         Ok(serde_json::from_str(&self.post(&endpoint, data).await?)?)
     }
 
@@ -585,12 +581,12 @@ impl BoltzApiClientV2 {
             }
         );
 
-        let endpoint = format!("swap/chain/{}/refund", id);
+        let endpoint = format!("swap/chain/{id}/refund");
         Ok(serde_json::from_str(&self.post(&endpoint, data).await?)?)
     }
 
     pub async fn get_mrh_bip21(&self, invoice: &str) -> Result<MrhResponse, Error> {
-        let request = format!("swap/reverse/{}/bip21", invoice);
+        let request = format!("swap/reverse/{invoice}/bip21");
         Ok(serde_json::from_str(&self.get(&request).await?)?)
     }
 
@@ -606,7 +602,7 @@ impl BoltzApiClientV2 {
             Chain::Liquid(_) => "L-BTC",
         };
 
-        let end_point = format!("chain/{}/transaction", chain);
+        let end_point = format!("chain/{chain}/transaction");
         Ok(serde_json::from_str(&self.post(&end_point, data).await?)?)
     }
 
@@ -1211,7 +1207,7 @@ impl Display for SubSwapStates {
             SubSwapStates::TransactionLockupFailed => "transaction.lockupFailed".to_string(),
             SubSwapStates::SwapExpired => "swap.expired".to_string(),
         };
-        write!(f, "{}", str)
+        write!(f, "{str}")
     }
 }
 
@@ -1296,7 +1292,7 @@ impl Display for RevSwapStates {
             RevSwapStates::TransactionFailed => "transaction.failed".to_string(),
             RevSwapStates::TransactionRefunded => "transaction.refunded".to_string(),
         };
-        write!(f, "{}", str)
+        write!(f, "{str}")
     }
 }
 
@@ -1380,7 +1376,7 @@ impl Display for ChainSwapStates {
             ChainSwapStates::TransactionFailed => "transaction.failed".to_string(),
             ChainSwapStates::TransactionRefunded => "transaction.refunded".to_string(),
         };
-        write!(f, "{}", str)
+        write!(f, "{str}")
     }
 }
 

--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -353,8 +353,7 @@ impl LBtcSwapScript {
 
             if lockup_xonly_pubkey != claim_key.into_inner() {
                 return Err(Error::Protocol(format!(
-                    "Taproot construction Failed. Lockup Pubkey: {}, Claim Pubkey {:?}",
-                    lockup_xonly_pubkey, claim_key
+                    "Taproot construction Failed. Lockup Pubkey: {lockup_xonly_pubkey}, Claim Pubkey {claim_key:?}"
                 )));
             }
 

--- a/src/swaps/status_stream.rs
+++ b/src/swaps/status_stream.rs
@@ -143,8 +143,7 @@ impl BoltzWsApi {
             Ok(_) => Ok(()),
             Err(e) => {
                 info!(
-                    "Failed to subscribe to swap {}, forcing reconnect and trying again: {:?}",
-                    swap_id, e
+                    "Failed to subscribe to swap {swap_id}, forcing reconnect and trying again: {e:?}"
                 );
                 self.reconnect().await?;
                 self.try_subscribe(swap_id).await
@@ -164,8 +163,7 @@ impl BoltzWsApi {
             .await
             .map_err(|e| {
                 Error::Generic(format!(
-                    "Failed to send subscription request to channel: {:?}",
-                    e
+                    "Failed to send subscription request to channel: {e:?}"
                 ))
             })?;
 
@@ -196,7 +194,7 @@ impl BoltzWsApi {
                         match connection.subscribe(ids.iter().cloned().collect()).await {
                             Ok(_) => {}
                             Err(e) => {
-                                error!("Error subscribing to swaps: {:?}", e);
+                                error!("Error subscribing to swaps: {e:?}");
                                 sleep(self.config.reconnect_delay).await;
                                 continue;
                             }
@@ -259,7 +257,7 @@ impl BoltzWsApi {
                                             Ok(WsResponse::Update(update)) => {
                                                 for update in update.args {
                                                     if let Err(e) = self.update_notifier.send(update) {
-                                                        warn!("Failed to broadcast update: {}", e);
+                                                        warn!("Failed to broadcast update: {e}");
                                                     }
                                                 }
                                             }
@@ -289,7 +287,7 @@ impl BoltzWsApi {
                     }
                 }
                 Err(e) => {
-                    error!("Error connecting to websocket: {:?}", e);
+                    error!("Error connecting to websocket: {e:?}");
                     sleep(self.config.reconnect_delay).await;
                 }
             }

--- a/src/util/lnurl.rs
+++ b/src/util/lnurl.rs
@@ -94,7 +94,7 @@ mod tests {
                     invoice.starts_with("lnbc"),
                     "Invoice should start with 'lnbc'"
                 );
-                println!("Successfully fetched invoice, format : {}", format)
+                println!("Successfully fetched invoice, format : {format}")
             }
             Err(e) => {
                 println!("Error occured with {} format: {}", format, e.message());
@@ -125,7 +125,7 @@ mod tests {
         let withdraw_response = match create_withdraw_response(voucher).await {
             Ok(response) => response,
             Err(e) => {
-                println!("Failed to create withdraw response: {:?}", e);
+                println!("Failed to create withdraw response: {e:?}");
                 return;
             }
         };
@@ -133,7 +133,7 @@ mod tests {
         let invoice_amount = match Bolt11Invoice::from_str(invoice) {
             Ok(invoice) => invoice.amount_milli_satoshis(),
             Err(e) => {
-                println!("Failed to parse invoice: {:?}", e);
+                println!("Failed to parse invoice: {e:?}");
                 return;
             }
         };
@@ -145,10 +145,7 @@ mod tests {
             invoice_amount,
             withdraw_response.max_withdrawable
         );
-        println!(
-            "Successfully created withdraw response{:?}",
-            withdraw_response
-        );
+        println!("Successfully created withdraw response{withdraw_response:?}");
         let result = process_withdrawal(&withdraw_response, invoice).await;
 
         assert!(result.is_ok(), "Withdrawal failed: {:?}", result.err());

--- a/src/util/secrets.rs
+++ b/src/util/secrets.rs
@@ -56,10 +56,8 @@ impl SwapKey {
             Chain::Liquid(LiquidChain::Liquid) => LIQUID_NETWORK_PATH,
             _ => TESTNET_NETWORK_PATH,
         };
-        let derivation_path = format!(
-            "m/{}h/{}h/{}h/0/{}",
-            purpose, network_path, SUBMARINE_SWAP_ACCOUNT, index
-        );
+        let derivation_path =
+            format!("m/{purpose}h/{network_path}h/{SUBMARINE_SWAP_ACCOUNT}h/0/{index}");
         let path = DerivationPath::from_str(&derivation_path)?;
         let child_xprv = root.derive_priv(&secp, &path)?;
 
@@ -92,10 +90,8 @@ impl SwapKey {
             _ => TESTNET_NETWORK_PATH,
         };
         // m/84h/1h/42h/<0;1>/*  - child key for segwit wallet - xprv
-        let derivation_path = format!(
-            "m/{}h/{}h/{}h/0/{}",
-            purpose, network_path, REVERSE_SWAP_ACCOUNT, index
-        );
+        let derivation_path =
+            format!("m/{purpose}h/{network_path}h/{REVERSE_SWAP_ACCOUNT}h/0/{index}");
         let path = DerivationPath::from_str(&derivation_path)?;
         let child_xprv = root.derive_priv(&secp, &path)?;
 
@@ -127,10 +123,8 @@ impl SwapKey {
             _ => TESTNET_NETWORK_PATH,
         };
         // m/84h/1h/42h/<0;1>/*  - child key for segwit wallet - xprv
-        let derivation_path = format!(
-            "m/{}h/{}h/{}h/0/{}",
-            purpose, network_path, CHAIN_SWAP_ACCOUNT, index
-        );
+        let derivation_path =
+            format!("m/{purpose}h/{network_path}h/{CHAIN_SWAP_ACCOUNT}h/0/{index}");
         let path = DerivationPath::from_str(&derivation_path)?;
         let child_xprv = root.derive_priv(&secp, &path)?;
 
@@ -295,7 +289,7 @@ impl RefundSwapFile {
         full_path.push(self.file_name());
         let mut file = File::create(&full_path)?;
         let json = serde_json::to_string_pretty(self)?;
-        writeln!(file, "{}", json)?;
+        writeln!(file, "{json}")?;
         Ok(())
     }
     pub fn read_from_file<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
@@ -326,7 +320,7 @@ mod tests {
             Ok(t) => t,
             Err(e) => {
                 // Conversion failed, handle the error
-                return println!("Error converting to LiquidSwapKey: {:?}", e);
+                return println!("Error converting to LiquidSwapKey: {e:?}");
             }
         };
         assert_eq!(sk.fingerprint, lsk.fingerprint);

--- a/tests/regtest/bitcoin.rs
+++ b/tests/regtest/bitcoin.rs
@@ -94,12 +94,12 @@ async fn bitcoin_v2_submarine<BC: BitcoinClient>(bitcoin_client: &BC, underpay: 
 
     log::info!("Got Swap Response from Boltz server");
 
-    log::debug!("Swap Response: {:?}", create_swap_response);
+    log::debug!("Swap Response: {create_swap_response:?}");
 
     let swap_script =
         BtcSwapScript::submarine_from_swap_resp(&create_swap_response, refund_public_key).unwrap();
     let swap_id = create_swap_response.id.clone();
-    log::debug!("Created Swap Script. : {:?}", swap_script);
+    log::debug!("Created Swap Script. : {swap_script:#?}");
 
     let mut rx = ws_api.updates();
     ws_api.subscribe(&swap_id).await.unwrap();
@@ -143,7 +143,7 @@ async fn bitcoin_v2_submarine<BC: BitcoinClient>(bitcoin_client: &BC, underpay: 
                     .await
                     .unwrap();
 
-                log::debug!("Received claim tx details : {:?}", claim_tx_response);
+                log::debug!("Received claim tx details : {claim_tx_response:#?}");
 
                 // Check that boltz have the correct preimage.
                 // At this stage the client should verify that LN invoice has been paid.
@@ -203,7 +203,7 @@ async fn bitcoin_v2_submarine<BC: BitcoinClient>(bitcoin_client: &BC, underpay: 
                     .unwrap();
 
                 let txid = swap_tx.broadcast(&tx, bitcoin_client).await.unwrap();
-                log::info!("Cooperative Refund Successfully broadcasted: {}", txid);
+                log::info!("Cooperative Refund Successfully broadcasted: {txid}");
 
                 // Non cooperative refund requires expired swap
                 /*log::info!("Cooperative refund failed. {:?}", e);
@@ -287,7 +287,7 @@ async fn bitcoin_v2_reverse<BC: BitcoinClient>(bitcoin_client: BC) {
         .unwrap()
         .unwrap();
 
-    log::debug!("Got Reverse swap response: {:?}", reverse_resp);
+    log::debug!("Got Reverse swap response: {reverse_resp:#?}");
 
     let swap_script =
         BtcSwapScript::reverse_from_swap_resp(&reverse_resp, claim_public_key).unwrap();
@@ -342,7 +342,7 @@ async fn bitcoin_v2_reverse<BC: BitcoinClient>(bitcoin_client: BC) {
                 claim_tx.broadcast(&tx, &bitcoin_client).await.unwrap();
 
                 log::info!("Successfully broadcasted claim tx!");
-                log::debug!("Claim Tx {:?}", tx);
+                log::debug!("Claim Tx {tx:?}");
             }
 
             "invoice.settled" => {
@@ -416,7 +416,7 @@ async fn bitcoin_v2_reverse_script_path<BC: BitcoinClient>(bitcoin_client: BC) {
         .unwrap()
         .unwrap();
 
-    log::debug!("Got Reverse swap response: {:?}", reverse_resp);
+    log::debug!("Got Reverse swap response: {reverse_resp:#?}");
 
     let swap_script =
         BtcSwapScript::reverse_from_swap_resp(&reverse_resp, claim_public_key).unwrap();
@@ -459,7 +459,7 @@ async fn bitcoin_v2_reverse_script_path<BC: BitcoinClient>(bitcoin_client: BC) {
                 claim_tx.broadcast(&tx, &bitcoin_client).await.unwrap();
 
                 log::info!("Successfully broadcasted claim tx!");
-                log::debug!("Claim Tx {:?}", tx);
+                log::debug!("Claim Tx {tx:?}");
             }
 
             "invoice.settled" => {

--- a/tests/regtest/chain_swaps.rs
+++ b/tests/regtest/chain_swaps.rs
@@ -58,7 +58,7 @@ async fn bitcoin_liquid_v2_chain<BC: BitcoinClient, LC: LiquidClient>(
     let network = BITCOIN_CHAIN;
     let secp = Secp256k1::new();
     let preimage = Preimage::new();
-    log::info!("{:#?}", preimage);
+    log::info!("{preimage:#?}");
     let our_claim_keys = Keypair::new(&secp, &mut thread_rng());
     let claim_public_key = PublicKey {
         compressed: true,
@@ -98,7 +98,7 @@ async fn bitcoin_liquid_v2_chain<BC: BitcoinClient, LC: LiquidClient>(
         refund_public_key,
     )
     .unwrap();
-    log::debug!("Lockup Script: {:#?}", lockup_script);
+    log::debug!("Lockup Script: {lockup_script:#?}");
     log::debug!(
         "Lockup Sender Pubkey: {:#?}",
         lockup_script.sender_pubkey.to_string()
@@ -123,11 +123,11 @@ async fn bitcoin_liquid_v2_chain<BC: BitcoinClient, LC: LiquidClient>(
 
     let claim_address = utils::generate_address_elementsd().await.unwrap();
     let lq_address = EAddress::from_str(&claim_address).unwrap();
-    log::debug!("{:#?}", lq_address);
+    log::debug!("{lq_address:#?}");
     // let claim_address = claim_script.to_address(network).unwrap();
     // assert_eq!(claim_address.to_string(), claim_details.claim_address.unwrap());
     let liquid_genesis_hash = liquid_client.get_genesis_hash().await.unwrap();
-    log::debug!("{:#?}", liquid_genesis_hash);
+    log::debug!("{liquid_genesis_hash:#?}");
 
     let ws_api = Arc::new(boltz_api_v2.ws(BoltzWsConfig::default()));
     utils::start_ws(ws_api.clone());
@@ -144,7 +144,7 @@ async fn bitcoin_liquid_v2_chain<BC: BitcoinClient, LC: LiquidClient>(
                 };
                 let address = create_chain_response.lockup_details.clone().lockup_address;
 
-                log::info!("Sending {} sats to BTC address {}", amount, address);
+                log::info!("Sending {amount} sats to BTC address {address}");
 
                 utils::send_to_address_bitcoind(&address, amount)
                     .await
@@ -284,7 +284,7 @@ async fn refund_bitcoin_liquid_v2_chain<BC: BitcoinClient>(
     refund_tx.broadcast(&tx, bitcoin_client).await.unwrap();
 
     log::info!("Successfully broadcasted refund tx!");
-    log::debug!("Refund Tx {:?}", tx);
+    log::debug!("Refund Tx {tx:#?}");
 }
 
 #[macros::async_test]
@@ -317,7 +317,7 @@ async fn liquid_bitcoin_v2_chain<BC: BitcoinClient, LC: LiquidClient>(
     let network = LIQUID_CHAIN;
     let secp = Secp256k1::new();
     let preimage = Preimage::new();
-    log::info!("{:#?}", preimage);
+    log::info!("{preimage:#?}");
     let our_claim_keys = Keypair::new(&secp, &mut thread_rng());
     let claim_public_key = PublicKey {
         compressed: true,
@@ -357,7 +357,7 @@ async fn liquid_bitcoin_v2_chain<BC: BitcoinClient, LC: LiquidClient>(
         refund_public_key,
     )
     .unwrap();
-    log::debug!("Lockup Script: {:#?}", lockup_script);
+    log::debug!("Lockup Script: {lockup_script:#?}");
     log::debug!(
         "Lockup Sender Pubkey: {:#?}",
         lockup_script.sender_pubkey.to_string()
@@ -401,7 +401,7 @@ async fn liquid_bitcoin_v2_chain<BC: BitcoinClient, LC: LiquidClient>(
                 };
                 let address = create_chain_response.lockup_details.clone().lockup_address;
 
-                log::info!("Sending {} sats to L-BTC address {}", amount, address);
+                log::info!("Sending {amount} sats to L-BTC address {address}");
 
                 utils::send_to_address_elementsd(&address, amount)
                     .await
@@ -502,7 +502,7 @@ async fn liquid_bitcoin_v2_chain<BC: BitcoinClient, LC: LiquidClient>(
                 refund_tx.broadcast(&tx, liquid_client, None).await.unwrap();
 
                 log::info!("Successfully broadcasted claim tx!");
-                log::debug!("Claim Tx {:?}", tx);
+                log::debug!("Claim Tx {tx:#?}");
                 break;
             }
             _ => {

--- a/tests/regtest/liquid.rs
+++ b/tests/regtest/liquid.rs
@@ -96,7 +96,7 @@ async fn liquid_v2_submarine<LC: LiquidClient>(liquid_client: &LC, underpay: boo
         .unwrap();
     log::info!("VALIDATED RESPONSE!");
 
-    log::debug!("Swap Response: {:?}", create_swap_response);
+    log::debug!("Swap Response: {create_swap_response:#?}");
 
     let swap_id = create_swap_response.id.clone();
 
@@ -104,7 +104,7 @@ async fn liquid_v2_submarine<LC: LiquidClient>(liquid_client: &LC, underpay: boo
         LBtcSwapScript::submarine_from_swap_resp(&create_swap_response, refund_public_key).unwrap();
     swap_script.to_address(chain).unwrap();
 
-    log::debug!("Created Swap Script. : {:?}", swap_script);
+    log::debug!("Created Swap Script. : {swap_script:#?}");
 
     let ws_api = Arc::new(boltz_api_v2.ws(BoltzWsConfig::default()));
     utils::start_ws(ws_api.clone());
@@ -151,7 +151,7 @@ async fn liquid_v2_submarine<LC: LiquidClient>(liquid_client: &LC, underpay: boo
                     .await
                     .unwrap();
 
-                log::debug!("Received claim tx details : {:?}", claim_tx_response);
+                log::debug!("Received claim tx details : {claim_tx_response:#?}");
 
                 // Check that boltz have the correct preimage.
                 // At this stage the client should verify that LN invoice has been paid.
@@ -210,7 +210,7 @@ async fn liquid_v2_submarine<LC: LiquidClient>(liquid_client: &LC, underpay: boo
                     .unwrap();
 
                 let txid = swap_tx.broadcast(&tx, liquid_client, None).await.unwrap();
-                log::info!("Cooperative Refund Successfully broadcasted: {}", txid);
+                log::info!("Cooperative Refund Successfully broadcasted: {txid}");
                 break;
             }
 
@@ -293,7 +293,7 @@ async fn liquid_v2_reverse<LC: LiquidClient>(liquid_client: &LC, lowball: bool) 
         .unwrap()
         .unwrap();
 
-    log::debug!("Got Reverse swap response: {:?}", reverse_resp);
+    log::debug!("Got Reverse swap response: {reverse_resp:#?}");
 
     let swap_script =
         LBtcSwapScript::reverse_from_swap_resp(&reverse_resp, claim_public_key).unwrap();
@@ -361,7 +361,7 @@ async fn liquid_v2_reverse<LC: LiquidClient>(liquid_client: &LC, lowball: bool) 
                         log::info!("Successfully broadcasted claim tx!");
                     }
                 }
-                log::debug!("Claim Tx {:?}", tx);
+                log::debug!("Claim Tx {tx:#?}");
             }
 
             "invoice.settled" => {
@@ -443,7 +443,7 @@ async fn liquid_v2_reverse_script_path<LC: LiquidClient>(liquid_client: &LC, low
         .unwrap()
         .unwrap();
 
-    log::debug!("Got Reverse swap response: {:?}", reverse_resp);
+    log::debug!("Got Reverse swap response: {reverse_resp:#?}");
 
     let swap_script =
         LBtcSwapScript::reverse_from_swap_resp(&reverse_resp, claim_public_key).unwrap();
@@ -499,7 +499,7 @@ async fn liquid_v2_reverse_script_path<LC: LiquidClient>(liquid_client: &LC, low
                         log::info!("Successfully broadcasted claim tx!");
                     }
                 }
-                log::debug!("Claim Tx {:?}", tx);
+                log::debug!("Claim Tx {tx:#?}");
             }
 
             "invoice.settled" => {

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -180,7 +180,7 @@ impl LbtcTestFramework {
     }
 
     pub fn fetch_utxo(&self, addrs: &EAddress) -> Option<(elements::OutPoint, elements::TxOut)> {
-        let scan_request = ScanTxOutRequest::Single(format!("addr({})", addrs));
+        let scan_request = ScanTxOutRequest::Single(format!("addr({addrs})"));
 
         let scan_reqs = [scan_request];
 

--- a/tests/txs.rs
+++ b/tests/txs.rs
@@ -60,11 +60,11 @@ fn prepare_btc_claim() -> (
         .to_address(BitcoinChain::BitcoinRegtest)
         .unwrap();
     let spk = swap_addrs.script_pubkey();
-    println!("spk: {}", spk);
+    println!("spk: {spk}");
     test_framework.send_coins(&swap_addrs, Amount::from_sat(FUNDING_AMOUNT));
     test_framework.generate_blocks(1);
 
-    let scan_request = ScanTxOutRequest::Single(format!("addr({})", swap_addrs));
+    let scan_request = ScanTxOutRequest::Single(format!("addr({swap_addrs})"));
 
     let scan_result = test_framework
         .as_ref()
@@ -239,7 +239,7 @@ fn prepare_btc_refund() -> (
     test_framework.send_coins(&swap_addrs, Amount::from_sat(10000));
     test_framework.generate_blocks(1);
 
-    let scan_request = ScanTxOutRequest::Single(format!("addr({})", swap_addrs));
+    let scan_request = ScanTxOutRequest::Single(format!("addr({swap_addrs})"));
 
     let scan_result = test_framework
         .as_ref()

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -56,7 +56,7 @@ async fn json_rpc_request(
 
 async fn lnd_request(method: &str, params: Value) -> Result<Value, Box<dyn Error>> {
     let client = Client::new();
-    let url = format!("{}/{}", LND_URL, method);
+    let url = format!("{LND_URL}/{method}");
 
     let res = client
         .post(PROXY_URL)
@@ -80,7 +80,7 @@ pub async fn generate_address_bitcoind() -> Result<String, Box<dyn Error>> {
     )
     .await?;
 
-    println!("Bitcoind response: {:?}", response); // Debug output
+    println!("Bitcoind response: {response:?}"); // Debug output
 
     response
         .as_str()


### PR DESCRIPTION
Latest version of clippy in the nightly channel complains when you don't use named parameters for the `format!` macro

That feature is available since [Rust 1.58](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0/) which was released as stable in 2022 so using it should be fine