### PR TITLE
Support reconstructing chain swap claim tx

### DIFF
--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -615,8 +615,7 @@ impl BtcSwapTx {
         if let Some(Cooperative {
             boltz_api,
             swap_id,
-            pub_nonce,
-            partial_sig,
+            signature,
         }) = is_cooperative
         {
             let secp = Secp256k1::new();
@@ -660,26 +659,20 @@ impl BtcSwapTx {
             // Step 7: Get boltz's partial sig
             let claim_tx_hex = claim_tx.serialize().to_lower_hex_string();
             let partial_sig_resp = match self.swap_script.swap_type {
-                SwapType::Chain => match (pub_nonce, partial_sig) {
-                    (Some(pub_nonce), Some(partial_sig)) => {
-                        boltz_api
-                            .post_chain_claim_tx_details(
-                                &swap_id,
-                                preimage,
-                                pub_nonce,
-                                partial_sig,
-                                ToSign {
-                                    pub_nonce: claim_pub_nonce.serialize().to_lower_hex_string(),
-                                    transaction: claim_tx_hex,
-                                    index: 0,
-                                },
-                            )
-                            .await
-                    }
-                    _ => Err(Error::Protocol(
-                        "Chain swap claim needs a partial_sig".to_string(),
-                    )),
-                },
+                SwapType::Chain => {
+                    boltz_api
+                        .post_chain_claim_tx_details(
+                            &swap_id,
+                            preimage,
+                            signature,
+                            ToSign {
+                                pub_nonce: claim_pub_nonce.serialize().to_lower_hex_string(),
+                                transaction: claim_tx_hex,
+                                index: 0,
+                            },
+                        )
+                        .await
+                }
                 SwapType::ReverseSubmarine => {
                     boltz_api
                         .get_reverse_partial_sig(

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -523,20 +523,27 @@ impl BoltzApiClientV2 {
         &self,
         id: &String,
         preimage: &Preimage,
-        pub_nonce: MusigPubNonce,
-        partial_sig: MusigPartialSignature,
+        signature: Option<(MusigPartialSignature, MusigPubNonce)>,
         to_sign: ToSign,
     ) -> Result<PartialSig, Error> {
-        let data = json!(
-            {
-                "preimage": preimage.bytes.expect("expected").to_lower_hex_string(),
-                "signature": PartialSig {
+        let data = match signature {
+            Some((partial_sig, pub_nonce)) => json!(
+                {
+                    "preimage": preimage.bytes.expect("expected").to_lower_hex_string(),
+                    "signature": PartialSig {
                     pub_nonce: pub_nonce.serialize().to_lower_hex_string(),
                     partial_signature: partial_sig.serialize().to_lower_hex_string(),
                 },
                 "toSign": to_sign,
             }
-        );
+            ),
+            None => json!(
+                {
+                    "preimage": preimage.bytes.expect("expected").to_lower_hex_string(),
+                    "toSign": to_sign,
+                }
+            ),
+        };
         let endpoint = format!("swap/chain/{id}/claim");
         Ok(serde_json::from_str(&self.post(&endpoint, data).await?)?)
     }
@@ -1267,10 +1274,9 @@ pub struct ToSign {
 pub struct Cooperative<'a> {
     pub boltz_api: &'a BoltzApiClientV2,
     pub swap_id: String,
-    /// The pub_nonce is needed to post the claim tx details of the Chain swap
-    pub pub_nonce: Option<MusigPubNonce>,
-    /// The partial_sig is needed to post the claim tx details of the Chain swap
-    pub partial_sig: Option<MusigPartialSignature>,
+    /// The signature (partial_sig + pub_nonce) is needed to post the claim tx details of the Chain swap
+    /// It may be omitted for a chain swap if we've already sent the signature to Boltz
+    pub signature: Option<(MusigPartialSignature, MusigPubNonce)>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -609,8 +609,7 @@ impl LBtcSwapTx {
         if let Some(Cooperative {
             boltz_api,
             swap_id,
-            pub_nonce,
-            partial_sig,
+            signature,
         }) = is_cooperative
         {
             let claim_tx_taproot_hash = SighashCache::new(&claim_tx)
@@ -651,26 +650,20 @@ impl LBtcSwapTx {
             // Step 7: Get boltz's partial sig
             let claim_tx_hex = serialize(&claim_tx).to_lower_hex_string();
             let partial_sig_resp = match self.swap_script.swap_type {
-                SwapType::Chain => match (pub_nonce, partial_sig) {
-                    (Some(pub_nonce), Some(partial_sig)) => {
-                        boltz_api
-                            .post_chain_claim_tx_details(
-                                &swap_id,
-                                preimage,
-                                pub_nonce,
-                                partial_sig,
-                                ToSign {
-                                    pub_nonce: claim_pub_nonce.serialize().to_lower_hex_string(),
-                                    transaction: claim_tx_hex,
-                                    index: 0,
-                                },
-                            )
-                            .await
-                    }
-                    _ => Err(Error::Protocol(
-                        "Chain swap claim needs a partial_sig".to_string(),
-                    )),
-                },
+                SwapType::Chain => {
+                    boltz_api
+                        .post_chain_claim_tx_details(
+                            &swap_id,
+                            preimage,
+                            signature,
+                            ToSign {
+                                pub_nonce: claim_pub_nonce.serialize().to_lower_hex_string(),
+                                transaction: claim_tx_hex,
+                                index: 0,
+                            },
+                        )
+                        .await
+                }
                 SwapType::ReverseSubmarine => {
                     boltz_api
                         .get_reverse_partial_sig(

--- a/src/swaps/wrappers.rs
+++ b/src/swaps/wrappers.rs
@@ -173,6 +173,7 @@ pub enum SwapScript {
     Liquid(Arc<LBtcSwapScript>),
 }
 
+#[derive(Clone)]
 pub struct SwapTransactionParams<'a> {
     pub keys: Keypair,
     pub output_address: String,

--- a/src/swaps/wrappers.rs
+++ b/src/swaps/wrappers.rs
@@ -313,17 +313,28 @@ impl SwapScript {
         swap_id: &String,
         boltz_api: &'a BoltzApiClientV2,
     ) -> Result<Cooperative<'a>, Error> {
-        let claim_tx_response = boltz_api.get_chain_claim_tx_details(swap_id).await?;
-        let (partial_sig, pub_nonce) = self.common().partial_sign(
-            our_refund_keys,
-            &claim_tx_response.pub_nonce,
-            &claim_tx_response.transaction_hash,
-        )?;
+        let signature: Option<(MusigPartialSignature, MusigPubNonce)> = match boltz_api
+            .get_chain_claim_tx_details(swap_id)
+            .await
+        {
+            Ok(claim_tx_response) => Some(self.common().partial_sign(
+                our_refund_keys,
+                &claim_tx_response.pub_nonce,
+                &claim_tx_response.transaction_hash,
+            )?),
+            Err(Error::JSON(e)) => {
+                log::warn!("Failed to parse chain claim tx details: {e} - continuing without signature as we may have already sent it");
+                None
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        };
+
         Ok(Cooperative {
             boltz_api,
             swap_id: swap_id.clone(),
-            pub_nonce: Some(pub_nonce),
-            partial_sig: Some(partial_sig),
+            signature,
         })
     }
 
@@ -350,8 +361,7 @@ impl SwapScript {
                 _ => Ok(Some(Cooperative {
                     boltz_api: boltz_client,
                     swap_id,
-                    pub_nonce: None,
-                    partial_sig: None,
+                    signature: None,
                 })),
             },
             false => Ok(None),

--- a/tests/regtest/chain_swaps.rs
+++ b/tests/regtest/chain_swaps.rs
@@ -168,42 +168,26 @@ async fn v2_chain(chain_client: &ChainClient, underpay: bool, from: Chain, to: C
                 sleep(WAIT_TIME).await;
                 log::info!("Claiming!");
 
+                let swap_params = SwapTransactionParams {
+                    keys: our_claim_keys,
+                    output_address: claim_address.clone(),
+                    fee: Fee::Absolute(1000),
+                    swap_id: swap_id.clone(),
+                    options: Some(
+                        TransactionOptions::default()
+                            .with_chain_claim(our_refund_keys, lockup_script.clone()),
+                    ),
+                    chain_client,
+                    boltz_client: &boltz_api_v2,
+                };
+
+                // Constructing a chain tx more than once should work
                 let _tx = claim_script
-                    .construct_claim(
-                        &preimage,
-                        SwapTransactionParams {
-                            keys: our_claim_keys,
-                            output_address: claim_address.clone(),
-                            fee: Fee::Absolute(1000),
-                            swap_id: swap_id.clone(),
-                            options: Some(
-                                TransactionOptions::default()
-                                    .with_chain_claim(our_refund_keys, lockup_script.clone()),
-                            ),
-                            chain_client,
-                            boltz_client: &boltz_api_v2,
-                        },
-                    )
+                    .construct_claim(&preimage, swap_params.clone())
                     .await
                     .unwrap();
-
-                // Trying to construct a claim tx again should work
                 let tx = claim_script
-                    .construct_claim(
-                        &preimage,
-                        SwapTransactionParams {
-                            keys: our_claim_keys,
-                            output_address: claim_address.clone(),
-                            fee: Fee::Absolute(1000),
-                            swap_id: swap_id.clone(),
-                            options: Some(
-                                TransactionOptions::default()
-                                    .with_chain_claim(our_refund_keys, lockup_script.clone()),
-                            ),
-                            chain_client,
-                            boltz_client: &boltz_api_v2,
-                        },
-                    )
+                    .construct_claim(&preimage, swap_params)
                     .await
                     .unwrap();
 

--- a/tests/regtest/chain_swaps.rs
+++ b/tests/regtest/chain_swaps.rs
@@ -168,6 +168,26 @@ async fn v2_chain(chain_client: &ChainClient, underpay: bool, from: Chain, to: C
                 sleep(WAIT_TIME).await;
                 log::info!("Claiming!");
 
+                let _tx = claim_script
+                    .construct_claim(
+                        &preimage,
+                        SwapTransactionParams {
+                            keys: our_claim_keys,
+                            output_address: claim_address.clone(),
+                            fee: Fee::Absolute(1000),
+                            swap_id: swap_id.clone(),
+                            options: Some(
+                                TransactionOptions::default()
+                                    .with_chain_claim(our_refund_keys, lockup_script.clone()),
+                            ),
+                            chain_client,
+                            boltz_client: &boltz_api_v2,
+                        },
+                    )
+                    .await
+                    .unwrap();
+
+                // Trying to construct a claim tx again should work
                 let tx = claim_script
                     .construct_claim(
                         &preimage,


### PR DESCRIPTION
After constructing a chain swap claim tx, if we fail to broadcast it or persist it, we wouldn't be able to create a new one because `get_chain_claim_tx_details` would fail due to Boltz already seeing the swap as claimed.

Boltz does allow fetching new partial sigs, we just have to omit our signature in `post_chain_claim_tx_details`. This proposes trying this whenever the response to `get_chain_claim_tx_details` is unexpected so that new claim tx can always be created.

The chain swap integration test has been adjusted to verify that claim transactions can now be recreated.