### PR TITLE
New SwapMasterKey struct for easier key management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ reqwest = { version = "0.12.12" , default-features = false, features = ["json", 
 macros = { path = "macros" }
 futures-util = "0.3.31"
 tokio-tungstenite-wasm = { version = "0.6.0", features = ["rustls-tls-webpki-roots"], optional = true }
+bip85_extended = "1.1.0"
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 electrum-client = { version = "0.21.0", default-features = false, features = ["use-rustls-ring", "proxy"], optional = true }

--- a/bindings/src/util.rs
+++ b/bindings/src/util.rs
@@ -7,7 +7,7 @@ pub struct Preimage(pub(crate) boltz_client::util::secrets::Preimage);
 impl Preimage {
     #[uniffi::constructor]
     pub fn new() -> Self {
-        Self(boltz_client::util::secrets::Preimage::new())
+        Self(boltz_client::util::secrets::Preimage::random())
     }
 
     #[uniffi::constructor]

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,7 @@ pub enum Error {
     ConfidentialTx(elements::ConfidentialTxOutError),
     BIP32(bitcoin::bip32::Error),
     BIP39(bip39::Error),
+    BIP85(bip85_extended::Error),
     Hash(bitcoin::hashes::FromSliceError),
     Locktime(String),
     Url(url::ParseError),
@@ -174,6 +175,12 @@ impl From<bip39::Error> for Error {
     }
 }
 
+impl From<bip85_extended::Error> for Error {
+    fn from(value: bip85_extended::Error) -> Self {
+        Self::BIP85(value)
+    }
+}
+
 impl From<bitcoin::absolute::ConversionError> for Error {
     fn from(value: bitcoin::absolute::ConversionError) -> Self {
         Self::Locktime(value.to_string())
@@ -273,6 +280,7 @@ impl Error {
             Error::ConfidentialTx(_) => "ConfidentialTx",
             Error::BIP32(_) => "BIP32",
             Error::BIP39(_) => "BIP39",
+            Error::BIP85(_) => "BIP85",
             Error::Hash(_) => "Hash",
             Error::Locktime(_) => "Locktime",
             Error::Url(_) => "Url",
@@ -311,6 +319,7 @@ impl Error {
             Error::ConfidentialTx(e) => e.to_string(),
             Error::BIP32(e) => e.to_string(),
             Error::BIP39(e) => e.to_string(),
+            Error::BIP85(e) => e.to_string(),
             Error::Hash(e) => e.to_string(),
             Error::Locktime(e) => e.clone(),
             Error::Url(e) => e.to_string(),

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -71,7 +71,7 @@ impl From<LiquidChain> for &'static AddressParams {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Network {
     Mainnet,
     Testnet,
@@ -94,6 +94,16 @@ impl From<Network> for LiquidChain {
             Network::Mainnet => LiquidChain::Liquid,
             Network::Testnet => LiquidChain::LiquidTestnet,
             Network::Regtest => LiquidChain::LiquidRegtest,
+        }
+    }
+}
+
+impl From<Network> for bitcoin::Network {
+    fn from(value: Network) -> Self {
+        match value {
+            Network::Mainnet => Self::Bitcoin,
+            Network::Testnet => Self::Testnet,
+            Network::Regtest => Self::Regtest,
         }
     }
 }

--- a/src/util/secrets.rs
+++ b/src/util/secrets.rs
@@ -1,12 +1,30 @@
-use std::fmt::Display;
-use std::fmt::Formatter;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+//! # Usage Instructions
+//!
+//! ## Creating SwapMasterKey
+//! Use `SwapMasterKey::new` with your wallet mnemonic and passphrase to create a SwapMasterKey.
+//! The method will internally derive the BIP85 swap mnemonic from your wallet mnemonic.
+//! The SwapMasterKey should then be stored (it can be serialized to JSON) to use for each swap with the `derive_swapkey` method.
+//!
+//! ## Example
+//! ```no_run
+//! use boltz_client::util::secrets::SwapMasterKey;
+//! use boltz_client::network::Network;
+//!
+//! // Create SwapMasterKey from wallet mnemonic (BIP85 derivation happens internally)
+//! let wallet_mnemonic = "bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon";
+//! let swap_master_key = SwapMasterKey::new(wallet_mnemonic, None, Network::Mainnet)?;
+//!
+//! // Store swap_master_key (can be serialized to JSON)
+//! // Later, derive keys for each swap
+//! let swap_key = swap_master_key.derive_swapkey(0)?;
+//! # Ok::<(), boltz_client::error::Error>(())
+//! ```
+
 use std::str::FromStr;
 
 use bip39::Mnemonic;
-use bitcoin::bip32::{DerivationPath, Fingerprint, Xpriv};
+use bip85_extended;
+use bitcoin::bip32::{DerivationPath, Fingerprint, Xpriv, Xpub};
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
 use bitcoin::hex::{DisplayHex, FromHex};
 use bitcoin::key::rand::{rngs::OsRng, RngCore};
@@ -14,170 +32,156 @@ use bitcoin::secp256k1::{Keypair, Secp256k1};
 use elements::secp256k1_zkp::{Keypair as ZKKeyPair, Secp256k1 as ZKSecp256k1};
 use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
-use serde_json;
 
 use crate::error::Error;
-use crate::network::{BitcoinChain, Chain, LiquidChain};
+use crate::network::Network;
 
-const SUBMARINE_SWAP_ACCOUNT: u32 = 21;
-const REVERSE_SWAP_ACCOUNT: u32 = 42;
-const CHAIN_SWAP_ACCOUNT: u32 = 84;
+const MNEMONIC_BIP85_INDEX: u32 = 26589;
+const SWAP_KEY_DERIVATION_PATH: &str = "m/26589'/0'/0'";
 
-const BITCOIN_NETWORK_PATH: u32 = 0;
-const LIQUID_NETWORK_PATH: u32 = 1776;
-const TESTNET_NETWORK_PATH: u32 = 1;
-
-/// Derived Keypair for use in a script.
-/// Can be used directly with Bitcoin structures
-/// Can be converted .into() LiquidSwapKey
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SwapKey {
+/// Swap master key to derive swap keys for all swaps.
+///
+/// This struct holds the BIP85-derived swap mnemonic and the master private key derived from it.
+/// It can be stored (serialized to JSON) and reused to derive individual swap keys without
+/// needing to pass the mnemonic and passphrase repeatedly.
+///
+/// The mnemonic field contains the BIP85-derived swap mnemonic, which can be used for recovery
+/// on: https://boltz.exchange/rescue/external?mode=rescue-key
+///
+/// Can also be used to get the root xpubs that can be used with the swap/restore API.
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct SwapMasterKey {
+    /// The BIP85-derived swap mnemonic
+    pub mnemonic: Mnemonic,
+    /// The child xprv derived from the swap mnemonic at the standard derivation path
+    pub xprv: Xpriv,
+    /// The fingerprint of the root key
     pub fingerprint: Fingerprint,
-    pub path: DerivationPath,
-    pub keypair: Keypair,
+    /// The network this key is for
+    pub network: Network,
 }
-impl SwapKey {
-    /// Derives keys for a submarine swap at standardized path
-    /// m/49'/<0;1777;1>/21'/0/*
-    pub fn from_submarine_account(
-        mnemonic: &str,
-        passphrase: &str,
-        network: Chain,
-        index: u64,
-    ) -> Result<SwapKey, Error> {
+
+impl SwapMasterKey {
+    /// Creates SwapMasterKey from a wallet mnemonic.
+    ///
+    /// This method internally derives the BIP85 swap mnemonic from the wallet mnemonic
+    /// using BIP85 index `26589`, then creates the SwapMasterKey
+    /// from that derived mnemonic.
+    ///
+    /// The swap mnemonic stored in the returned struct can be used for recovery on:
+    /// https://boltz.exchange/rescue/external?mode=rescue-key
+    ///
+    /// # Arguments
+    /// * `wallet_mnemonic` - The wallet mnemonic to derive the swap mnemonic from
+    /// * `wallet_passphrase` - Optional passphrase for the wallet mnemonic
+    /// * `network` - The network (Mainnet, Testnet, or Regtest)
+    pub fn new(
+        wallet_mnemonic: &str,
+        wallet_passphrase: Option<&str>,
+        network: Network,
+    ) -> Result<SwapMasterKey, Error> {
         let secp = Secp256k1::new();
-        let mnemonic_struct = Mnemonic::from_str(mnemonic)?;
-        let seed = mnemonic_struct.to_seed(passphrase);
-        let root = Xpriv::new_master(bitcoin::Network::Testnet, &seed)?;
-        let fingerprint = root.fingerprint(&secp);
-        let purpose = DerivationPurpose::Compatible;
-        let network_path = match network {
-            Chain::Bitcoin(BitcoinChain::Bitcoin) => BITCOIN_NETWORK_PATH,
-            Chain::Liquid(LiquidChain::Liquid) => LIQUID_NETWORK_PATH,
-            _ => TESTNET_NETWORK_PATH,
-        };
-        let derivation_path =
-            format!("m/{purpose}h/{network_path}h/{SUBMARINE_SWAP_ACCOUNT}h/0/{index}");
-        let path = DerivationPath::from_str(&derivation_path)?;
-        let child_xprv = root.derive_priv(&secp, &path)?;
-
-        let key_pair = Keypair::from_secret_key(&secp, &child_xprv.private_key);
-
-        Ok(SwapKey {
-            path,
-            fingerprint,
-            keypair: key_pair,
-        })
+        let root = Self::derive_root_xpriv(wallet_mnemonic, wallet_passphrase, network)?;
+        let swap_mnemonic =
+            bip85_extended::mnemonic::to_mnemonic(&secp, &root, 12, MNEMONIC_BIP85_INDEX)?;
+        Self::from_mnemonic(&swap_mnemonic.to_string(), None, network)
     }
-    /// Derives keys for a reverse swap at standardized path
-    /// m/49'/<0;1777;1>/42'/0/*
-    pub fn from_reverse_account(
-        mnemonic: &str,
-        passphrase: &str,
-        network: Chain,
-        index: u64,
-    ) -> Result<SwapKey, Error> {
-        let secp = Secp256k1::new();
-        let mnemonic_struct = Mnemonic::from_str(mnemonic)?;
 
-        let seed = mnemonic_struct.to_seed(passphrase);
-        let root = Xpriv::new_master(bitcoin::Network::Testnet, &seed)?;
+    /// Creates SwapMasterKey directly from a mnemonic.
+    ///
+    /// Use this method if you already have the swap mnemonic (e.g., from a previous
+    /// SwapMasterKey that was serialized, or if you're restoring from the rescue key).
+    ///
+    /// The mnemonic will be used to derive the master key at the standard derivation path
+    /// `m/26589'/0'/0'`.
+    ///
+    /// # Arguments
+    /// * `mnemonic` - The swap mnemonic (12-word BIP39 mnemonic)
+    /// * `passphrase` - Optional passphrase for the mnemonic
+    /// * `network` - The network (Mainnet, Testnet, or Regtest)
+    pub fn from_mnemonic(
+        mnemonic: &str,
+        passphrase: Option<&str>,
+        network: Network,
+    ) -> Result<SwapMasterKey, Error> {
+        let secp = Secp256k1::new();
+        let root = Self::derive_root_xpriv(mnemonic, passphrase, network)?;
         let fingerprint = root.fingerprint(&secp);
-        let purpose = DerivationPurpose::Native;
-        let network_path = match network {
-            Chain::Bitcoin(BitcoinChain::Bitcoin) => BITCOIN_NETWORK_PATH,
-            Chain::Liquid(LiquidChain::Liquid) => LIQUID_NETWORK_PATH,
-            _ => TESTNET_NETWORK_PATH,
-        };
-        // m/84h/1h/42h/<0;1>/*  - child key for segwit wallet - xprv
-        let derivation_path =
-            format!("m/{purpose}h/{network_path}h/{REVERSE_SWAP_ACCOUNT}h/0/{index}");
-        let path = DerivationPath::from_str(&derivation_path)?;
-        let child_xprv = root.derive_priv(&secp, &path)?;
 
-        let key_pair = Keypair::from_secret_key(&secp, &child_xprv.private_key);
+        let master_path = DerivationPath::from_str(SWAP_KEY_DERIVATION_PATH)?;
+        let xprv = root.derive_priv(&secp, &master_path)?;
 
-        Ok(SwapKey {
-            path,
-            fingerprint,
-            keypair: key_pair,
-        })
-    }
-    /// Derives keys for a chain swap at standardized path
-    pub fn from_chain_account(
-        mnemonic: &str,
-        passphrase: &str,
-        network: Chain,
-        index: u64,
-    ) -> Result<SwapKey, Error> {
-        let secp = Secp256k1::new();
         let mnemonic_struct = Mnemonic::from_str(mnemonic)?;
 
-        let seed = mnemonic_struct.to_seed(passphrase);
-        let root = Xpriv::new_master(bitcoin::Network::Testnet, &seed)?;
-        let fingerprint = root.fingerprint(&secp);
-        let purpose = DerivationPurpose::Taproot;
-        let network_path = match network {
-            Chain::Bitcoin(BitcoinChain::Bitcoin) => BITCOIN_NETWORK_PATH,
-            Chain::Liquid(LiquidChain::Liquid) => LIQUID_NETWORK_PATH,
-            _ => TESTNET_NETWORK_PATH,
-        };
-        // m/84h/1h/42h/<0;1>/*  - child key for segwit wallet - xprv
-        let derivation_path =
-            format!("m/{purpose}h/{network_path}h/{CHAIN_SWAP_ACCOUNT}h/0/{index}");
-        let path = DerivationPath::from_str(&derivation_path)?;
-        let child_xprv = root.derive_priv(&secp, &path)?;
-
-        let key_pair = Keypair::from_secret_key(&secp, &child_xprv.private_key);
-
-        Ok(SwapKey {
-            path,
+        Ok(SwapMasterKey {
+            mnemonic: mnemonic_struct,
+            xprv,
             fingerprint,
-            keypair: key_pair,
+            network,
         })
     }
-}
-#[derive(Clone)]
+    /// Derives a KeyPair for a specific swap index.
+    ///
+    /// Use this method for each swap. The client must handle incrementing the index
+    /// themselves to ensure each swap uses a unique key.
+    ///
+    /// # Arguments
+    /// * `index` - The swap index (0, 1, 2, etc.)
+    ///
+    /// # Returns
+    /// A `KeyPair` derived at path `m/26589'/0'/0'/{index}`
+    pub fn derive_swapkey(&self, index: u64) -> Result<Keypair, Error> {
+        let secp = Secp256k1::new();
+        let child_path = DerivationPath::from_str(&format!("m/{index}"))?;
+        let child_xprv = self.xprv.derive_priv(&secp, &child_path)?;
+        let key_pair = Keypair::from_secret_key(&secp, &child_xprv.private_key);
+        Ok(key_pair)
+    }
 
-/// For Liquid keys, first create a SwapKey and then call .into() to get the equivalent ZKKeypair
-/// let sk = SwapKey::from_reverse_account(&mnemonic.to_string(), "", Chain::LiquidTestnet, 1)?
-/// let lsk: LiquidSwapKey = swap_key.try_into()?;
-/// let zkkp = lsk.keypair;
-#[derive(Serialize, Deserialize, Debug)]
-pub struct LiquidSwapKey {
-    pub fingerprint: Fingerprint,
-    pub path: DerivationPath,
-    pub keypair: ZKKeyPair,
-}
-impl TryFrom<SwapKey> for LiquidSwapKey {
-    type Error = Error;
-    fn try_from(swapkey: SwapKey) -> Result<Self, Self::Error> {
+    /// Derives a ZKKeyPair for Liquid swaps at a specific swap index.
+    ///
+    /// Use this method for each Liquid swap. The client must handle incrementing the index
+    /// themselves to ensure each swap uses a unique key.
+    ///
+    /// # Arguments
+    /// * `index` - The swap index (0, 1, 2, etc.)
+    ///
+    /// # Returns
+    /// A `ZKKeyPair` derived at path `m/26589'/0'/0'/{index}`
+    pub fn derive_liquid_swapkey(&self, index: u64) -> Result<ZKKeyPair, Error> {
+        let keypair = self.derive_swapkey(index)?;
         let secp = ZKSecp256k1::new();
-        let liquid_keypair =
-            ZKKeyPair::from_seckey_str(&secp, &swapkey.keypair.display_secret().to_string())?;
+        let zk_keypair = ZKKeyPair::from_seckey_str(&secp, &keypair.display_secret().to_string())?;
+        Ok(zk_keypair)
+    }
 
-        Ok(LiquidSwapKey {
-            fingerprint: swapkey.fingerprint,
-            path: swapkey.path,
-            keypair: liquid_keypair,
-        })
+    /// Gets the master extended public key (xpub) derived from the master private key.
+    ///
+    /// This xpub can be used with the swap/restore API to enable key recovery.
+    ///
+    /// # Returns
+    /// The master extended public key
+    pub fn get_master_xpub(&self) -> Xpub {
+        let secp = Secp256k1::new();
+        Xpub::from_priv(&secp, &self.xprv)
+    }
+
+    fn derive_root_xpriv(
+        mnemonic: &str,
+        passphrase: Option<&str>,
+        network: Network,
+    ) -> Result<Xpriv, Error> {
+        let mnemonic_struct = Mnemonic::from_str(mnemonic)?;
+        let seed = mnemonic_struct.to_seed(passphrase.unwrap_or(""));
+        let root = Xpriv::new_master(bitcoin::Network::from(network), &seed)?;
+        Ok(root)
     }
 }
-enum DerivationPurpose {
-    Compatible,
-    Native,
-    Taproot,
-}
-impl Display for DerivationPurpose {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        match self {
-            DerivationPurpose::Compatible => write!(f, "49"),
-            DerivationPurpose::Native => write!(f, "84"),
-            DerivationPurpose::Taproot => write!(f, "86"),
-        }
-    }
-}
 
+/// For Liquid keys, first create a KeyPair from SwapMasterKey and then convert it to ZKKeyPair
+/// let swap_master_key = SwapMasterKey::new(wallet_mnemonic, None, Network::Mainnet)?;
+/// let keypair = swap_master_key.derive_swapkey(1)?;
+/// let zk_keypair = ZKKeyPair::from_seckey_str(&ZKSecp256k1::new(), &keypair.display_secret().to_string())?;
 /// Internally used rng to generate secure 32 byte preimages
 pub(crate) fn rng_32b() -> [u8; 32] {
     let mut bytes = [0u8; 32];
@@ -186,7 +190,7 @@ pub(crate) fn rng_32b() -> [u8; 32] {
 }
 
 /// Helper to work with Preimage & Hashes required for swap scripts.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
 pub struct Preimage {
     pub bytes: Option<[u8; 32]>,
     pub sha256: sha256::Hash,
@@ -204,13 +208,15 @@ impl FromStr for Preimage {
 
 impl Default for Preimage {
     fn default() -> Self {
-        Preimage::new()
+        Preimage::random()
     }
 }
 
 impl Preimage {
     /// Creates a new random preimage
-    pub fn new() -> Preimage {
+    /// RECOMMENDED NOT TO USE THIS FUNCTION
+    /// USE FROM_SWAP_KEY INSTEAD
+    pub fn random() -> Preimage {
         let preimage = rng_32b();
         let sha256 = sha256::Hash::hash(&preimage);
         let hash160 = hash160::Hash::hash(&preimage);
@@ -269,34 +275,22 @@ impl Preimage {
     pub fn to_string(&self) -> Option<String> {
         self.bytes.map(|res| res.to_lower_hex_string())
     }
-}
 
-/// Boltz standard JSON refund swap file. Can be used to create a file that can be uploaded to boltz.exchange
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RefundSwapFile {
-    pub id: String,
-    pub currency: String,
-    pub redeem_script: String,
-    pub private_key: String,
-    pub timeout_block_height: u32,
-}
-impl RefundSwapFile {
-    pub fn file_name(&self) -> String {
-        format!("boltz-{}.json", self.id)
-    }
-    pub fn write_to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
-        let mut full_path = PathBuf::from(path.as_ref());
-        full_path.push(self.file_name());
-        let mut file = File::create(&full_path)?;
-        let json = serde_json::to_string_pretty(self)?;
-        writeln!(file, "{json}")?;
-        Ok(())
-    }
-    pub fn read_from_file<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        let mut file = File::open(path)?;
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
-        Ok(serde_json::from_str(&contents)?)
+    /// Creates a Preimage from a KeyPair's private key hash
+    /// sha256(privateKey(index))
+    /// RECOMMENDED TO ENSURE SWAPS CAN BE RESTORED MORE EASILY
+    pub fn from_swap_key(keypair: &Keypair) -> Preimage {
+        let private_key_bytes = keypair.secret_key().secret_bytes();
+        let preimage = sha256::Hash::hash(&private_key_bytes);
+        let preimage_bytes: [u8; 32] = *preimage.as_byte_array();
+        let sha256 = sha256::Hash::hash(&preimage_bytes);
+        let hash160 = hash160::Hash::hash(&preimage_bytes);
+
+        Preimage {
+            bytes: Some(preimage_bytes),
+            sha256,
+            hash160,
+        }
     }
 }
 
@@ -309,32 +303,18 @@ mod tests {
     fn test_derivation() {
         let mnemonic: &str = "bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon";
         let index = 0_u64; // 0
-        let sk = SwapKey::from_submarine_account(
-            mnemonic,
-            "",
-            Chain::Bitcoin(BitcoinChain::Bitcoin),
-            index,
-        )
-        .unwrap();
-        let lsk: LiquidSwapKey = match LiquidSwapKey::try_from(sk.clone()) {
-            Ok(t) => t,
-            Err(e) => {
-                // Conversion failed, handle the error
-                return println!("Error converting to LiquidSwapKey: {e:?}");
-            }
-        };
-        assert_eq!(sk.fingerprint, lsk.fingerprint);
-        // println!("{:?}", derived.unwrap().Keypair.display_secret());
-        assert_eq!(&sk.fingerprint.to_string().clone(), "9a6a2580");
-        assert_eq!(
-            &sk.keypair.display_secret().to_string(),
-            "d8d26ab9ba4e2c44f1a1fb9e10dc9d78707aaaaf38b5d42cf5c8bf00306acd85"
-        );
+        let swap_master_key =
+            SwapMasterKey::from_mnemonic(mnemonic, None, Network::Mainnet).unwrap();
+        let keypair = swap_master_key.derive_swapkey(index).unwrap();
+        let secp = ZKSecp256k1::new();
+        let zk_keypair =
+            ZKKeyPair::from_seckey_str(&secp, &keypair.display_secret().to_string()).unwrap();
+        assert_eq!(keypair.public_key(), zk_keypair.public_key());
     }
 
     #[macros::test_all]
     fn test_preimage_from_str() {
-        let preimage = Preimage::new();
+        let preimage = Preimage::random();
         assert_eq!(
             Preimage::from_str(&hex::encode(preimage.bytes.unwrap()).to_string()).unwrap(),
             preimage
@@ -343,7 +323,7 @@ mod tests {
 
     #[macros::test_all]
     fn test_preimage_from_vec() {
-        let preimage = Preimage::new();
+        let preimage = Preimage::random();
         assert_eq!(
             Preimage::from_vec(Vec::from(preimage.bytes.unwrap())).unwrap(),
             preimage
@@ -365,7 +345,7 @@ mod tests {
 
     #[macros::test_all]
     fn test_preimage_from_sha256_str() {
-        let preimage = Preimage::new();
+        let preimage = Preimage::random();
         let compare = Preimage::from_sha256_str(preimage.sha256.to_string().as_str()).unwrap();
 
         assert_eq!(compare.bytes, None);
@@ -375,7 +355,7 @@ mod tests {
 
     #[macros::test_all]
     fn test_preimage_from_sha256_vec() {
-        let preimage = Preimage::new();
+        let preimage = Preimage::random();
         let compare = Preimage::from_sha256_vec(preimage.sha256.serialize()).unwrap();
 
         assert_eq!(compare.bytes, None);
@@ -383,28 +363,62 @@ mod tests {
         assert_eq!(compare.hash160, preimage.hash160);
     }
 
-    // #[macros::test_all]
-    // #[ignore]
-    // fn test_recover() {
-    //     let recovery = BtcSubmarineRecovery {
-    //         id: "y8uGeA".to_string(),
-    //         refund_key: "5416f1e024c191605502017d066786e294f841e711d3d437d13e9d27e40e066e".to_string(),
-    //         redeem_script: "a914046fabc17989627f6ca9c1846af8e470263e712d87632102c929edb654bc1da91001ec27d74d42b5d6a8cf8aef2fab7c55f2eb728eed0d1f6703634d27b1752102c530b4583640ab3df5c75c5ce381c4b747af6bdd6c618db7e5248cb0adcf3a1868ac".to_string(),
-    //     };
-    //     //let file: RefundSwapFile = recovery.try_into();
+    #[macros::test_all]
+    fn test_swap_master_key() -> Result<(), Error> {
+        let wallet_mnemonic = "bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon bacon";
+        let wallet_passphrase = None;
+        let network = Network::Mainnet;
 
-    //     let file: RefundSwapFile = match BtcSubmarineRecovery::try_into(recovery) {
-    //         Ok(file) => file,
-    //         Err(err) => {
-    //             // Handle the error
-    //             return println!("Error converting: {:?}", err);
-    //         }
-    //     };
+        let swap_master_key = SwapMasterKey::new(wallet_mnemonic, wallet_passphrase, network)?;
 
-    //     let base_path = "/tmp/boltz-rust";
-    //     file.write_to_file(base_path).unwrap();
-    //     let file_path = base_path.to_owned() + "/" + &file.file_name();
-    //     let file_struct = RefundSwapFile::read_from_file(file_path);
-    //     println!("Refund File: {:?}", file_struct);
-    // }
+        assert_eq!(
+            swap_master_key.mnemonic.to_string(),
+            "velvet engage shaft effort clarify annual protect client only surround sock gain"
+                .to_string(),
+            "BIP85 extended method should produce the same mnemonic as raw derivation"
+        );
+
+        assert_eq!(
+            swap_master_key.xprv.to_string(),
+            "xprv9z1rybmkZ6Bx45RJ4wGsXWuMtrrKpvyMgny9ZPcoWWgXs2XWotuaqYaiLJuM8DEtj62DZ2wHpo4t2HsRtKfBf3mGf2LwK5xZix5LuvKNU7x",
+            "xpriv should match expected value"
+        );
+
+        let master_xpub = swap_master_key.get_master_xpub();
+        assert_eq!(
+            master_xpub.to_string(),
+            "xpub6D1DP7JePTkFGZVmAxoster6StgpEPhD41tkMn2R4rDWjprfMSDqPLuCBb4JjF9XCAhtosDaxBqxUnbx49796i4fqsARfWFqMuHffxyuQRT",
+            "xpub should match expected value"
+        );
+
+        let swap_key_at_index_0 = swap_master_key.derive_swapkey(0)?;
+
+        let xprv_str = "xprvA1o5FLJ3sGydPdLFruGAx4HdgftKNZAjNCrzinqfXavcSBToLsgmNYjyXG8hbygMQSnKMsVt7kqHoZ4DZRXgpCxUN2JZLGU67FRgXXJWhNK";
+        let swap_xprv = Xpriv::from_str(xprv_str)?;
+        let secp = Secp256k1::new();
+
+        let keypair_from_xprv = Keypair::from_secret_key(&secp, &swap_xprv.private_key);
+
+        assert_eq!(
+            swap_key_at_index_0.public_key(),
+            keypair_from_xprv.public_key(),
+            "Swap key at index 0 should match KeyPair derived from xprv"
+        );
+        assert_eq!(
+            swap_key_at_index_0.secret_key(),
+            keypair_from_xprv.secret_key(),
+            "Swap key secret at index 0 should match KeyPair secret derived from xprv"
+        );
+        println!(
+            "Private key: {}",
+            swap_key_at_index_0.secret_key().display_secret()
+        );
+        let preimage = Preimage::from_swap_key(&swap_key_at_index_0);
+        assert_eq!(
+            preimage.bytes.unwrap().to_lower_hex_string(),
+            "92cde8be384328b97307492898383470dc4a967398bf45326b38e507752f844d".to_string(),
+        );
+
+        Ok(())
+    }
 }

--- a/tests/regtest/chain_swaps.rs
+++ b/tests/regtest/chain_swaps.rs
@@ -44,7 +44,7 @@ async fn bitcoin_liquid_v2_chain_esplora() {
 
 async fn v2_chain(chain_client: &ChainClient, underpay: bool, from: Chain, to: Chain) {
     let secp = Secp256k1::new();
-    let preimage = Preimage::new();
+    let preimage = Preimage::random();
     log::info!("{preimage:#?}");
     let our_claim_keys = Keypair::new(&secp, &mut thread_rng());
     let claim_public_key = PublicKey {

--- a/tests/regtest/reverse.rs
+++ b/tests/regtest/reverse.rs
@@ -24,7 +24,7 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 async fn swap(chain: Chain, chain_client: &ChainClient) {
     let secp = Secp256k1::new();
-    let preimage = Preimage::new();
+    let preimage = Preimage::random();
     let our_keys = Keypair::new(&secp, &mut thread_rng());
     let invoice_amount = 100000;
     let claim_public_key = PublicKey {

--- a/tests/txs.rs
+++ b/tests/txs.rs
@@ -31,7 +31,7 @@ fn prepare_btc_claim() -> (
     let test_framework = BtcTestFramework::init();
 
     // Generate a random preimage and hash it.
-    let preimage = Preimage::new();
+    let preimage = Preimage::random();
 
     // Generate dummy receiver and sender's keypair
     let secp = Secp256k1::new();
@@ -210,7 +210,7 @@ fn prepare_btc_refund() -> (
     let test_framework = BtcTestFramework::init();
 
     // Generate dummy receiver and sender's keypair
-    let preimage = Preimage::new();
+    let preimage = Preimage::random();
     let secp = Secp256k1::new();
     let recvr_keypair = Keypair::new(&secp, &mut thread_rng());
     let sender_keypair = Keypair::new(&secp, &mut thread_rng());
@@ -389,7 +389,7 @@ fn prepare_lbtc_claim() -> (
     let test_framework = LbtcTestFramework::init();
 
     // Generate a random preimage and hash it.
-    let preimage = Preimage::new();
+    let preimage = Preimage::random();
 
     // Generate dummy receiver and sender's keypair
     let secp = Secp256k1::new();
@@ -543,7 +543,7 @@ fn prepare_lbtc_refund() -> (
     let test_framework = LbtcTestFramework::init();
 
     // Generate dummy receiver and sender's keypair
-    let preimage = Preimage::new();
+    let preimage = Preimage::random();
     let secp = Secp256k1::new();
     let recvr_keypair = Keypair::new(&secp, &mut thread_rng());
     let sender_keypair = Keypair::new(&secp, &mut thread_rng());


### PR DESCRIPTION
- [x] New struct to manage swap keys (SwapMasterKey). Does not require constantly using wallet mnemonic to generate swaps keys. A single instance of SwapMasterKey can be saved and used to derive all swap keys. *BREAKING CHANGE*

- [x] SwapMasterKey has a method to generate the root xpub that can be used with the `restore` endpoint to restore swap history 

- [x] Added support for deterministic preimage generation based on boltz spec: https://api.docs.boltz.exchange/swap-restore.html#preimages

- [x] Remove unused swap recovery file code

- [x] Standardize derivation paths with boltz web-app
