### PR TITLE
Update macros cargo.toml for publishing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,6 +60,9 @@ jobs:
         run: make cargo-regtest-test
       - name: Run WASM regtest tests
         run: make wasm-regtest-test
+      - name: Build bindings
+        working-directory: bindings
+        run: make build-debug
       - name: Run bindings tests
         working-directory: bindings
         run: make test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ env_logger = "0.7"
 hex = "0.4"
 lnurl-rs = { version = "0.9.0", default-features = false, features = ["async", "async-https"], optional = true }
 reqwest = { version = "0.12.12" , default-features = false, features = ["json", "rustls-tls"] }
-macros = { path = "macros" }
+macros = { path = "macros", package = "boltz-client-macros" }
 futures-util = "0.3.31"
 tokio-tungstenite-wasm = { version = "0.6.0", features = ["rustls-tls-webpki-roots"], optional = true }
 bip85_extended = "1.1.0"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boltz_client"
-version = "0.3.0.post1"
+version = "0.3.1.post1"
 description = "Boltz Swap library"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boltz_client"
-version = "0.3.1.post1"
+version = "0.3.1"
 description = "Boltz Swap library"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
-name = "macros"
+name = "boltz-client-macros"
+version = "1.0.0"
 edition = "2021"
+license = "MIT"
+description = "Proc macros for boltz-client"
+repository = "https://github.com/SatoshiPortal/boltz-rust"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
To publish boltz-client to crates, macros must be published first to and the dependecny has to resolve to a published version. 

It is not possible to place this crate as a mod file within the project.

Also update the CI file to build bindings and updated the bindings to 0.3.1.post1