### PR TITLE
Allow setting WebSocket protocol headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ lnurl-rs = { version = "0.9.0", default-features = false, features = ["async", "
 # Pin to commit until https://github.com/seanmonstar/reqwest/pull/1760 gets released
 reqwest = { git = "https://github.com/seanmonstar/reqwest", rev = "00b15b9a893d350388af513179e1a973dfa26f85", features = ["json"] }
 tokio = { version = "1.43.0", features = ["time"] }
-tokio-tungstenite-wasm = { version = "0.5.0", features = ["native-tls-vendored"], optional = true }
+tokio-tungstenite-wasm = { version = "0.6.0", features = ["native-tls-vendored"], optional = true }
 async-trait = "0.1.86"
 macros = { path = "macros" }
 futures-util = "0.3.31"

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -41,7 +41,7 @@ use reqwest::RequestBuilder;
 #[cfg(feature = "ws")]
 pub use tokio_tungstenite_wasm;
 #[cfg(feature = "ws")]
-use tokio_tungstenite_wasm::{connect, WebSocketStream};
+use tokio_tungstenite_wasm::{connect, connect_with_protocols, WebSocketStream};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct HeightResponse {
@@ -357,17 +357,29 @@ impl BoltzApiClientV2 {
         }
     }
 
+    /// Returns the WebSocket URL for the Boltz server
+    fn get_ws_url(&self) -> String {
+        self.base_url.clone().replace("http", "ws") + "/ws"
+    }
+
     /// Returns the web socket connection to the boltz server
     #[cfg(feature = "ws")]
     pub async fn connect_ws(&self) -> Result<WebSocketStream, Error> {
-        let ws_string = self.base_url.clone().replace("http", "ws") + "/ws";
-        Ok(connect(ws_string).await?)
+        Ok(connect(self.get_ws_url()).await?)
+    }
+
+    /// Same as `connect_ws` but with protocols
+    #[cfg(feature = "ws")]
+    pub async fn connect_ws_with_protocols(
+        &self,
+        protocols: &[&str],
+    ) -> Result<WebSocketStream, Error> {
+        Ok(connect_with_protocols(self.get_ws_url(), protocols).await?)
     }
 
     #[cfg(feature = "ws")]
     pub fn ws(&self, config: BoltzWsConfig) -> BoltzWsApi {
-        let ws_string = self.base_url.clone().replace("http", "ws") + "/ws";
-        BoltzWsApi::new(ws_string, config)
+        BoltzWsApi::new(self.get_ws_url(), config)
     }
 
     /// Make a GET request. Returns the Response

--- a/src/swaps/status_stream.rs
+++ b/src/swaps/status_stream.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc, oneshot, Mutex};
-use tokio_tungstenite_wasm::{connect, Message, WebSocketStream};
+use tokio_tungstenite_wasm::{connect, connect_with_protocols, Message, WebSocketStream};
 
 use super::boltz::{ErrorResponse, InvoiceRequest, InvoiceRequestParams, SubscribeRequest};
 
@@ -21,8 +21,12 @@ struct RequestPacket {
 }
 
 impl BoltzWsConnection {
-    async fn new(url: &str) -> Result<Self, Error> {
-        let ws = connect(url).await?;
+    async fn new(url: &str, protocols: Option<&[&str]>) -> Result<Self, Error> {
+        let ws = if let Some(protocols) = protocols {
+            connect_with_protocols(url, protocols).await?
+        } else {
+            connect(url).await?
+        };
         Ok(Self { ws })
     }
 
@@ -38,6 +42,7 @@ pub struct BoltzWsConfig {
     pub keep_alive_interval: Duration,
     pub reconnect_delay: Duration,
     pub subscription_timeout: Duration,
+    pub protocols: Option<Vec<String>>,
 }
 
 impl Default for BoltzWsConfig {
@@ -46,6 +51,7 @@ impl Default for BoltzWsConfig {
             keep_alive_interval: Duration::from_secs(15),
             reconnect_delay: Duration::from_secs(2),
             subscription_timeout: Duration::from_secs(5),
+            protocols: None,
         }
     }
 }
@@ -265,7 +271,12 @@ impl BoltzWsApi {
                 Some(((), ()))
             }));
 
-            match BoltzWsConnection::new(self.ws_url.as_str()).await {
+            let protocols = self
+                .config
+                .protocols
+                .as_ref()
+                .map(|p| p.iter().map(|s| s.as_ref()).collect::<Vec<_>>());
+            match BoltzWsConnection::new(self.ws_url.as_str(), protocols.as_deref()).await {
                 Ok(mut connection) => {
                     {
                         let subscriptions = self.subscriptions.lock().await;


### PR DESCRIPTION
This PR adds the possibility of setting WebSocket `Sec-WebSocket-Protocol` headers, which may be useful when connecting to "unofficial" boltz server instances (e.g. a proxy).