### PR TITLE
Discriminate error on `get_submarine_claim_tx_details`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 use std::fmt::{Display, Formatter};
 
+use serde_json::Value;
+
 /// The Global Error enum. Encodes all possible internal library errors
 #[derive(Debug)]
 pub enum Error {
@@ -33,6 +35,7 @@ pub enum Error {
     Taproot(String),
     Musig2(String),
     Generic(String),
+    HTTPStatusNotSuccess(reqwest::StatusCode, Value),
 }
 
 #[cfg(feature = "electrum")]
@@ -282,6 +285,7 @@ impl Error {
             Error::Taproot(_) => "Taproot",
             Error::Musig2(_) => "Musig2",
             Error::Generic(_) => "Generic",
+            Error::HTTPStatusNotSuccess(_, _) => "HTTPStatusNotSuccess",
         }
         .to_string()
     }
@@ -319,6 +323,9 @@ impl Error {
             Error::Taproot(e) => e.clone(),
             Error::Musig2(e) => e.clone(),
             Error::Generic(e) => e.clone(),
+            Error::HTTPStatusNotSuccess(status, body) => {
+                format!("HTTP Status Not Success: {status}, {body}")
+            }
         }
     }
 }

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -507,7 +507,15 @@ impl BoltzApiClientV2 {
         id: &String,
     ) -> Result<SubmarineClaimTxResponse, Error> {
         let endpoint = format!("swap/submarine/{id}/claim");
-        Ok(serde_json::from_str(&self.get(&endpoint).await?)?)
+        let response = self.get_response(&endpoint).await?;
+        let status = response.status();
+        if status.is_success() {
+            let body = response.text().await?;
+            Ok(serde_json::from_str(&body)?)
+        } else {
+            let body = serde_json::from_str(&response.text().await?)?;
+            Err(Error::HTTPStatusNotSuccess(status, body))
+        }
     }
 
     pub async fn get_chain_claim_tx_details(

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -393,11 +393,16 @@ impl BoltzApiClientV2 {
     }
 
     /// Make a GET request. Returns the Response
-    async fn get(&self, end_point: &str) -> Result<String, Error> {
+    async fn get_response(&self, end_point: &str) -> Result<reqwest::Response, Error> {
         let url = format!("{}/{}", self.base_url, end_point);
         let req_builder = self.http_client.get(url);
         let req_builder = self.maybe_add_timeout(req_builder);
-        Ok(req_builder.send().await?.text().await?)
+        Ok(req_builder.send().await?)
+    }
+
+    /// Make a GET request. Returns the Response as text
+    async fn get(&self, end_point: &str) -> Result<String, Error> {
+        Ok(self.get_response(end_point).await?.text().await?)
     }
 
     /// Make a POST request. Returns the Response


### PR DESCRIPTION
During mainnet testing of the submarine flow in lwk with boltz-rust, for a small enough swaps, like 234 satoshi, the cooperative_claim was failing.

It seems boltz backend is returning "swap not eligible for a cooperative claim" in this case but the library is trying to parse the error as a succesful response.

By handling the error this way I can discriminate the error downstream and I think in this case the client should consider the swap complete.  