### PR TITLE
refactor: regtest test flows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,6 +53,8 @@ jobs:
         env:
           COMPOSE_PROFILES: ci, esplora
         run: sh start.sh
+      - name: Permissions for regtest data
+        run: sudo chmod -R 777 regtest/boltz
       - name: Run cargo regtest tests
         run: make cargo-regtest-test
       - name: Run WASM regtest tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ secp256k1-zkp = { git = "https://github.com/breez/rust-secp256k1-zkp.git", rev =
 [dev-dependencies]
 serial_test = { workspace = true }
 tokio = { version = "1.43.0", features = ["rt"] }
+anyhow = "1.0"
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 bitcoind = { version = "0.36.0", features = ["25_0"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ secp256k1-zkp = { git = "https://github.com/breez/rust-secp256k1-zkp.git", rev =
 [dev-dependencies]
 serial_test = { workspace = true }
 tokio = { version = "1.43.0", features = ["rt"] }
-anyhow = "1.0"
+anyhow = "1.0.100"
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 bitcoind = { version = "0.36.0", features = ["25_0"] }

--- a/tests/regtest/chain_swaps.rs
+++ b/tests/regtest/chain_swaps.rs
@@ -1,53 +1,35 @@
+use crate::regtest::common::*;
 use crate::regtest::WAIT_TIME;
 use crate::utils;
-use bitcoin::{key::rand::thread_rng, PublicKey};
-use boltz_client::boltz::{
-    BoltzApiClientV2, BoltzWsConfig, ChainSwapDetails, CreateChainRequest, Side, BOLTZ_REGTEST,
-};
+use bitcoin::key::rand::thread_rng;
+use bitcoin::PublicKey;
+use boltz_client::boltz::BoltzApiClientV2;
+use boltz_client::boltz::BoltzWsConfig;
+use boltz_client::boltz::CreateChainRequest;
+use boltz_client::boltz::Side;
+use boltz_client::boltz::BOLTZ_REGTEST;
 use boltz_client::fees::Fee;
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-#[cfg(feature = "electrum")]
-use boltz_client::network::electrum::{ElectrumBitcoinClient, ElectrumLiquidClient};
-#[cfg(feature = "esplora")]
-use boltz_client::network::esplora::{EsploraBitcoinClient, EsploraLiquidClient};
-use boltz_client::network::{BitcoinChain, Chain, LiquidChain};
-use boltz_client::swaps::{ChainClient, SwapScript, SwapTransactionParams, TransactionOptions};
-use boltz_client::util::sleep;
-use boltz_client::{
-    util::{secrets::Preimage, setup_logger},
-    Keypair, Secp256k1,
-};
+use boltz_client::network::Chain;
+use boltz_client::swaps::ChainClient;
+use boltz_client::swaps::SwapScript;
+use boltz_client::swaps::{SwapTransactionParams, TransactionOptions};
+use boltz_client::util::{secrets::Preimage, setup_logger, sleep};
+use boltz_client::Keypair;
+use boltz_client::Secp256k1;
 use serial_test::serial;
 use std::sync::Arc;
 
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-const BITCOIN_CHAIN: BitcoinChain = BitcoinChain::BitcoinRegtest;
-const LIQUID_CHAIN: LiquidChain = LiquidChain::LiquidRegtest;
-
 #[macros::async_test]
 #[serial]
 #[cfg(feature = "electrum")]
 async fn bitcoin_liquid_v2_chain_electrum() {
     setup_logger();
-    let chain_client = ChainClient::new()
-        .with_bitcoin(ElectrumBitcoinClient::default(BITCOIN_CHAIN, None).unwrap())
-        .with_liquid(ElectrumLiquidClient::default(LIQUID_CHAIN, None).unwrap());
-    v2_chain(
-        &chain_client,
-        false,
-        BITCOIN_CHAIN.into(),
-        LIQUID_CHAIN.into(),
-    )
-    .await;
-    v2_chain(
-        &chain_client,
-        true,
-        BITCOIN_CHAIN.into(),
-        LIQUID_CHAIN.into(),
-    )
-    .await;
+    let chain_client = create_chain_client_electrum();
+    v2_chain(&chain_client, false, BTC_CHAIN.into(), LBTC_CHAIN.into()).await;
+    v2_chain(&chain_client, true, BTC_CHAIN.into(), LBTC_CHAIN.into()).await;
 }
 
 #[macros::async_test_all]
@@ -55,23 +37,9 @@ async fn bitcoin_liquid_v2_chain_electrum() {
 #[cfg(feature = "esplora")]
 async fn bitcoin_liquid_v2_chain_esplora() {
     setup_logger();
-    let chain_client = ChainClient::new()
-        .with_bitcoin(EsploraBitcoinClient::default(BITCOIN_CHAIN, None))
-        .with_liquid(EsploraLiquidClient::default(LIQUID_CHAIN, None));
-    v2_chain(
-        &chain_client,
-        false,
-        BITCOIN_CHAIN.into(),
-        LIQUID_CHAIN.into(),
-    )
-    .await;
-    v2_chain(
-        &chain_client,
-        true,
-        BITCOIN_CHAIN.into(),
-        LIQUID_CHAIN.into(),
-    )
-    .await;
+    let chain_client = create_chain_client_esplora();
+    v2_chain(&chain_client, false, BTC_CHAIN.into(), LBTC_CHAIN.into()).await;
+    v2_chain(&chain_client, true, BTC_CHAIN.into(), LBTC_CHAIN.into()).await;
 }
 
 async fn v2_chain(chain_client: &ChainClient, underpay: bool, from: Chain, to: Chain) {
@@ -112,7 +80,7 @@ async fn v2_chain(chain_client: &ChainClient, underpay: bool, from: Chain, to: C
         .validate(&claim_public_key, &refund_public_key, from, to)
         .unwrap();
     let swap_id = create_chain_response.clone().id;
-    let lockup_details: ChainSwapDetails = create_chain_response.clone().lockup_details;
+    let lockup_details = create_chain_response.clone().lockup_details;
 
     let lockup_script = SwapScript::chain_from_swap_resp(
         from,
@@ -125,8 +93,7 @@ async fn v2_chain(chain_client: &ChainClient, underpay: bool, from: Chain, to: C
 
     let refund_address = utils::generate_address(from).await.unwrap();
 
-    let claim_details: ChainSwapDetails = create_chain_response.claim_details;
-
+    let claim_details = create_chain_response.claim_details;
     let claim_script =
         SwapScript::chain_from_swap_resp(to, Side::Claim, claim_details.clone(), claim_public_key)
             .unwrap();
@@ -141,98 +108,99 @@ async fn v2_chain(chain_client: &ChainClient, underpay: bool, from: Chain, to: C
 
     log::info!("Subscribed to swap {swap_id}");
 
-    loop {
-        let update = rx.recv().await.unwrap();
-        match update.status.as_str() {
-            "swap.created" => {
-                let amount = match underpay {
-                    true => create_chain_response.lockup_details.amount / 2,
-                    false => create_chain_response.lockup_details.amount,
-                };
-                let address = create_chain_response.lockup_details.clone().lockup_address;
+    next_status(&mut rx, "swap.created").await.unwrap();
 
-                log::info!("Sending {amount} sats to {from} address {address}");
+    let amount = match underpay {
+        true => create_chain_response.lockup_details.amount / 2,
+        false => create_chain_response.lockup_details.amount,
+    };
+    let address = create_chain_response.lockup_details.clone().lockup_address;
 
-                utils::send_to_address(from, &address, amount)
-                    .await
-                    .unwrap();
-            }
+    log::info!("Sending {amount} sats to {from} address {address}");
 
-            "transaction.mempool" | "transaction.server.mempool" => {
-                utils::mine_blocks(1).await.unwrap();
-            }
+    utils::send_to_address(from, &address, amount)
+        .await
+        .unwrap();
 
-            "transaction.server.confirmed" => {
-                log::info!("Server lockup tx is confirmed!");
+    if underpay {
+        next_status(&mut rx, "transaction.lockupFailed")
+            .await
+            .unwrap();
 
-                sleep(WAIT_TIME).await;
-                log::info!("Claiming!");
-
-                let swap_params = SwapTransactionParams {
-                    keys: our_claim_keys,
-                    output_address: claim_address.clone(),
-                    fee: Fee::Absolute(1000),
-                    swap_id: swap_id.clone(),
-                    options: Some(
-                        TransactionOptions::default()
-                            .with_chain_claim(our_refund_keys, lockup_script.clone()),
-                    ),
-                    chain_client,
-                    boltz_client: &boltz_api_v2,
-                };
-
-                // Constructing a chain tx more than once should work
-                let _tx = claim_script
-                    .construct_claim(&preimage, swap_params.clone())
-                    .await
-                    .unwrap();
-                let tx = claim_script
-                    .construct_claim(&preimage, swap_params)
-                    .await
-                    .unwrap();
-
-                chain_client.broadcast_tx(&tx).await.unwrap();
-
-                log::info!("Successfully broadcasted claim tx!");
-            }
-
-            "transaction.claimed" => {
-                log::info!("Successfully completed chain swap");
-                break;
-            }
-
-            "transaction.lockupFailed" => {
-                sleep(WAIT_TIME).await;
-                log::info!("REFUNDING!");
-                refund_v2_chain(
-                    lockup_script.clone(),
-                    refund_address.clone(),
-                    swap_id.clone(),
-                    our_refund_keys,
-                    boltz_api_v2.clone(),
-                    100,
-                    chain_client,
-                )
-                .await;
-                if let Chain::Bitcoin(_) = from {
-                    log::info!("REFUNDING with higher fee");
-                    refund_v2_chain(
-                        lockup_script.clone(),
-                        refund_address.clone(),
-                        swap_id.clone(),
-                        our_refund_keys,
-                        boltz_api_v2.clone(),
-                        1000,
-                        chain_client,
-                    )
-                    .await;
-                }
-                break;
-            }
-            _ => {
-                log::info!("Got Update from server: {}", update.status);
-            }
+        sleep(WAIT_TIME).await;
+        log::info!("REFUNDING!");
+        refund_v2_chain(
+            lockup_script.clone(),
+            refund_address.clone(),
+            swap_id.clone(),
+            our_refund_keys,
+            boltz_api_v2.clone(),
+            100,
+            chain_client,
+        )
+        .await;
+        if let Chain::Bitcoin(_) = from {
+            log::info!("REFUNDING with higher fee");
+            refund_v2_chain(
+                lockup_script.clone(),
+                refund_address.clone(),
+                swap_id.clone(),
+                our_refund_keys,
+                boltz_api_v2.clone(),
+                1000,
+                chain_client,
+            )
+            .await;
         }
+    } else {
+        next_status(&mut rx, "transaction.mempool").await.unwrap();
+        utils::mine_blocks(1).await.unwrap();
+
+        next_status(&mut rx, "transaction.confirmed").await.unwrap();
+
+        next_status(&mut rx, "transaction.server.mempool")
+            .await
+            .unwrap();
+        utils::mine_blocks(1).await.unwrap();
+
+        next_status(&mut rx, "transaction.server.confirmed")
+            .await
+            .unwrap();
+
+        log::info!("Server lockup tx is confirmed!");
+
+        sleep(WAIT_TIME).await;
+        log::info!("Claiming!");
+
+        let swap_params = SwapTransactionParams {
+            keys: our_claim_keys,
+            output_address: claim_address.clone(),
+            fee: Fee::Absolute(1000),
+            swap_id: swap_id.clone(),
+            options: Some(
+                TransactionOptions::default()
+                    .with_chain_claim(our_refund_keys, lockup_script.clone()),
+            ),
+            chain_client,
+            boltz_client: &boltz_api_v2,
+        };
+
+        // Constructing a chain tx more than once should work
+        let _tx = claim_script
+            .construct_claim(&preimage, swap_params.clone())
+            .await
+            .unwrap();
+        let tx = claim_script
+            .construct_claim(&preimage, swap_params)
+            .await
+            .unwrap();
+
+        chain_client.broadcast_tx(&tx).await.unwrap();
+
+        log::info!("Successfully broadcasted claim tx!");
+
+        next_status(&mut rx, "transaction.claimed").await.unwrap();
+        log::info!("Successfully completed chain swap");
     }
 }
 
@@ -269,23 +237,9 @@ async fn refund_v2_chain(
 #[cfg(feature = "electrum")]
 async fn liquid_bitcoin_v2_chain_electrum() {
     setup_logger();
-    let chain_client = ChainClient::new()
-        .with_bitcoin(ElectrumBitcoinClient::default(BITCOIN_CHAIN, None).unwrap())
-        .with_liquid(ElectrumLiquidClient::default(LIQUID_CHAIN, None).unwrap());
-    v2_chain(
-        &chain_client,
-        false,
-        LIQUID_CHAIN.into(),
-        BITCOIN_CHAIN.into(),
-    )
-    .await;
-    v2_chain(
-        &chain_client,
-        true,
-        LIQUID_CHAIN.into(),
-        BITCOIN_CHAIN.into(),
-    )
-    .await;
+    let chain_client = create_chain_client_electrum();
+    v2_chain(&chain_client, false, LBTC_CHAIN.into(), BTC_CHAIN.into()).await;
+    v2_chain(&chain_client, true, LBTC_CHAIN.into(), BTC_CHAIN.into()).await;
 }
 
 #[macros::async_test_all]
@@ -293,21 +247,7 @@ async fn liquid_bitcoin_v2_chain_electrum() {
 #[cfg(feature = "esplora")]
 async fn liquid_bitcoin_v2_chain_esplora() {
     setup_logger();
-    let chain_client = ChainClient::new()
-        .with_bitcoin(EsploraBitcoinClient::default(BITCOIN_CHAIN, None))
-        .with_liquid(EsploraLiquidClient::default(LIQUID_CHAIN, None));
-    v2_chain(
-        &chain_client,
-        false,
-        LIQUID_CHAIN.into(),
-        BITCOIN_CHAIN.into(),
-    )
-    .await;
-    v2_chain(
-        &chain_client,
-        true,
-        LIQUID_CHAIN.into(),
-        BITCOIN_CHAIN.into(),
-    )
-    .await;
+    let chain_client = create_chain_client_esplora();
+    v2_chain(&chain_client, false, LBTC_CHAIN.into(), BTC_CHAIN.into()).await;
+    v2_chain(&chain_client, true, LBTC_CHAIN.into(), BTC_CHAIN.into()).await;
 }

--- a/tests/regtest/common.rs
+++ b/tests/regtest/common.rs
@@ -1,4 +1,4 @@
-use bitcoind::anyhow;
+use anyhow;
 use boltz_client::swaps::ChainClient;
 use boltz_client::util::sleep;
 use boltz_client::{

--- a/tests/regtest/common.rs
+++ b/tests/regtest/common.rs
@@ -1,3 +1,4 @@
+use bitcoind::anyhow;
 use boltz_client::swaps::ChainClient;
 use boltz_client::util::sleep;
 use boltz_client::{
@@ -5,7 +6,7 @@ use boltz_client::{
     network::{BitcoinChain, LiquidChain},
 };
 use std::time::Duration;
-use tokio::sync::broadcast::{error::RecvError, Receiver};
+use tokio::sync::broadcast::Receiver;
 
 pub const BTC_CHAIN: BitcoinChain = BitcoinChain::BitcoinRegtest;
 pub const LBTC_CHAIN: LiquidChain = LiquidChain::LiquidRegtest;
@@ -36,7 +37,7 @@ pub fn create_chain_client_esplora() -> ChainClient {
 pub async fn next_status(
     updates: &mut Receiver<SwapStatus>,
     expected_status: &str,
-) -> Result<boltz_client::boltz::SwapStatus, RecvError> {
+) -> Result<boltz_client::boltz::SwapStatus, anyhow::Error> {
     tokio::select! {
         result = async {
             loop {
@@ -48,7 +49,7 @@ pub async fn next_status(
             }
         } => result,
         _ = sleep(Duration::from_secs(10)) => {
-            Err(RecvError::Closed)
+            Err(anyhow::anyhow!("Timeout waiting for status: {}", expected_status))
         }
     }
 }

--- a/tests/regtest/common.rs
+++ b/tests/regtest/common.rs
@@ -1,4 +1,5 @@
 use boltz_client::swaps::ChainClient;
+use boltz_client::util::sleep;
 use boltz_client::{
     boltz::{BoltzApiClientV2, SwapStatus, BOLTZ_REGTEST},
     network::{BitcoinChain, LiquidChain},
@@ -46,7 +47,7 @@ pub async fn next_status(
                 }
             }
         } => result,
-        _ = tokio::time::sleep(Duration::from_secs(10)) => {
+        _ = sleep(Duration::from_secs(10)) => {
             Err(RecvError::Closed)
         }
     }

--- a/tests/regtest/common.rs
+++ b/tests/regtest/common.rs
@@ -1,0 +1,53 @@
+use boltz_client::swaps::ChainClient;
+use boltz_client::{
+    boltz::{BoltzApiClientV2, SwapStatus, BOLTZ_REGTEST},
+    network::{BitcoinChain, LiquidChain},
+};
+use std::time::Duration;
+use tokio::sync::broadcast::{error::RecvError, Receiver};
+
+pub const BTC_CHAIN: BitcoinChain = BitcoinChain::BitcoinRegtest;
+pub const LBTC_CHAIN: LiquidChain = LiquidChain::LiquidRegtest;
+
+// Create default Boltz API client
+pub fn create_boltz_api() -> BoltzApiClientV2 {
+    BoltzApiClientV2::new(BOLTZ_REGTEST.to_string(), Some(super::BOLTZ_TIMEOUT))
+}
+
+#[cfg(feature = "electrum")]
+pub fn create_chain_client_electrum() -> ChainClient {
+    use boltz_client::network::electrum::{ElectrumBitcoinClient, ElectrumLiquidClient};
+
+    ChainClient::new()
+        .with_bitcoin(ElectrumBitcoinClient::default(BTC_CHAIN, None).unwrap())
+        .with_liquid(ElectrumLiquidClient::default(LBTC_CHAIN, None).unwrap())
+}
+
+#[cfg(feature = "esplora")]
+pub fn create_chain_client_esplora() -> ChainClient {
+    use boltz_client::network::esplora::{EsploraBitcoinClient, EsploraLiquidClient};
+
+    ChainClient::new()
+        .with_bitcoin(EsploraBitcoinClient::default(BTC_CHAIN, None))
+        .with_liquid(EsploraLiquidClient::default(LBTC_CHAIN, None))
+}
+
+pub async fn next_status(
+    updates: &mut Receiver<SwapStatus>,
+    expected_status: &str,
+) -> Result<boltz_client::boltz::SwapStatus, RecvError> {
+    tokio::select! {
+        result = async {
+            loop {
+                let update = updates.recv().await?;
+                log::info!("Waiting for status: {}", update.status);
+                if update.status == expected_status {
+                    return Ok(update);
+                }
+            }
+        } => result,
+        _ = tokio::time::sleep(Duration::from_secs(10)) => {
+            Err(RecvError::Closed)
+        }
+    }
+}

--- a/tests/regtest/common.rs
+++ b/tests/regtest/common.rs
@@ -1,4 +1,3 @@
-use anyhow;
 use boltz_client::swaps::ChainClient;
 use boltz_client::util::sleep;
 use boltz_client::{

--- a/tests/regtest/mod.rs
+++ b/tests/regtest/mod.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 mod chain_swaps;
+mod common;
 mod reverse;
 mod submarine;
 

--- a/tests/regtest/reverse.rs
+++ b/tests/regtest/reverse.rs
@@ -1,37 +1,28 @@
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-#[cfg(feature = "electrum")]
-use boltz_client::network::electrum::{ElectrumBitcoinClient, ElectrumLiquidClient};
-#[cfg(feature = "esplora")]
-use boltz_client::network::esplora::{EsploraBitcoinClient, EsploraLiquidClient};
-use boltz_client::swaps::TransactionOptions;
-use boltz_client::util::sleep;
+use bitcoin::{key::rand::thread_rng, secp256k1::Keypair, PublicKey};
+use boltz_client::boltz::BoltzWsConfig;
+use boltz_client::fees::Fee;
+use boltz_client::swaps::{ChainClient, TransactionOptions};
 use boltz_client::{
     network::Chain,
     swaps::{
-        boltz::{BoltzApiClientV2, CreateReverseRequest},
+        boltz::CreateReverseRequest,
         magic_routing::{check_for_mrh, sign_address},
-        {ChainClient, SwapScript, SwapTransactionParams},
+        {SwapScript, SwapTransactionParams},
     },
-    util::{secrets::Preimage, setup_logger},
+    util::{secrets::Preimage, setup_logger, sleep},
     Secp256k1,
 };
+use serial_test::serial;
 use std::sync::Arc;
 
+use crate::regtest::common::*;
 use crate::regtest::WAIT_TIME;
 use crate::utils;
-use bitcoin::{key::rand::thread_rng, secp256k1::Keypair, PublicKey};
-use boltz_client::boltz::{BoltzWsConfig, BOLTZ_REGTEST};
-use boltz_client::fees::Fee;
-use boltz_client::network::{BitcoinChain, LiquidChain};
-use serial_test::serial;
 
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-const BTC_CHAIN: BitcoinChain = BitcoinChain::BitcoinRegtest;
-const LIQUID_CHAIN: LiquidChain = LiquidChain::LiquidRegtest;
-
-async fn v2_reverse(chain_client: &ChainClient, chain: Chain, cooperative: bool) {
+async fn swap(chain: Chain, chain_client: &ChainClient) {
     let secp = Secp256k1::new();
     let preimage = Preimage::new();
     let our_keys = Keypair::new(&secp, &mut thread_rng());
@@ -60,7 +51,7 @@ async fn v2_reverse(chain_client: &ChainClient, chain: Chain, cooperative: bool)
         webhook: None,
     };
 
-    let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_REGTEST.to_string(), Some(super::BOLTZ_TIMEOUT));
+    let boltz_api_v2 = create_boltz_api();
     let ws_api = Arc::new(boltz_api_v2.ws(BoltzWsConfig::default()));
     utils::start_ws(ws_api.clone());
 
@@ -82,57 +73,38 @@ async fn v2_reverse(chain_client: &ChainClient, chain: Chain, cooperative: bool)
     let swap_id = reverse_resp.id.clone();
 
     ws_api.subscribe_swap(&swap_id).await.unwrap();
-    let mut rx = ws_api.updates();
+    let mut updates = ws_api.updates();
 
-    loop {
-        let update = rx.recv().await.unwrap();
-        match update.status.as_str() {
-            "swap.created" => {
-                log::info!("Waiting for Invoice to be paid: {}", &invoice);
+    next_status(&mut updates, "swap.created").await.unwrap();
 
-                utils::start_pay_invoice_lnd(invoice.clone());
+    utils::start_pay_invoice_lnd(reverse_resp.invoice.clone().unwrap());
 
-                continue;
-            }
+    next_status(&mut updates, "transaction.mempool")
+        .await
+        .unwrap();
 
-            "transaction.mempool" => {
-                log::info!("Boltz broadcasted funding tx");
+    sleep(WAIT_TIME).await;
 
-                sleep(WAIT_TIME).await;
+    let claim_address = utils::generate_address(chain).await.unwrap();
+    let tx = swap_script
+        .construct_claim(
+            &preimage,
+            SwapTransactionParams {
+                swap_id: swap_id.clone(),
+                keys: our_keys,
+                fee: Fee::Absolute(200),
+                output_address: claim_address,
+                chain_client,
+                boltz_client: &boltz_api_v2,
+                options: Some(TransactionOptions::default()),
+            },
+        )
+        .await
+        .unwrap();
 
-                let tx = swap_script
-                    .construct_claim(
-                        &preimage,
-                        SwapTransactionParams {
-                            keys: our_keys,
-                            output_address: claim_address.clone(),
-                            fee: Fee::Absolute(1000),
-                            swap_id: swap_id.clone(),
-                            options: Some(
-                                TransactionOptions::default().with_cooperative(cooperative),
-                            ),
-                            chain_client,
-                            boltz_client: &boltz_api_v2,
-                        },
-                    )
-                    .await
-                    .unwrap();
+    chain_client.broadcast_tx(&tx).await.unwrap();
 
-                chain_client.broadcast_tx(&tx).await.unwrap();
-
-                log::info!("Successfully broadcasted claim tx!");
-                log::debug!("Claim Tx {tx:?}");
-            }
-
-            "invoice.settled" => {
-                log::info!("Reverse Swap Successful!");
-                break;
-            }
-            _ => {
-                log::info!("Got Update from server: {}", update.status);
-            }
-        }
-    }
+    next_status(&mut updates, "invoice.settled").await.unwrap();
 }
 
 #[macros::async_test]
@@ -140,10 +112,9 @@ async fn v2_reverse(chain_client: &ChainClient, chain: Chain, cooperative: bool)
 #[cfg(feature = "electrum")]
 async fn bitcoin_v2_reverse_electrum() {
     setup_logger();
-    let chain_client =
-        ChainClient::new().with_bitcoin(ElectrumBitcoinClient::default(BTC_CHAIN, None).unwrap());
-    v2_reverse(&chain_client, BTC_CHAIN.into(), false).await;
-    v2_reverse(&chain_client, BTC_CHAIN.into(), true).await;
+    let chain_client = create_chain_client_electrum();
+    swap(BTC_CHAIN.into(), &chain_client).await;
+    swap(BTC_CHAIN.into(), &chain_client).await;
 }
 
 #[macros::async_test_all]
@@ -151,10 +122,9 @@ async fn bitcoin_v2_reverse_electrum() {
 #[cfg(feature = "esplora")]
 async fn bitcoin_v2_reverse_esplora() {
     setup_logger();
-    let chain_client =
-        ChainClient::new().with_bitcoin(EsploraBitcoinClient::default(BTC_CHAIN, None));
-    v2_reverse(&chain_client, BTC_CHAIN.into(), false).await;
-    v2_reverse(&chain_client, BTC_CHAIN.into(), true).await;
+    let chain_client = create_chain_client_esplora();
+    swap(BTC_CHAIN.into(), &chain_client).await;
+    swap(BTC_CHAIN.into(), &chain_client).await;
 }
 
 #[macros::async_test]
@@ -162,10 +132,9 @@ async fn bitcoin_v2_reverse_esplora() {
 #[cfg(feature = "electrum")]
 async fn liquid_v2_reverse_electrum() {
     setup_logger();
-    let chain_client =
-        ChainClient::new().with_liquid(ElectrumLiquidClient::default(LIQUID_CHAIN, None).unwrap());
-    v2_reverse(&chain_client, LIQUID_CHAIN.into(), false).await;
-    v2_reverse(&chain_client, LIQUID_CHAIN.into(), true).await;
+    let chain_client = create_chain_client_electrum();
+    swap(LBTC_CHAIN.into(), &chain_client).await;
+    swap(LBTC_CHAIN.into(), &chain_client).await;
 }
 
 #[macros::async_test_all]
@@ -173,8 +142,7 @@ async fn liquid_v2_reverse_electrum() {
 #[cfg(feature = "esplora")]
 async fn liquid_v2_reverse_esplora() {
     setup_logger();
-    let chain_client =
-        ChainClient::new().with_liquid(EsploraLiquidClient::default(LIQUID_CHAIN, None));
-    v2_reverse(&chain_client, LIQUID_CHAIN.into(), false).await;
-    v2_reverse(&chain_client, LIQUID_CHAIN.into(), true).await;
+    let chain_client = create_chain_client_esplora();
+    swap(LBTC_CHAIN.into(), &chain_client).await;
+    swap(LBTC_CHAIN.into(), &chain_client).await;
 }

--- a/tests/regtest/submarine.rs
+++ b/tests/regtest/submarine.rs
@@ -5,18 +5,16 @@ use boltz_client::network::electrum::{ElectrumBitcoinClient, ElectrumLiquidClien
 use boltz_client::network::esplora::{EsploraBitcoinClient, EsploraLiquidClient};
 use boltz_client::{
     network::Chain,
-    swaps::{
-        boltz::{BoltzApiClientV2, CreateSubmarineRequest},
-        ChainClient, SwapScript, SwapTransactionParams,
-    },
+    swaps::{boltz::CreateSubmarineRequest, ChainClient, SwapScript, SwapTransactionParams},
     util::{setup_logger, sleep},
 };
 use std::sync::Arc;
 
+use crate::regtest::common::*;
 use crate::regtest::WAIT_TIME;
 use crate::utils;
 use bitcoin::{key::rand::thread_rng, secp256k1::Keypair, PublicKey};
-use boltz_client::boltz::{BoltzWsConfig, BOLTZ_REGTEST};
+use boltz_client::boltz::BoltzWsConfig;
 use boltz_client::fees::Fee;
 use boltz_client::network::{BitcoinChain, LiquidChain};
 use serial_test::serial;
@@ -40,7 +38,7 @@ async fn v2_submarine(chain_client: &ChainClient, underpay: bool, chain: Chain) 
     let invoice = utils::generate_invoice_lnd(50_000).await.unwrap();
     let refund_address = utils::generate_address(chain).await.unwrap();
 
-    let boltz_api_v2 = BoltzApiClientV2::new(BOLTZ_REGTEST.to_string(), Some(super::BOLTZ_TIMEOUT));
+    let boltz_api_v2 = create_boltz_api();
     let ws_api = Arc::new(boltz_api_v2.ws(BoltzWsConfig::default()));
     utils::start_ws(ws_api.clone());
 
@@ -81,86 +79,67 @@ async fn v2_submarine(chain_client: &ChainClient, underpay: bool, chain: Chain) 
 
     let mut rx = ws_api.updates();
     ws_api.subscribe_swap(&swap_id).await.unwrap();
-    // Event handlers for various swap status.
-    loop {
-        let update = rx.recv().await.unwrap();
-        match update.status.as_str() {
-            "invoice.set" => {
-                log::info!(
-                    "Send {} sats to {} address {}",
-                    create_swap_response.expected_amount,
-                    chain,
-                    create_swap_response.address
-                );
 
-                let amount = match underpay {
-                    true => create_swap_response.expected_amount - 1,
-                    false => create_swap_response.expected_amount,
-                };
-                utils::send_to_address(chain, &create_swap_response.address, amount)
-                    .await
-                    .unwrap();
-            }
-            "transaction.mempool" => {
-                utils::mine_blocks(1).await.unwrap();
-            }
-            "transaction.claim.pending" => {
-                let response = swap_script
-                    .submarine_cooperative_claim(
-                        &swap_id,
-                        &our_keys,
-                        &create_swap_req.invoice,
-                        &boltz_api_v2,
-                    )
-                    .await
-                    .unwrap();
-                log::debug!("Received claim tx details : {response:?}");
-            }
+    next_status(&mut rx, "invoice.set").await.unwrap();
 
-            "transaction.claimed" => {
-                log::info!("Successfully completed submarine swap");
-                break;
-            }
+    log::info!(
+        "Send {} sats to {} address {}",
+        create_swap_response.expected_amount,
+        chain,
+        create_swap_response.address
+    );
 
-            // This means the funding transaction was rejected by Boltz for whatever reason, and we need to get
-            // the funds back via refund.
-            "transaction.lockupFailed" | "invoice.failedToPay" => {
-                sleep(WAIT_TIME).await;
-                let tx = swap_script
-                    .construct_refund(SwapTransactionParams {
-                        keys: our_keys,
-                        output_address: refund_address,
-                        fee: Fee::Absolute(1000),
-                        swap_id: swap_id.clone(),
-                        chain_client,
-                        boltz_client: &boltz_api_v2,
-                        options: None,
-                    })
-                    .await
-                    .unwrap();
+    let amount = match underpay {
+        true => create_swap_response.expected_amount - 1,
+        false => create_swap_response.expected_amount,
+    };
+    utils::send_to_address(chain, &create_swap_response.address, amount)
+        .await
+        .unwrap();
 
-                let txid = chain_client.broadcast_tx(&tx).await.unwrap();
-                log::info!("Cooperative Refund Successfully broadcasted: {txid}");
+    if underpay {
+        next_status(&mut rx, "transaction.lockupFailed")
+            .await
+            .unwrap();
 
-                // Non cooperative refund requires expired swap
-                /*log::info!("Cooperative refund failed. {:?}", e);
-                log::info!("Attempting Non-cooperative refund.");
+        sleep(WAIT_TIME).await;
+        let tx = swap_script
+            .construct_refund(SwapTransactionParams {
+                keys: our_keys,
+                output_address: refund_address,
+                fee: Fee::Absolute(1000),
+                swap_id: swap_id.clone(),
+                chain_client,
+                boltz_client: &boltz_api_v2,
+                options: None,
+            })
+            .await
+            .unwrap();
 
-                let tx = swap_tx
-                    .sign_refund(&our_keys, Fee::Absolute(1000), None)
-                    .await
-                    .unwrap();
-                let txid = swap_tx
-                    .broadcast(&tx, bitcoin_client)
-                    .await
-                    .unwrap();
-                log::info!("Non-cooperative Refund Successfully broadcasted: {}", txid);*/
-                break;
-            }
-            _ => {
-                log::info!("Got Update from server: {}", update.status);
-            }
-        };
+        let txid = chain_client.broadcast_tx(&tx).await.unwrap();
+        log::info!("Cooperative Refund Successfully broadcasted: {txid}");
+    } else {
+        next_status(&mut rx, "transaction.mempool").await.unwrap();
+        utils::mine_blocks(1).await.unwrap();
+
+        if let Chain::Liquid(_) = chain {
+            next_status(&mut rx, "transaction.claim.pending")
+                .await
+                .unwrap();
+            let response = swap_script
+                .submarine_cooperative_claim(
+                    &swap_id,
+                    &our_keys,
+                    &create_swap_req.invoice,
+                    &boltz_api_v2,
+                )
+                .await
+                .unwrap();
+            log::debug!("Received claim tx details : {response:?}");
+        }
+
+        next_status(&mut rx, "transaction.claimed").await.unwrap();
+        log::info!("Successfully completed submarine swap");
     }
 }
 


### PR DESCRIPTION
refactor the regtest tests to sequentially move through the swap status
with timeouts inbetween if needed. tests should be more reliable this
way, and if failing give better insight were exactly instead of
potentially getting stuck in an infinite loop
