### PR TITLE
include amount in RefundDetails

### DIFF
--- a/src/swaps/boltz.rs
+++ b/src/swaps/boltz.rs
@@ -944,6 +944,7 @@ pub struct RefundDetails {
     pub server_public_key: String,
     pub timeout_block_height: u32,
     pub blinding_key: Option<String>,
+    pub amount: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
I am not sure about this change since I can see the field in the API docs, https://api.boltz.exchange/swagger#/Swap/post_swap_restore

But running a test locally with regtest env (at 3ac3ec69ddfae7800c4b949d16fa2e78042d74f8) the amount field doesn't seem to be returned