### PR TITLE
refactor: remove `SwapTx` wrapper

### DIFF
--- a/src/swaps/wrappers.rs
+++ b/src/swaps/wrappers.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use super::boltz::{
     BoltzApiClientV2, ChainSwapDetails, Cooperative, CreateReverseResponse,
-    CreateSubmarineResponse, Side, SwapType,
+    CreateSubmarineResponse, Side, SwapTxKind, SwapType,
 };
 use crate::error::Error;
 use crate::network::{BitcoinClient, Chain, LiquidClient};
@@ -21,16 +21,42 @@ use crate::swaps::liquid::{LBtcSwapScript, LBtcSwapTx};
 use crate::util::fees::Fee;
 use crate::util::secrets::Preimage;
 
-/// Options for signing swap transactions
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
+struct ChainClaim {
+    refund_keys: Keypair,
+    lockup_script: SwapScript,
+}
+
+#[derive(Clone, Debug)]
 pub struct TransactionOptions {
-    /// Whether to use discount confidential transactions for Liquid swaps
-    pub is_discount_ct: bool,
+    cooperative: bool,
+    chain_claim: Option<ChainClaim>,
+}
+
+impl Default for TransactionOptions {
+    fn default() -> Self {
+        Self {
+            cooperative: true,
+            chain_claim: None,
+        }
+    }
 }
 
 impl TransactionOptions {
-    pub fn with_discount_ct(mut self) -> Self {
-        self.is_discount_ct = true;
+    /// Whether a cooperative claim with boltz should be attempted
+    pub fn with_cooperative(mut self, cooperative: bool) -> Self {
+        self.cooperative = cooperative;
+        self
+    }
+
+    /// For a cooperative claim of a chain swap, the refund keys and lockup script of the swap have to be provided
+    /// Calling this function will implicitly set cooperative to true
+    pub fn with_chain_claim(mut self, refund_keys: Keypair, lockup_script: SwapScript) -> Self {
+        self.cooperative = true;
+        self.chain_claim = Some(ChainClaim {
+            refund_keys,
+            lockup_script,
+        });
         self
     }
 }
@@ -145,6 +171,16 @@ pub trait SwapScriptCommon {
 pub enum SwapScript {
     Bitcoin(Arc<BtcSwapScript>),
     Liquid(Arc<LBtcSwapScript>),
+}
+
+pub struct SwapTransactionParams<'a> {
+    pub keys: Keypair,
+    pub output_address: String,
+    pub fee: Fee,
+    pub swap_id: String,
+    pub client: &'a Client,
+    pub boltz_client: &'a BoltzApiClientV2,
+    pub options: Option<TransactionOptions>,
 }
 
 impl SwapScript {
@@ -293,135 +329,121 @@ impl SwapScript {
             partial_sig: Some(partial_sig),
         })
     }
-}
 
-/// A wrapper for swap transactions that can be either Bitcoin or Liquid
-#[derive(Clone, Debug)]
-pub enum SwapTx {
-    Bitcoin(Arc<BtcSwapTx>),
-    Liquid(Arc<LBtcSwapTx>),
-}
-
-impl SwapTx {
-    pub fn bitcoin(tx: BtcSwapTx) -> Self {
-        Self::Bitcoin(Arc::new(tx))
-    }
-
-    pub fn liquid(tx: LBtcSwapTx) -> Self {
-        Self::Liquid(Arc::new(tx))
-    }
-
-    pub async fn sign_refund(
+    async fn get_cooperative<'a>(
         &self,
-        keys: &Keypair,
-        fee: Fee,
-        is_cooperative: Option<Cooperative<'_>>,
+        tx_kind: SwapTxKind,
         options: Option<TransactionOptions>,
-    ) -> Result<BtcLikeTransaction, Error> {
-        match self {
-            Self::Bitcoin(tx) => {
-                let tx = tx.sign_refund(keys, fee, is_cooperative).await?;
-                Ok(BtcLikeTransaction::bitcoin(tx))
-            }
-            Self::Liquid(tx) => {
-                let is_discount_ct = options.map(|o| o.is_discount_ct).unwrap_or_default();
-                let tx = tx
-                    .sign_refund(keys, fee, is_cooperative, is_discount_ct)
-                    .await?;
-                Ok(BtcLikeTransaction::liquid(tx))
-            }
-        }
-    }
-
-    pub async fn sign_claim(
-        &self,
-        keys: &Keypair,
-        preimage: &Preimage,
-        fee: Fee,
-        is_cooperative: Option<Cooperative<'_>>,
-        options: Option<TransactionOptions>,
-    ) -> Result<BtcLikeTransaction, Error> {
-        match self {
-            Self::Bitcoin(tx) => {
-                let tx = tx.sign_claim(keys, preimage, fee, is_cooperative).await?;
-                Ok(BtcLikeTransaction::bitcoin(tx))
-            }
-            Self::Liquid(tx) => {
-                let is_discount_ct = options.map(|o| o.is_discount_ct).unwrap_or_default();
-                let tx = tx
-                    .sign_claim(keys, preimage, fee, is_cooperative, is_discount_ct)
-                    .await?;
-                Ok(BtcLikeTransaction::liquid(tx))
-            }
-        }
-    }
-
-    pub async fn new_claim(
-        swap_script: SwapScript,
-        output_address: String,
-        client: &Client,
-        boltz_client: &BoltzApiClientV2,
+        boltz_client: &'a BoltzApiClientV2,
         swap_id: String,
-    ) -> Result<Self, Error> {
-        match swap_script {
+    ) -> Result<Option<Cooperative<'a>>, Error> {
+        let o = options.unwrap_or_default();
+        match o.cooperative {
+            true => match (self.common().swap_type(), tx_kind) {
+                (SwapType::Chain, SwapTxKind::Claim) => {
+                    let claim = o.chain_claim.ok_or(Error::Generic(
+                        "Chain claim options are missing".to_string(),
+                    ))?;
+                    claim
+                        .lockup_script
+                        .cooperative_chain_claim(&claim.refund_keys, &swap_id, boltz_client)
+                        .await
+                        .map(Option::Some)
+                }
+                _ => Ok(Some(Cooperative {
+                    boltz_api: boltz_client,
+                    swap_id,
+                    pub_nonce: None,
+                    partial_sig: None,
+                })),
+            },
+            false => Ok(None),
+        }
+    }
+
+    pub async fn construct_claim(
+        &self,
+        preimage: &Preimage,
+        params: SwapTransactionParams<'_>,
+    ) -> Result<BtcLikeTransaction, Error> {
+        let cooperative = self
+            .get_cooperative(
+                SwapTxKind::Claim,
+                params.options,
+                params.boltz_client,
+                params.swap_id.clone(),
+            )
+            .await?;
+        match self {
             SwapScript::Bitcoin(script) => {
-                let btc_client = client.require_bitcoin_client()?;
                 let tx = BtcSwapTx::new_claim(
                     script.as_ref().clone(),
-                    output_address,
-                    btc_client,
-                    boltz_client,
-                    swap_id,
+                    params.output_address.clone(),
+                    params.client.require_bitcoin_client()?,
+                    params.boltz_client,
+                    params.swap_id.clone(),
                 )
                 .await?;
-                Ok(Self::bitcoin(tx))
+
+                tx.sign_claim(&params.keys, preimage, params.fee, cooperative)
+                    .await
+                    .map(BtcLikeTransaction::bitcoin)
             }
             SwapScript::Liquid(script) => {
-                let lbtc_client = client.require_liquid_client()?;
                 let tx = LBtcSwapTx::new_claim(
                     script.as_ref().clone(),
-                    output_address,
-                    lbtc_client,
-                    boltz_client,
-                    swap_id,
+                    params.output_address.clone(),
+                    params.client.require_liquid_client()?,
+                    params.boltz_client,
+                    params.swap_id.clone(),
                 )
                 .await?;
-                Ok(Self::liquid(tx))
+
+                tx.sign_claim(&params.keys, preimage, params.fee, cooperative, true)
+                    .await
+                    .map(BtcLikeTransaction::liquid)
             }
         }
     }
 
-    pub async fn new_refund(
-        swap_script: SwapScript,
-        output_address: &str,
-        client: &Client,
-        boltz_client: &BoltzApiClientV2,
-        swap_id: String,
-    ) -> Result<Self, Error> {
-        match swap_script {
+    pub async fn construct_refund(
+        &self,
+        params: SwapTransactionParams<'_>,
+    ) -> Result<BtcLikeTransaction, Error> {
+        let cooperative = self
+            .get_cooperative(
+                SwapTxKind::Refund,
+                params.options,
+                params.boltz_client,
+                params.swap_id.clone(),
+            )
+            .await?;
+        match self {
             SwapScript::Bitcoin(script) => {
-                let btc_client = client.require_bitcoin_client()?;
                 let tx = BtcSwapTx::new_refund(
                     script.as_ref().clone(),
-                    output_address,
-                    btc_client,
-                    boltz_client,
-                    swap_id,
+                    &params.output_address,
+                    params.client.require_bitcoin_client()?,
+                    params.boltz_client,
+                    params.swap_id.clone(),
                 )
                 .await?;
-                Ok(Self::bitcoin(tx))
+                tx.sign_refund(&params.keys, params.fee, cooperative)
+                    .await
+                    .map(BtcLikeTransaction::bitcoin)
             }
             SwapScript::Liquid(script) => {
-                let lbtc_client = client.require_liquid_client()?;
                 let tx = LBtcSwapTx::new_refund(
                     script.as_ref().clone(),
-                    output_address,
-                    lbtc_client,
-                    boltz_client,
-                    swap_id,
+                    &params.output_address,
+                    params.client.require_liquid_client()?,
+                    params.boltz_client,
+                    params.swap_id.clone(),
                 )
                 .await?;
-                Ok(Self::liquid(tx))
+                tx.sign_refund(&params.keys, params.fee, cooperative, true)
+                    .await
+                    .map(BtcLikeTransaction::liquid)
             }
         }
     }

--- a/src/util/fees.rs
+++ b/src/util/fees.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 
+#[derive(Copy, Debug, Clone)]
 pub enum Fee {
     // In sat/vByte
     Relative(f64),

--- a/tests/regtest/chain_swaps.rs
+++ b/tests/regtest/chain_swaps.rs
@@ -2,8 +2,7 @@ use crate::regtest::WAIT_TIME;
 use crate::utils;
 use bitcoin::{key::rand::thread_rng, PublicKey};
 use boltz_client::boltz::{
-    BoltzApiClientV2, BoltzWsConfig, ChainSwapDetails, Cooperative, CreateChainRequest, Side,
-    BOLTZ_REGTEST,
+    BoltzApiClientV2, BoltzWsConfig, ChainSwapDetails, CreateChainRequest, Side, BOLTZ_REGTEST,
 };
 use boltz_client::fees::Fee;
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
@@ -12,7 +11,7 @@ use boltz_client::network::electrum::{ElectrumBitcoinClient, ElectrumLiquidClien
 #[cfg(feature = "esplora")]
 use boltz_client::network::esplora::{EsploraBitcoinClient, EsploraLiquidClient};
 use boltz_client::network::{BitcoinChain, Chain, LiquidChain};
-use boltz_client::swaps::{Client, SwapScript, SwapTx};
+use boltz_client::swaps::{Client, SwapScript, SwapTransactionParams, TransactionOptions};
 use boltz_client::util::sleep;
 use boltz_client::{
     util::{secrets::Preimage, setup_logger},
@@ -150,26 +149,21 @@ async fn v2_chain(client: &Client, underpay: bool, from: Chain, to: Chain) {
                 sleep(WAIT_TIME).await;
                 log::info!("Claiming!");
 
-                let claim_tx = SwapTx::new_claim(
-                    claim_script.clone(),
-                    claim_address.clone(),
-                    client,
-                    &boltz_api_v2,
-                    swap_id.clone(),
-                )
-                .await
-                .unwrap();
-                let coop = lockup_script
-                    .cooperative_chain_claim(&our_refund_keys, &swap_id, &boltz_api_v2)
-                    .await
-                    .unwrap();
-                let tx = claim_tx
-                    .sign_claim(
-                        &our_claim_keys,
+                let tx = claim_script
+                    .construct_claim(
                         &preimage,
-                        Fee::Absolute(1000),
-                        Some(coop),
-                        None,
+                        SwapTransactionParams {
+                            keys: our_claim_keys,
+                            output_address: claim_address.clone(),
+                            fee: Fee::Absolute(1000),
+                            swap_id: swap_id.clone(),
+                            client,
+                            boltz_client: &boltz_api_v2,
+                            options: Some(
+                                TransactionOptions::default()
+                                    .with_chain_claim(our_refund_keys, lockup_script.clone()),
+                            ),
+                        },
                     )
                     .await
                     .unwrap();
@@ -228,27 +222,16 @@ async fn refund_v2_chain(
     absolute_fees: u64,
     client: &Client,
 ) {
-    let refund_tx = SwapTx::new_refund(
-        lockup_script.clone(),
-        &refund_address,
-        client,
-        &boltz_api_v2,
-        swap_id.clone(),
-    )
-    .await
-    .unwrap();
-    let tx = refund_tx
-        .sign_refund(
-            &our_refund_keys,
-            Fee::Absolute(absolute_fees),
-            Some(Cooperative {
-                boltz_api: &boltz_api_v2,
-                swap_id: swap_id.clone(),
-                pub_nonce: None,
-                partial_sig: None,
-            }),
-            None,
-        )
+    let tx = lockup_script
+        .construct_refund(SwapTransactionParams {
+            keys: our_refund_keys,
+            output_address: refund_address,
+            fee: Fee::Absolute(absolute_fees),
+            swap_id: swap_id.clone(),
+            client,
+            boltz_client: &boltz_api_v2,
+            options: None,
+        })
         .await
         .unwrap();
 

--- a/tests/regtest/reverse.rs
+++ b/tests/regtest/reverse.rs
@@ -3,13 +3,14 @@
 use boltz_client::network::electrum::{ElectrumBitcoinClient, ElectrumLiquidClient};
 #[cfg(feature = "esplora")]
 use boltz_client::network::esplora::{EsploraBitcoinClient, EsploraLiquidClient};
+use boltz_client::swaps::TransactionOptions;
 use boltz_client::util::sleep;
 use boltz_client::{
     network::Chain,
     swaps::{
-        boltz::{BoltzApiClientV2, Cooperative, CreateReverseRequest},
+        boltz::{BoltzApiClientV2, CreateReverseRequest},
         magic_routing::{check_for_mrh, sign_address},
-        {Client, SwapScript, SwapTx},
+        {Client, SwapScript, SwapTransactionParams},
     },
     util::{secrets::Preimage, setup_logger},
     Secp256k1,
@@ -98,32 +99,20 @@ async fn v2_reverse(client: &Client, chain: Chain, cooperative: bool) {
 
                 sleep(WAIT_TIME).await;
 
-                let claim_tx = SwapTx::new_claim(
-                    swap_script.clone(),
-                    claim_address.clone(),
-                    client,
-                    &boltz_api_v2,
-                    swap_id.clone(),
-                )
-                .await
-                .expect("Funding tx expected");
-
-                let tx = claim_tx
-                    .sign_claim(
-                        &our_keys,
+                let tx = swap_script
+                    .construct_claim(
                         &preimage,
-                        Fee::Absolute(1000),
-                        if cooperative {
-                            Some(Cooperative {
-                                boltz_api: &boltz_api_v2,
-                                swap_id: swap_id.clone(),
-                                pub_nonce: None,
-                                partial_sig: None,
-                            })
-                        } else {
-                            None
+                        SwapTransactionParams {
+                            keys: our_keys,
+                            output_address: claim_address.clone(),
+                            fee: Fee::Absolute(1000),
+                            swap_id: swap_id.clone(),
+                            client,
+                            boltz_client: &boltz_api_v2,
+                            options: Some(
+                                TransactionOptions::default().with_cooperative(cooperative),
+                            ),
                         },
-                        None,
                     )
                     .await
                     .unwrap();

--- a/tests/regtest/submarine.rs
+++ b/tests/regtest/submarine.rs
@@ -6,8 +6,8 @@ use boltz_client::network::esplora::{EsploraBitcoinClient, EsploraLiquidClient};
 use boltz_client::{
     network::Chain,
     swaps::{
-        boltz::{BoltzApiClientV2, Cooperative, CreateSubmarineRequest},
-        {Client, SwapScript, SwapTx},
+        boltz::{BoltzApiClientV2, CreateSubmarineRequest},
+        Client, SwapScript, SwapTransactionParams,
     },
     util::{setup_logger, sleep},
 };
@@ -126,28 +126,16 @@ async fn v2_submarine(client: &Client, underpay: bool, chain: Chain) {
             // the funds back via refund.
             "transaction.lockupFailed" | "invoice.failedToPay" => {
                 sleep(WAIT_TIME).await;
-                let swap_tx = SwapTx::new_refund(
-                    swap_script.clone(),
-                    &refund_address,
-                    client,
-                    &boltz_api_v2,
-                    swap_id.to_owned(),
-                )
-                .await
-                .expect("Funding UTXO not found");
-
-                let tx = swap_tx
-                    .sign_refund(
-                        &our_keys,
-                        Fee::Absolute(1000),
-                        Some(Cooperative {
-                            boltz_api: &boltz_api_v2,
-                            swap_id: swap_id.clone(),
-                            pub_nonce: None,
-                            partial_sig: None,
-                        }),
-                        None,
-                    )
+                let tx = swap_script
+                    .construct_refund(SwapTransactionParams {
+                        keys: our_keys,
+                        output_address: refund_address,
+                        fee: Fee::Absolute(1000),
+                        swap_id: swap_id.clone(),
+                        client,
+                        boltz_client: &boltz_api_v2,
+                        options: None,
+                    })
                     .await
                     .unwrap();
 


### PR DESCRIPTION
I think there's no practical use case where consumers of the library would have to seperate the respective `new` and `sign` calls for transactions.