### PR TITLE
Changes for nix development

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ secp256k1-zkp = { git = "https://github.com/breez/rust-secp256k1-zkp.git", rev =
 
 [dev-dependencies]
 serial_test = { workspace = true }
-tokio = { version = "1.43.0", features = ["rt"] }
+tokio = { version = "1.43.0", features = ["rt", "macros"] }
 anyhow = "1.0.100"
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1754269165,
+        "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "444e81206df3f7d92780680e45858e31d2f07a08",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1755052812,
+        "narHash": "sha256-Tjw2YP7Hz8+ibE8wJ+Ps65vh1lzAe5ozmoo9sdQ7rGg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "433023cba5f4fa66b8b0fdbb8f91d420c9cc2527",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,98 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+    crane = {
+      url = "github:ipetkov/crane";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, crane }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+          inherit (pkgs) lib;
+
+          rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+          craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+          # When filtering sources, we want to allow assets other than .rs files
+          src = lib.cleanSourceWith {
+            src = ./.; # The original, unfiltered source
+            filter = path: type:
+              (lib.hasSuffix "\.toml" path) ||
+              (lib.hasSuffix "\.md" path) ||
+              (lib.hasInfix "/test" path) ||
+              (lib.hasInfix "/tests/" path) ||
+
+              # Default filter from crane (allow .rs files)
+              (craneLib.filterCargoSources path type)
+            ;
+          };
+
+          nativeBuildInputs = with pkgs; [ 
+            rustToolchain 
+            pkg-config 
+          ]; # required only at build time
+          
+          buildInputs = with pkgs; [ 
+            openssl 
+          ] ++ lib.optionals pkgs.stdenv.isDarwin [
+            # Additional darwin dependencies if needed
+            pkgs.darwin.apple_sdk.frameworks.Security
+            pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+          ]; # also required at runtime
+
+          commonArgs = {
+            inherit src buildInputs nativeBuildInputs;
+            pname = "boltz-client";
+            version = "0.3.0";
+          };
+
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          
+          bin = craneLib.buildPackage (commonArgs // {
+            inherit cargoArtifacts;
+            cargoTestExtraArgs = "--lib"; # only unit testing, integration testing has more requirements
+          });
+
+        in
+        {
+          packages = {
+            inherit bin;
+            default = bin;
+          };
+
+          devShells.default = pkgs.mkShell {
+            inputsFrom = [ bin ];
+
+            buildInputs = with pkgs; [
+              # Additional development tools
+              cargo-watch
+              cargo-edit
+            ];
+
+            # Environment variables for development
+            RUST_LOG = "debug";
+
+            BITCOIND_SKIP_DOWNLOAD = true;
+            ELEMENTSD_SKIP_DOWNLOAD = true;
+
+            BITCOIND_EXEC = "${pkgs.bitcoind}/bin/bitcoind";
+            ELEMENTSD_EXEC = "${pkgs.elementsd}/bin/elementsd";
+
+          };
+        }
+      );
+} 

--- a/macros/src/testing.rs
+++ b/macros/src/testing.rs
@@ -6,7 +6,7 @@ pub fn async_test(
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     let mut out = TokenStream::new();
-    out.extend(quote! { #[cfg_attr(not(all(target_family = "wasm", target_os = "unknown")), tokio::test)] });
+    out.extend(quote! { #[cfg_attr(not(all(target_family = "wasm", target_os = "unknown")), ::tokio::test)] });
     out.extend(TokenStream::from(input));
     out.into()
 }
@@ -26,7 +26,7 @@ pub fn async_test_all(
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     let mut out = TokenStream::new();
-    out.extend(quote! { #[cfg_attr(not(all(target_family = "wasm", target_os = "unknown")), tokio::test)] });
+    out.extend(quote! { #[cfg_attr(not(all(target_family = "wasm", target_os = "unknown")), ::tokio::test)] });
     out.extend(quote! { #[cfg_attr(all(target_family = "wasm", target_os = "unknown"), wasm_bindgen_test::wasm_bindgen_test)] });
     out.extend(TokenStream::from(input));
     out.into()

--- a/regtest/start.sh
+++ b/regtest/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/regtest/stop.sh
+++ b/regtest/stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85.0"
+components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]

--- a/src/util/secrets.rs
+++ b/src/util/secrets.rs
@@ -7,9 +7,9 @@ use std::str::FromStr;
 
 use bip39::Mnemonic;
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpriv};
+use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
 use bitcoin::hex::{DisplayHex, FromHex};
 use bitcoin::key::rand::{rngs::OsRng, RngCore};
-use bitcoin::secp256k1::hashes::{hash160, ripemd160, sha256, Hash};
 use bitcoin::secp256k1::{Keypair, Secp256k1};
 use elements::secp256k1_zkp::{Keypair as ZKKeyPair, Secp256k1 as ZKSecp256k1};
 use lightning_invoice::Bolt11Invoice;

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -31,7 +31,10 @@ impl BtcTestFramework {
         let mut conf = Conf::default();
 
         conf.args.push("-txindex=1");
-        let bitcoind = BitcoinD::from_downloaded_with_conf(&conf).unwrap();
+        let bitcoind = match std::env::var("BITCOIND_EXEC") {
+            Ok(exe) => BitcoinD::with_conf(&exe, &conf).unwrap(),
+            Err(_) => BitcoinD::from_downloaded_with_conf(&conf).unwrap(),
+        };
 
         // Generate initial 101 blocks
         let mining_address = bitcoind
@@ -113,7 +116,12 @@ impl LbtcTestFramework {
         let mut conf = elementsd::Conf::default();
         conf.0.args.push("-txindex=1");
 
-        let elementsd = ElementsD::with_conf(downloaded_exe_path().unwrap(), &conf).unwrap();
+        let exe = match std::env::var("ELEMENTSD_EXEC") {
+            Ok(exe) => exe,
+            Err(_) => downloaded_exe_path().unwrap(),
+        };
+
+        let elementsd = ElementsD::with_conf(&exe, &conf).unwrap();
 
         let tf = LbtcTestFramework { elementsd };
 


### PR DESCRIPTION
This PR is to facilitate development on nixos.

nix requires also the Cargo.lock to be available in the tree, however that change seems invasive for this library which don't commit that file on purpose (which is recommended on library).