### PR TITLE
Use released secp musig instead of secp zkp branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,12 @@ codegen-units = 1
 panic = "abort"
 
 [dependencies]
-bitcoin = { workspace = true }
+bitcoin = { workspace = true } 
+
+# Used for musig API not available in secp included in bitcoin/elements
+# TODO: remove once bitcoin included version contains musig
+secp256k1_musig = { package = "secp256k1", version = "0.32.0-beta.0" }
+
 elements = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -63,8 +68,6 @@ web-sys = "0.3.77"
 wasm-bindgen-futures = "0.4.50"
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 
-[patch.crates-io]
-secp256k1-zkp = { git = "https://github.com/breez/rust-secp256k1-zkp.git", rev = "eac2e479255a6e32b5588bc25ee53c642fdd8395" }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.88.0"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]
+targets = ["wasm32-unknown-unknown"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 use std::fmt::{Display, Formatter};
 
+use secp256k1_musig::musig;
+use secp256k1_musig::scalar;
 use serde_json::Value;
 
 /// The Global Error enum. Encodes all possible internal library errors
@@ -221,33 +223,27 @@ impl From<bitcoin::taproot::TaprootBuilderError> for Error {
     }
 }
 
-impl From<elements::secp256k1_zkp::MusigTweakErr> for Error {
-    fn from(value: elements::secp256k1_zkp::MusigTweakErr) -> Self {
-        Self::Musig2(value.to_string())
-    }
-}
-
-impl From<elements::secp256k1_zkp::MusigNonceGenError> for Error {
-    fn from(value: elements::secp256k1_zkp::MusigNonceGenError) -> Self {
-        Self::Musig2(value.to_string())
-    }
-}
-
-impl From<elements::secp256k1_zkp::ParseError> for Error {
-    fn from(value: elements::secp256k1_zkp::ParseError) -> Self {
-        Self::Musig2(value.to_string())
-    }
-}
-
-impl From<elements::secp256k1_zkp::MusigSignError> for Error {
-    fn from(value: elements::secp256k1_zkp::MusigSignError) -> Self {
-        Self::Musig2(value.to_string())
-    }
-}
-
 impl From<bitcoin::consensus::encode::Error> for Error {
     fn from(value: bitcoin::consensus::encode::Error) -> Self {
         Self::BitcoinEncode(value)
+    }
+}
+
+impl From<musig::InvalidTweakErr> for Error {
+    fn from(value: musig::InvalidTweakErr) -> Self {
+        Self::Musig2(value.to_string())
+    }
+}
+
+impl From<scalar::OutOfRangeError> for Error {
+    fn from(value: scalar::OutOfRangeError) -> Self {
+        Self::Musig2(value.to_string())
+    }
+}
+
+impl From<musig::ParseError> for Error {
+    fn from(value: musig::ParseError) -> Self {
+        Self::Musig2(value.to_string())
     }
 }
 

--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -1,9 +1,9 @@
 use bitcoin::consensus::deserialize;
 use bitcoin::hashes::Hash;
-use bitcoin::hex::{DisplayHex, FromHex};
+use bitcoin::hex::DisplayHex;
 use bitcoin::key::rand::rngs::OsRng;
-use bitcoin::key::rand::{thread_rng, RngCore};
-use bitcoin::secp256k1::{Keypair, Message, Secp256k1, SecretKey};
+use bitcoin::key::rand::RngCore;
+use bitcoin::secp256k1::{Keypair, Message, Secp256k1};
 use bitcoin::sighash::Prevouts;
 use bitcoin::taproot::{LeafVersion, Signature, TaprootBuilder, TaprootSpendInfo};
 use bitcoin::transaction::Version;
@@ -15,8 +15,14 @@ use bitcoin::{
 use bitcoin::{sighash::SighashCache, Network, Sequence, Transaction, TxIn, TxOut, Witness};
 use bitcoin::{Amount, TapLeafHash, TapSighashType, Txid, XOnlyPublicKey};
 use elements::pset::serialize::Serialize;
+use secp256k1_musig::{
+    musig::{self},
+    Scalar,
+};
 use std::str::FromStr;
 
+use crate::util::hex_to_bytes32;
+use crate::util::secrets::rng_32b;
 use crate::{error::Error, util::secrets::Preimage};
 
 use bitcoin::{blockdata::locktime::absolute::LockTime, hashes::hash160};
@@ -29,10 +35,6 @@ use super::wrappers::SwapScriptCommon;
 
 use crate::network::{BitcoinChain, BitcoinClient};
 use crate::util::fees::{create_tx_with_fee, Fee};
-use elements::secp256k1_zkp::{
-    MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
-    MusigSessionId,
-};
 
 /// Bitcoin v2 swap script helper.
 // TODO: This should encode the network at global level.
@@ -115,16 +117,18 @@ impl BtcSwapScript {
         })
     }
 
-    pub fn musig_keyagg_cache(&self) -> MusigKeyAggCache {
+    pub fn musig_keyagg_cache(&self) -> musig::KeyAggCache {
         match (self.swap_type, self.side.clone()) {
             (SwapType::ReverseSubmarine, _) | (SwapType::Chain, Some(Side::Claim)) => {
                 let pubkeys = [self.sender_pubkey.inner, self.receiver_pubkey.inner];
-                MusigKeyAggCache::new(&Secp256k1::new(), &pubkeys)
+                let [a, b] = convert_pubkeys_for_musig(&pubkeys);
+                musig::KeyAggCache::new(&[&a, &b])
             }
 
             (SwapType::Submarine, _) | (SwapType::Chain, _) => {
                 let pubkeys = [self.receiver_pubkey.inner, self.sender_pubkey.inner];
-                MusigKeyAggCache::new(&Secp256k1::new(), &pubkeys)
+                let [a, b] = convert_pubkeys_for_musig(&pubkeys);
+                musig::KeyAggCache::new(&[&a, &b])
             }
         }
     }
@@ -315,14 +319,15 @@ impl BtcSwapScript {
         let taproot_builder =
             taproot_builder.add_leaf_with_ver(1, self.refund_script(), LeafVersion::TapScript)?;
 
-        let taproot_spend_info = match taproot_builder.finalize(&secp, internal_key) {
-            Ok(r) => r,
-            Err(e) => {
-                return Err(Error::Taproot(format!(
-                    "Could not finalize taproot constructions: {e:?}"
-                )))
-            }
-        };
+        let taproot_spend_info =
+            match taproot_builder.finalize(&secp, convert_xonly_key(internal_key)) {
+                Ok(r) => r,
+                Err(e) => {
+                    return Err(Error::Taproot(format!(
+                        "Could not finalize taproot constructions: {e:?}"
+                    )))
+                }
+            };
 
         // Verify taproot construction, only if we have funding address previously known.
         // Which will be None only for regtest integration tests, so verification will be skipped for them.
@@ -579,7 +584,7 @@ impl BtcSwapTx {
         keys: &Keypair,
         pub_nonce: &str,
         transaction_hash: &str,
-    ) -> Result<(MusigPartialSignature, MusigPubNonce), Error> {
+    ) -> Result<(musig::PartialSignature, musig::PublicNonce), Error> {
         self.swap_script
             .partial_sign(keys, pub_nonce, transaction_hash)
     }
@@ -637,32 +642,33 @@ impl BtcSwapTx {
                     bitcoin::TapSighashType::Default,
                 )?;
 
-            let msg = Message::from_digest_slice(claim_tx_taproot_hash.as_byte_array())?;
+            let msg = *claim_tx_taproot_hash.as_byte_array();
 
             // Step 2: Get the Public and Secret nonces
             let mut key_agg_cache = self.swap_script.musig_keyagg_cache();
 
-            let tweak = SecretKey::from_slice(
-                self.swap_script
+            let tweak = Scalar::from_be_bytes(
+                *self
+                    .swap_script
                     .taproot_spendinfo()?
                     .tap_tweak()
                     .as_byte_array(),
             )?;
 
-            let _ = key_agg_cache.pubkey_xonly_tweak_add(&secp, tweak)?;
+            let _ = key_agg_cache.pubkey_xonly_tweak_add(&tweak)?;
 
-            let session_id = MusigSessionId::new(&mut thread_rng());
+            let session_secret_rand =
+                musig::SessionSecretRand::assume_unique_per_nonce_gen(rng_32b());
 
             let mut extra_rand = [0u8; 32];
             OsRng.fill_bytes(&mut extra_rand);
 
             let (claim_sec_nonce, claim_pub_nonce) = key_agg_cache.nonce_gen(
-                &secp,
-                session_id,
-                keys.public_key(),
-                msg,
+                session_secret_rand,
+                convert_public_key(keys.public_key()),
+                &msg,
                 Some(extra_rand),
-            )?;
+            );
 
             // Step 7: Get boltz's partial sig
             let claim_tx_hex = claim_tx.serialize().to_lower_hex_string();
@@ -697,25 +703,22 @@ impl BtcSwapTx {
                 ))),
             }?;
 
-            let boltz_public_nonce =
-                MusigPubNonce::from_slice(&Vec::from_hex(&partial_sig_resp.pub_nonce)?)?;
+            let boltz_public_nonce = musig::PublicNonce::from_str(&partial_sig_resp.pub_nonce)?;
 
-            let boltz_partial_sig = MusigPartialSignature::from_slice(&Vec::from_hex(
-                &partial_sig_resp.partial_signature,
-            )?)?;
+            let boltz_partial_sig =
+                musig::PartialSignature::from_str(&partial_sig_resp.partial_signature)?;
 
             // Aggregate Our's and Other's Nonce and start the Musig session.
-            let agg_nonce = MusigAggNonce::new(&secp, &[boltz_public_nonce, claim_pub_nonce]);
+            let agg_nonce = musig::AggregatedNonce::new(&[&boltz_public_nonce, &claim_pub_nonce]);
 
-            let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+            let musig_session = musig::Session::new(&key_agg_cache, agg_nonce, &msg);
 
             // Verify the Boltz's sig.
             let boltz_partial_sig_verify = musig_session.partial_verify(
-                &secp,
                 &key_agg_cache,
-                boltz_partial_sig,
-                boltz_public_nonce,
-                self.swap_script.sender_pubkey.inner,
+                &boltz_partial_sig,
+                &boltz_public_nonce,
+                convert_public_key(self.swap_script.sender_pubkey.inner),
             );
 
             if !boltz_partial_sig_verify {
@@ -725,12 +728,14 @@ impl BtcSwapTx {
             }
 
             let our_partial_sig =
-                musig_session.partial_sign(&secp, claim_sec_nonce, keys, &key_agg_cache)?;
+                musig_session.partial_sign(claim_sec_nonce, &convert_keypair(keys), &key_agg_cache);
 
-            let schnorr_sig = musig_session.partial_sig_agg(&[boltz_partial_sig, our_partial_sig]);
+            let schnorr_sig = musig_session
+                .partial_sig_agg(&[&boltz_partial_sig, &our_partial_sig])
+                .assume_valid();
 
             let final_schnorr_sig = Signature {
-                signature: schnorr_sig,
+                signature: convert_schnorr_signature(schnorr_sig),
                 sighash_type: TapSighashType::Default,
             };
 
@@ -738,7 +743,7 @@ impl BtcSwapTx {
 
             secp.verify_schnorr(
                 &final_schnorr_sig.signature,
-                &msg,
+                &bitcoin::secp256k1::Message::from_digest_slice(&msg)?,
                 &output_key.to_x_only_public_key(),
             )?;
 
@@ -870,6 +875,8 @@ impl BtcSwapTx {
             boltz_api, swap_id, ..
         }) = is_cooperative
         {
+            let secp = Secp256k1::new();
+
             // Start the Musig session
             refund_tx.lock_time = LockTime::ZERO; // No locktime for cooperative spend
 
@@ -883,33 +890,33 @@ impl BtcSwapTx {
                         bitcoin::TapSighashType::Default,
                     )?;
 
-                let msg = Message::from_digest_slice(refund_tx_taproot_hash.as_byte_array())?;
+                let msg = *refund_tx_taproot_hash.as_byte_array();
 
                 // Step 2: Get the Public and Secret nonces
                 let mut key_agg_cache = self.swap_script.musig_keyagg_cache();
 
-                let tweak = SecretKey::from_slice(
-                    self.swap_script
+                let tweak = Scalar::from_be_bytes(
+                    *self
+                        .swap_script
                         .taproot_spendinfo()?
                         .tap_tweak()
                         .as_byte_array(),
                 )?;
 
-                let secp = Secp256k1::new();
-                let _ = key_agg_cache.pubkey_xonly_tweak_add(&secp, tweak)?;
+                let _ = key_agg_cache.pubkey_xonly_tweak_add(&tweak)?;
 
-                let session_id = MusigSessionId::new(&mut thread_rng());
+                let session_secret_rand =
+                    musig::SessionSecretRand::assume_unique_per_nonce_gen(rng_32b());
 
                 let mut extra_rand = [0u8; 32];
                 OsRng.fill_bytes(&mut extra_rand);
 
                 let (sec_nonce, pub_nonce) = key_agg_cache.nonce_gen(
-                    &secp,
-                    session_id,
-                    keys.public_key(),
-                    msg,
+                    session_secret_rand,
+                    convert_public_key(keys.public_key()),
+                    &msg,
                     Some(extra_rand),
-                )?;
+                );
 
                 // Step 7: Get boltz's partial sig
                 let refund_tx_hex = refund_tx.serialize().to_lower_hex_string();
@@ -940,25 +947,22 @@ impl BtcSwapTx {
                     ))),
                 }?;
 
-                let boltz_public_nonce =
-                    MusigPubNonce::from_slice(&Vec::from_hex(&partial_sig_resp.pub_nonce)?)?;
+                let boltz_public_nonce = musig::PublicNonce::from_str(&partial_sig_resp.pub_nonce)?;
 
-                let boltz_partial_sig = MusigPartialSignature::from_slice(&Vec::from_hex(
-                    &partial_sig_resp.partial_signature,
-                )?)?;
+                let boltz_partial_sig =
+                    musig::PartialSignature::from_str(&partial_sig_resp.partial_signature)?;
 
                 // Aggregate Our's and Other's Nonce and start the Musig session.
-                let agg_nonce = MusigAggNonce::new(&secp, &[boltz_public_nonce, pub_nonce]);
+                let agg_nonce = musig::AggregatedNonce::new(&[&boltz_public_nonce, &pub_nonce]);
 
-                let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+                let musig_session = musig::Session::new(&key_agg_cache, agg_nonce, &msg);
 
                 // Verify the Boltz's sig.
                 let boltz_partial_sig_verify = musig_session.partial_verify(
-                    &secp,
                     &key_agg_cache,
-                    boltz_partial_sig,
-                    boltz_public_nonce,
-                    self.swap_script.receiver_pubkey.inner, //boltz key
+                    &boltz_partial_sig,
+                    &boltz_public_nonce,
+                    convert_public_key(self.swap_script.receiver_pubkey.inner), //boltz key
                 );
 
                 if !boltz_partial_sig_verify {
@@ -968,13 +972,14 @@ impl BtcSwapTx {
                 }
 
                 let our_partial_sig =
-                    musig_session.partial_sign(&secp, sec_nonce, keys, &key_agg_cache)?;
+                    musig_session.partial_sign(sec_nonce, &convert_keypair(keys), &key_agg_cache);
 
-                let schnorr_sig =
-                    musig_session.partial_sig_agg(&[boltz_partial_sig, our_partial_sig]);
+                let schnorr_sig = musig_session
+                    .partial_sig_agg(&[&boltz_partial_sig, &our_partial_sig])
+                    .assume_valid();
 
                 let final_schnorr_sig = Signature {
-                    signature: schnorr_sig,
+                    signature: convert_schnorr_signature(schnorr_sig),
                     sighash_type: TapSighashType::Default,
                 };
 
@@ -982,7 +987,7 @@ impl BtcSwapTx {
 
                 secp.verify_schnorr(
                     &final_schnorr_sig.signature,
-                    &msg,
+                    &bitcoin::secp256k1::Message::from_digest_slice(&msg)?,
                     &output_key.to_x_only_public_key(),
                 )?;
 
@@ -1163,35 +1168,68 @@ impl SwapScriptCommon for BtcSwapScript {
         keys: &Keypair,
         pub_nonce: &str,
         transaction_hash: &str,
-    ) -> Result<(MusigPartialSignature, MusigPubNonce), Error> {
+    ) -> Result<(musig::PartialSignature, musig::PublicNonce), Error> {
         // Step 1: Start with a Musig KeyAgg Cache
-        let secp = Secp256k1::new();
 
         let mut key_agg_cache = self.musig_keyagg_cache();
 
-        let tweak = SecretKey::from_slice(self.taproot_spendinfo()?.tap_tweak().as_byte_array())?;
+        let tweak = Scalar::from_be_bytes(*self.taproot_spendinfo()?.tap_tweak().as_byte_array())?;
 
-        let _ = key_agg_cache.pubkey_xonly_tweak_add(&secp, tweak)?;
+        let _ = key_agg_cache.pubkey_xonly_tweak_add(&tweak)?;
 
-        let session_id = MusigSessionId::new(&mut thread_rng());
+        let session_secret_rand = musig::SessionSecretRand::assume_unique_per_nonce_gen(rng_32b());
 
-        let msg = Message::from_digest_slice(&Vec::from_hex(transaction_hash)?)?;
+        let msg = hex_to_bytes32(transaction_hash)?;
 
         // Step 4: Start the Musig2 Signing session
         let mut extra_rand = [0u8; 32];
         OsRng.fill_bytes(&mut extra_rand);
 
-        let (gen_sec_nonce, gen_pub_nonce) =
-            key_agg_cache.nonce_gen(&secp, session_id, keys.public_key(), msg, Some(extra_rand))?;
+        let (gen_sec_nonce, gen_pub_nonce) = key_agg_cache.nonce_gen(
+            session_secret_rand,
+            convert_public_key(keys.public_key()),
+            &msg,
+            Some(extra_rand),
+        );
 
-        let boltz_nonce = MusigPubNonce::from_slice(&Vec::from_hex(pub_nonce)?)?;
+        let boltz_nonce = musig::PublicNonce::from_str(pub_nonce)?;
 
-        let agg_nonce = MusigAggNonce::new(&secp, &[boltz_nonce, gen_pub_nonce]);
+        let agg_nonce = musig::AggregatedNonce::new(&[&boltz_nonce, &gen_pub_nonce]);
 
-        let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+        let musig_session = musig::Session::new(&key_agg_cache, agg_nonce, &msg);
 
-        let partial_sig = musig_session.partial_sign(&secp, gen_sec_nonce, keys, &key_agg_cache)?;
+        let partial_sig =
+            musig_session.partial_sign(gen_sec_nonce, &convert_keypair(keys), &key_agg_cache);
 
         Ok((partial_sig, gen_pub_nonce))
     }
+}
+
+fn convert_pubkeys_for_musig(
+    pubkeys: &[bitcoin::secp256k1::PublicKey; 2],
+) -> [secp256k1_musig::PublicKey; 2] {
+    [
+        convert_public_key(pubkeys[0]),
+        convert_public_key(pubkeys[1]),
+    ]
+}
+
+fn convert_xonly_key(key: secp256k1_musig::XOnlyPublicKey) -> bitcoin::XOnlyPublicKey {
+    bitcoin::XOnlyPublicKey::from_slice(&key.serialize()[..]).expect("xonly key size matches")
+}
+
+fn convert_public_key(key: bitcoin::secp256k1::PublicKey) -> secp256k1_musig::PublicKey {
+    secp256k1_musig::PublicKey::from_slice(&key.serialize()[..]).expect("public key size matches")
+}
+
+fn convert_keypair(keys: &bitcoin::secp256k1::Keypair) -> secp256k1_musig::Keypair {
+    secp256k1_musig::Keypair::from_seckey_byte_array(keys.secret_bytes())
+        .expect("keypair size matches")
+}
+
+fn convert_schnorr_signature(
+    schnorr_sig: secp256k1_musig::schnorr::Signature,
+) -> bitcoin::secp256k1::schnorr::Signature {
+    bitcoin::secp256k1::schnorr::Signature::from_slice(schnorr_sig.as_byte_array())
+        .expect("signature size matches")
 }

--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -24,6 +24,7 @@ use bitcoin::secp256k1;
 use bitcoin::{hashes::sha256, hex::DisplayHex, PublicKey};
 use lightning_invoice::Bolt11Invoice;
 use reqwest::Method;
+use secp256k1_musig::musig;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -37,7 +38,6 @@ pub const BOLTZ_REGTEST: &str = "http://localhost:9001/v2";
 
 #[cfg(feature = "ws")]
 pub use crate::swaps::status_stream::{BoltzWsApi, BoltzWsConfig};
-use elements::secp256k1_zkp::{MusigPartialSignature, MusigPubNonce};
 use reqwest::RequestBuilder;
 #[cfg(feature = "ws")]
 pub use tokio_tungstenite_wasm;
@@ -368,7 +368,7 @@ impl BoltzApiClientV2 {
     }
 
     /// Returns the WebSocket URL for the Boltz server
-    fn get_ws_url(&self) -> String {
+    pub fn get_ws_url(&self) -> String {
         self.base_url.clone().replace("http", "ws") + "/ws"
     }
 
@@ -529,8 +529,8 @@ impl BoltzApiClientV2 {
     pub async fn post_submarine_claim_tx_details(
         &self,
         id: &String,
-        pub_nonce: MusigPubNonce,
-        partial_sig: MusigPartialSignature,
+        pub_nonce: musig::PublicNonce,
+        partial_sig: musig::PartialSignature,
     ) -> Result<Value, Error> {
         let data = json!(
             {
@@ -546,7 +546,7 @@ impl BoltzApiClientV2 {
         &self,
         id: &String,
         preimage: &Preimage,
-        signature: Option<(MusigPartialSignature, MusigPubNonce)>,
+        signature: Option<(musig::PartialSignature, musig::PublicNonce)>,
         to_sign: ToSign,
     ) -> Result<PartialSig, Error> {
         let data = match signature {
@@ -604,7 +604,7 @@ impl BoltzApiClientV2 {
         &self,
         id: &String,
         preimage: &Preimage,
-        pub_nonce: &MusigPubNonce,
+        pub_nonce: &musig::PublicNonce,
         claim_tx_hex: &String,
     ) -> Result<PartialSig, Error> {
         let data = json!(
@@ -624,7 +624,7 @@ impl BoltzApiClientV2 {
         &self,
         id: &String,
         input_index: usize,
-        pub_nonce: &MusigPubNonce,
+        pub_nonce: &musig::PublicNonce,
         refund_tx_hex: &String,
     ) -> Result<PartialSig, Error> {
         let data = json!(
@@ -643,7 +643,7 @@ impl BoltzApiClientV2 {
         &self,
         id: &String,
         input_index: usize,
-        pub_nonce: &MusigPubNonce,
+        pub_nonce: &musig::PublicNonce,
         refund_tx_hex: &String,
     ) -> Result<PartialSig, Error> {
         let data = json!(
@@ -1361,7 +1361,7 @@ pub struct Cooperative<'a> {
     pub swap_id: String,
     /// The signature (partial_sig + pub_nonce) is needed to post the claim tx details of the Chain swap
     /// It may be omitted for a chain swap if we've already sent the signature to Boltz
-    pub signature: Option<(MusigPartialSignature, MusigPubNonce)>,
+    pub signature: Option<(musig::PartialSignature, musig::PublicNonce)>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -1,28 +1,29 @@
 use bitcoin::{
     hashes::{hash160, Hash},
     hex::DisplayHex,
-    key::rand::{rngs::OsRng, thread_rng, RngCore},
+    key::rand::{rngs::OsRng, RngCore},
     secp256k1::Keypair,
     Amount, Witness, XOnlyPublicKey,
 };
 use elements::{
     confidential::{Asset, AssetBlindingFactor, ValueBlindingFactor},
     hex::FromHex,
-    secp256k1_zkp::{
-        MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSession,
-        MusigSessionId, Secp256k1, SecretKey,
-    },
+    secp256k1_zkp::{Secp256k1, SecretKey},
     sighash::{Prevouts, SighashCache},
     taproot::{LeafVersion, TapLeafHash, TaprootBuilder, TaprootSpendInfo},
     Address, AssetIssuance, BlockHash, LockTime, OutPoint, SchnorrSig, SchnorrSighashType, Script,
     Sequence, Transaction, TxIn, TxInWitness, TxOut, TxOutWitness,
 };
+use secp256k1_musig::{musig, Scalar};
 use std::str::FromStr;
 
 use elements::encode::serialize;
 use elements::secp256k1_zkp::Message;
 
-use crate::util::secrets::Preimage;
+use crate::util::{
+    hex_to_bytes32,
+    secrets::{rng_32b, Preimage},
+};
 
 use crate::error::Error;
 
@@ -309,16 +310,18 @@ impl LBtcSwapScript {
             .into_script()
     }
 
-    pub fn musig_keyagg_cache(&self) -> MusigKeyAggCache {
+    pub fn musig_keyagg_cache(&self) -> musig::KeyAggCache {
         match (self.swap_type, self.side.clone()) {
             (SwapType::ReverseSubmarine, _) | (SwapType::Chain, Some(Side::Claim)) => {
                 let pubkeys = [self.sender_pubkey.inner, self.receiver_pubkey.inner];
-                MusigKeyAggCache::new(&Secp256k1::new(), &pubkeys)
+                let [a, b] = convert_pubkeys_for_musig(&pubkeys);
+                musig::KeyAggCache::new(&[&a, &b])
             }
 
             (SwapType::Submarine, _) | (SwapType::Chain, _) => {
                 let pubkeys = [self.receiver_pubkey.inner, self.sender_pubkey.inner];
-                MusigKeyAggCache::new(&Secp256k1::new(), &pubkeys)
+                let [a, b] = convert_pubkeys_for_musig(&pubkeys);
+                musig::KeyAggCache::new(&[&a, &b])
             }
         }
     }
@@ -340,7 +343,8 @@ impl LBtcSwapScript {
         let taproot_builder =
             taproot_builder.add_leaf_with_ver(1, self.refund_script(), LeafVersion::default())?;
 
-        let taproot_spend_info = taproot_builder.finalize(&secp, internal_key)?;
+        let taproot_spend_info =
+            taproot_builder.finalize(&secp, convert_xonly_key(internal_key))?;
 
         // Verify taproot construction
         if let Some(funding_addrs) = &self.funding_addrs {
@@ -578,7 +582,7 @@ impl LBtcSwapTx {
         keys: &Keypair,
         pub_nonce: &str,
         transaction_hash: &str,
-    ) -> Result<(MusigPartialSignature, MusigPubNonce), Error> {
+    ) -> Result<(musig::PartialSignature, musig::PublicNonce), Error> {
         self.swap_script
             .partial_sign(keys, pub_nonce, transaction_hash)
     }
@@ -628,32 +632,32 @@ impl LBtcSwapTx {
                     self.genesis_hash,
                 )?;
 
-            let msg = Message::from_digest_slice(claim_tx_taproot_hash.as_byte_array())?;
+            let msg = *claim_tx_taproot_hash.as_byte_array();
 
             let mut key_agg_cache = self.swap_script.musig_keyagg_cache();
 
-            let tweak = SecretKey::from_slice(
-                self.swap_script
+            let tweak = Scalar::from_be_bytes(
+                *self
+                    .swap_script
                     .taproot_spendinfo()?
                     .tap_tweak()
                     .as_byte_array(),
             )?;
 
-            let secp = Secp256k1::new();
-            let _ = key_agg_cache.pubkey_xonly_tweak_add(&secp, tweak)?;
+            let _ = key_agg_cache.pubkey_xonly_tweak_add(&tweak)?;
 
-            let session_id = MusigSessionId::new(&mut thread_rng());
+            let session_secret_rand =
+                musig::SessionSecretRand::assume_unique_per_nonce_gen(rng_32b());
 
             let mut extra_rand = [0u8; 32];
             OsRng.fill_bytes(&mut extra_rand);
 
             let (claim_sec_nonce, claim_pub_nonce) = key_agg_cache.nonce_gen(
-                &secp,
-                session_id,
-                keys.public_key(),
-                msg,
+                session_secret_rand,
+                convert_public_key(keys.public_key()),
+                &msg,
                 Some(extra_rand),
-            )?;
+            );
 
             // Step 7: Get boltz's partial sig
             let claim_tx_hex = serialize(&claim_tx).to_lower_hex_string();
@@ -688,24 +692,21 @@ impl LBtcSwapTx {
                 ))),
             }?;
 
-            let boltz_public_nonce =
-                MusigPubNonce::from_slice(&Vec::from_hex(&partial_sig_resp.pub_nonce)?)?;
+            let boltz_public_nonce = musig::PublicNonce::from_str(&partial_sig_resp.pub_nonce)?;
 
-            let boltz_partial_sig = MusigPartialSignature::from_slice(&Vec::from_hex(
-                &partial_sig_resp.partial_signature,
-            )?)?;
+            let boltz_partial_sig =
+                musig::PartialSignature::from_str(&partial_sig_resp.partial_signature)?;
 
-            let agg_nonce = MusigAggNonce::new(&secp, &[boltz_public_nonce, claim_pub_nonce]);
+            let agg_nonce = musig::AggregatedNonce::new(&[&boltz_public_nonce, &claim_pub_nonce]);
 
-            let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+            let musig_session = musig::Session::new(&key_agg_cache, agg_nonce, &msg);
 
             // Verify the sigs.
             let boltz_partial_sig_verify = musig_session.partial_verify(
-                &secp,
                 &key_agg_cache,
-                boltz_partial_sig,
-                boltz_public_nonce,
-                self.swap_script.sender_pubkey.inner, //boltz key
+                &boltz_partial_sig,
+                &boltz_public_nonce,
+                convert_public_key(self.swap_script.sender_pubkey.inner), //boltz key
             );
 
             if !boltz_partial_sig_verify {
@@ -715,17 +716,21 @@ impl LBtcSwapTx {
             }
 
             let our_partial_sig =
-                musig_session.partial_sign(&secp, claim_sec_nonce, keys, &key_agg_cache)?;
+                musig_session.partial_sign(claim_sec_nonce, &convert_keypair(keys), &key_agg_cache);
 
-            let schnorr_sig = musig_session.partial_sig_agg(&[boltz_partial_sig, our_partial_sig]);
+            let schnorr_sig = musig_session
+                .partial_sig_agg(&[&boltz_partial_sig, &our_partial_sig])
+                .assume_valid();
 
             let final_schnorr_sig = SchnorrSig {
-                sig: schnorr_sig,
+                sig: convert_schnorr_signature(schnorr_sig),
                 hash_ty: SchnorrSighashType::Default,
             };
 
             let output_key = self.swap_script.taproot_spendinfo()?.output_key();
 
+            let secp = Secp256k1::new();
+            let msg = Message::from_digest_slice(&msg)?;
             secp.verify_schnorr(&final_schnorr_sig.sig, &msg, &output_key.into_inner())?;
 
             let mut script_witness = Witness::new();
@@ -765,16 +770,17 @@ impl LBtcSwapTx {
         };
 
         let secp = Secp256k1::new();
+        let mut rng = OsRng;
 
         let unblined_utxo = self
             .funding_utxo
             .unblind(&secp, self.swap_script.blinding_key.secret_key())?;
         let asset_id = unblined_utxo.asset;
-        let out_abf = AssetBlindingFactor::new(&mut thread_rng());
+        let out_abf = AssetBlindingFactor::new(&mut rng);
         let exp_asset = Asset::Explicit(asset_id);
 
         let (blinded_asset, asset_surjection_proof) =
-            exp_asset.blind(&mut thread_rng(), &secp, out_abf, &[unblined_utxo])?;
+            exp_asset.blind(&mut rng, &secp, out_abf, &[unblined_utxo])?;
 
         let output_value = Amount::from_sat(unblined_utxo.value) - Amount::from_sat(absolute_fees);
 
@@ -798,7 +804,7 @@ impl LBtcSwapTx {
             asset: asset_id,
             bf: out_abf,
         };
-        let ephemeral_sk = SecretKey::new(&mut thread_rng());
+        let ephemeral_sk = SecretKey::new(&mut rng);
 
         // assuming we always use a blinded address that has an extractable blinding pub
         let blinding_key = self
@@ -932,31 +938,32 @@ impl LBtcSwapTx {
                     self.genesis_hash,
                 )?;
 
-            let msg = Message::from_digest_slice(claim_tx_taproot_hash.as_byte_array())?;
+            let msg = *claim_tx_taproot_hash.as_byte_array();
 
             let mut key_agg_cache = self.swap_script.musig_keyagg_cache();
 
-            let tweak = SecretKey::from_slice(
-                self.swap_script
+            let tweak = Scalar::from_be_bytes(
+                *self
+                    .swap_script
                     .taproot_spendinfo()?
                     .tap_tweak()
                     .as_byte_array(),
             )?;
 
-            let _ = key_agg_cache.pubkey_xonly_tweak_add(&secp, tweak)?;
+            let _ = key_agg_cache.pubkey_xonly_tweak_add(&tweak)?;
 
-            let session_id = MusigSessionId::new(&mut thread_rng());
+            let session_secret_rand =
+                musig::SessionSecretRand::assume_unique_per_nonce_gen(rng_32b());
 
             let mut extra_rand = [0u8; 32];
             OsRng.fill_bytes(&mut extra_rand);
 
             let (sec_nonce, pub_nonce) = key_agg_cache.nonce_gen(
-                &secp,
-                session_id,
-                keys.public_key(),
-                msg,
+                session_secret_rand,
+                convert_public_key(keys.public_key()),
+                &msg,
                 Some(extra_rand),
-            )?;
+            );
 
             // Step 7: Get boltz's partial sig
             let refund_tx_hex = serialize(&refund_tx).to_lower_hex_string();
@@ -977,24 +984,21 @@ impl LBtcSwapTx {
                 ))),
             }?;
 
-            let boltz_public_nonce =
-                MusigPubNonce::from_slice(&Vec::from_hex(&partial_sig_resp.pub_nonce)?)?;
+            let boltz_public_nonce = musig::PublicNonce::from_str(&partial_sig_resp.pub_nonce)?;
 
-            let boltz_partial_sig = MusigPartialSignature::from_slice(&Vec::from_hex(
-                &partial_sig_resp.partial_signature,
-            )?)?;
+            let boltz_partial_sig =
+                musig::PartialSignature::from_str(&partial_sig_resp.partial_signature)?;
 
-            let agg_nonce = MusigAggNonce::new(&secp, &[boltz_public_nonce, pub_nonce]);
+            let agg_nonce = musig::AggregatedNonce::new(&[&boltz_public_nonce, &pub_nonce]);
 
-            let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+            let musig_session = musig::Session::new(&key_agg_cache, agg_nonce, &msg);
 
             // Verify the sigs.
             let boltz_partial_sig_verify = musig_session.partial_verify(
-                &secp,
                 &key_agg_cache,
-                boltz_partial_sig,
-                boltz_public_nonce,
-                self.swap_script.receiver_pubkey.inner, //boltz key
+                &boltz_partial_sig,
+                &boltz_public_nonce,
+                convert_public_key(self.swap_script.receiver_pubkey.inner), //boltz key
             );
 
             if !boltz_partial_sig_verify {
@@ -1004,17 +1008,20 @@ impl LBtcSwapTx {
             }
 
             let our_partial_sig =
-                musig_session.partial_sign(&secp, sec_nonce, keys, &key_agg_cache)?;
+                musig_session.partial_sign(sec_nonce, &convert_keypair(keys), &key_agg_cache);
 
-            let schnorr_sig = musig_session.partial_sig_agg(&[boltz_partial_sig, our_partial_sig]);
+            let schnorr_sig = musig_session
+                .partial_sig_agg(&[&boltz_partial_sig, &our_partial_sig])
+                .assume_valid();
 
             let final_schnorr_sig = SchnorrSig {
-                sig: schnorr_sig,
+                sig: convert_schnorr_signature(schnorr_sig),
                 hash_ty: SchnorrSighashType::Default,
             };
 
             let output_key = self.swap_script.taproot_spendinfo()?.output_key();
 
+            let msg = Message::from_digest_slice(&msg)?;
             secp.verify_schnorr(&final_schnorr_sig.sig, &msg, &output_key.into_inner())?;
 
             let mut script_witness = Witness::new();
@@ -1050,16 +1057,17 @@ impl LBtcSwapTx {
         };
 
         let secp = Secp256k1::new();
+        let mut rng = OsRng;
 
         let unblined_utxo = self
             .funding_utxo
             .unblind(&secp, self.swap_script.blinding_key.secret_key())?;
         let asset_id = unblined_utxo.asset;
-        let out_abf = AssetBlindingFactor::new(&mut thread_rng());
+        let out_abf = AssetBlindingFactor::new(&mut rng);
         let exp_asset = Asset::Explicit(asset_id);
 
         let (blinded_asset, asset_surjection_proof) =
-            exp_asset.blind(&mut thread_rng(), &secp, out_abf, &[unblined_utxo])?;
+            exp_asset.blind(&mut rng, &secp, out_abf, &[unblined_utxo])?;
 
         let output_value = Amount::from_sat(unblined_utxo.value) - Amount::from_sat(absolute_fees);
 
@@ -1083,7 +1091,7 @@ impl LBtcSwapTx {
             asset: asset_id,
             bf: out_abf,
         };
-        let ephemeral_sk = SecretKey::new(&mut thread_rng());
+        let ephemeral_sk = SecretKey::new(&mut rng);
 
         // assuming we always use a blinded address that has an extractable blinding pub
         let blinding_key = self
@@ -1240,6 +1248,30 @@ impl LBtcSwapTx {
     }
 }
 
+fn convert_schnorr_signature(
+    schnorr_sig: secp256k1_musig::schnorr::Signature,
+) -> bitcoin::secp256k1::schnorr::Signature {
+    bitcoin::secp256k1::schnorr::Signature::from_slice(schnorr_sig.as_byte_array())
+        .expect("signature size matches")
+}
+
+fn convert_pubkeys_for_musig(
+    pubkeys: &[elements::secp256k1_zkp::PublicKey; 2],
+) -> [secp256k1_musig::PublicKey; 2] {
+    [
+        convert_public_key(pubkeys[0]),
+        convert_public_key(pubkeys[1]),
+    ]
+}
+
+fn convert_xonly_key(key: secp256k1_musig::XOnlyPublicKey) -> bitcoin::XOnlyPublicKey {
+    bitcoin::XOnlyPublicKey::from_slice(&key.serialize()[..]).expect("xonly key size matches")
+}
+
+fn convert_public_key(key: elements::secp256k1_zkp::PublicKey) -> secp256k1_musig::PublicKey {
+    secp256k1_musig::PublicKey::from_slice(&key.serialize()[..]).expect("public key size matches")
+}
+
 impl SwapScriptCommon for LBtcSwapScript {
     fn swap_type(&self) -> SwapType {
         self.swap_type
@@ -1252,39 +1284,48 @@ impl SwapScriptCommon for LBtcSwapScript {
         keys: &Keypair,
         pub_nonce: &str,
         transaction_hash: &str,
-    ) -> Result<(MusigPartialSignature, MusigPubNonce), Error> {
+    ) -> Result<(musig::PartialSignature, musig::PublicNonce), Error> {
         // Step 1: Start with a Musig KeyAgg Cache
-        let secp = Secp256k1::new();
-
         let pubkeys = [self.receiver_pubkey.inner, self.sender_pubkey.inner];
+        let [a, b] = convert_pubkeys_for_musig(&pubkeys);
 
-        let mut key_agg_cache = MusigKeyAggCache::new(&secp, &pubkeys);
+        let mut key_agg_cache = musig::KeyAggCache::new(&[&a, &b]);
 
-        let tweak = SecretKey::from_slice(self.taproot_spendinfo()?.tap_tweak().as_byte_array())?;
+        let tweak = Scalar::from_be_bytes(*self.taproot_spendinfo()?.tap_tweak().as_byte_array())?;
 
-        let _ = key_agg_cache.pubkey_xonly_tweak_add(&secp, tweak)?;
+        let _ = key_agg_cache.pubkey_xonly_tweak_add(&tweak)?;
 
-        let session_id = MusigSessionId::new(&mut thread_rng());
+        let session_secret_rand = musig::SessionSecretRand::assume_unique_per_nonce_gen(rng_32b());
 
-        let msg = Message::from_digest_slice(&Vec::from_hex(transaction_hash)?)?;
+        let msg = hex_to_bytes32(transaction_hash)?;
 
         // Step 4: Start the Musig2 Signing session
         let mut extra_rand = [0u8; 32];
         OsRng.fill_bytes(&mut extra_rand);
 
-        let (gen_sec_nonce, gen_pub_nonce) =
-            key_agg_cache.nonce_gen(&secp, session_id, keys.public_key(), msg, Some(extra_rand))?;
+        let (gen_sec_nonce, gen_pub_nonce) = key_agg_cache.nonce_gen(
+            session_secret_rand,
+            convert_public_key(keys.public_key()),
+            &msg,
+            Some(extra_rand),
+        );
 
-        let boltz_nonce = MusigPubNonce::from_slice(&Vec::from_hex(pub_nonce)?)?;
+        let boltz_nonce = musig::PublicNonce::from_str(pub_nonce)?;
 
-        let agg_nonce = MusigAggNonce::new(&secp, &[boltz_nonce, gen_pub_nonce]);
+        let agg_nonce = musig::AggregatedNonce::new(&[&boltz_nonce, &gen_pub_nonce]);
 
-        let musig_session = MusigSession::new(&secp, &key_agg_cache, agg_nonce, msg);
+        let musig_session = musig::Session::new(&key_agg_cache, agg_nonce, &msg);
 
-        let partial_sig = musig_session.partial_sign(&secp, gen_sec_nonce, keys, &key_agg_cache)?;
+        let partial_sig =
+            musig_session.partial_sign(gen_sec_nonce, &convert_keypair(keys), &key_agg_cache);
 
         Ok((partial_sig, gen_pub_nonce))
     }
+}
+
+fn convert_keypair(keys: &Keypair) -> secp256k1_musig::Keypair {
+    secp256k1_musig::Keypair::from_seckey_byte_array(keys.secret_bytes())
+        .expect("keypair size matches")
 }
 
 fn tx_size(tx: &Transaction, is_discount_ct: bool) -> usize {

--- a/src/swaps/wrappers.rs
+++ b/src/swaps/wrappers.rs
@@ -5,9 +5,9 @@ use bitcoin::hashes::{sha256, Hash};
 use bitcoin::hex::FromHex;
 use bitcoin::secp256k1::Keypair;
 use bitcoin::Transaction as BtcTransaction;
-use elements::secp256k1_zkp::{MusigPartialSignature, MusigPubNonce};
 use elements::Transaction as LbtcTransaction;
 use lightning_invoice::Bolt11Invoice;
+use secp256k1_musig::musig;
 use serde_json::Value;
 
 use super::boltz::{
@@ -163,7 +163,7 @@ pub trait SwapScriptCommon {
         keys: &Keypair,
         pub_nonce: &str,
         transaction_hash: &str,
-    ) -> Result<(MusigPartialSignature, MusigPubNonce), Error>;
+    ) -> Result<(musig::PartialSignature, musig::PublicNonce), Error>;
 }
 
 /// A wrapper for swap scripts that can be either Bitcoin or Liquid
@@ -314,7 +314,7 @@ impl SwapScript {
         swap_id: &String,
         boltz_api: &'a BoltzApiClientV2,
     ) -> Result<Cooperative<'a>, Error> {
-        let signature: Option<(MusigPartialSignature, MusigPubNonce)> = match boltz_api
+        let signature: Option<(musig::PartialSignature, musig::PublicNonce)> = match boltz_api
             .get_chain_claim_tx_details(swap_id)
             .await
         {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
+use bitcoin::hex::FromHex;
 use std::time::Duration;
 
 pub mod ec;
@@ -8,6 +9,8 @@ pub mod secrets;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use gloo_timers::future::TimeoutFuture;
+
+use crate::error::Error;
 
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 static INIT: std::sync::Once = std::sync::Once::new();
@@ -37,4 +40,17 @@ pub async fn sleep(duration: Duration) {
         let timeout_ms = duration.as_millis() as u32;
         TimeoutFuture::new(timeout_ms).await;
     }
+}
+
+pub(crate) fn hex_to_bytes32(hex: &str) -> Result<[u8; 32], Error> {
+    let bytes = Vec::from_hex(hex)?;
+    if bytes.len() != 32 {
+        return Err(Error::Protocol(format!(
+            "Expected 32 bytes, got {}",
+            bytes.len()
+        )));
+    }
+    let mut result = [0u8; 32];
+    result.copy_from_slice(&bytes);
+    Ok(result)
 }

--- a/src/util/secrets.rs
+++ b/src/util/secrets.rs
@@ -179,7 +179,7 @@ impl Display for DerivationPurpose {
 }
 
 /// Internally used rng to generate secure 32 byte preimages
-fn rng_32b() -> [u8; 32] {
+pub(crate) fn rng_32b() -> [u8; 32] {
     let mut bytes = [0u8; 32];
     OsRng.fill_bytes(&mut bytes);
     bytes

--- a/tests/regtest/common.rs
+++ b/tests/regtest/common.rs
@@ -48,7 +48,7 @@ pub async fn next_status(
             }
         } => result,
         _ = sleep(Duration::from_secs(10)) => {
-            Err(anyhow::anyhow!("Timeout waiting for status: {}", expected_status))
+            Err(anyhow::anyhow!("Timeout waiting for status: {expected_status}"))
         }
     }
 }


### PR DESCRIPTION
`SessionSecretRand::assume_unique_per_nonce_gen` is used instead of adding rand feature to secp because it was causing issues on wasm32 target

All the `convert_*` methods will not be necessary anymore once secp_musig is used from bitcoin crate

tested the commit c0e4f2d57ca88027ff2db5feb9ffd63dc34c2e8c from lwk_boltz and I made a submarine and a reverse swap in regtest