### PR TITLE
Bump Boltz regtest submodule

### DIFF
--- a/bindings/tests/bindings/submarine.py
+++ b/bindings/tests/bindings/submarine.py
@@ -63,11 +63,10 @@ async def swap(from_chain: boltz_client.Chain, refund: bool):
         await next_status(updates, "transaction.mempool")
         await mine_block()
 
-        if from_chain == lbtc_chain:
-            await next_status(updates, "transaction.claim.pending")
-            await swap_script.submarine_cooperative_claim(
-                swap_id, key_pair, invoice, boltz_api
-            )
+        await next_status(updates, "transaction.claim.pending")
+        await swap_script.submarine_cooperative_claim(
+            swap_id, key_pair, invoice, boltz_api
+        )
 
         await next_status(updates, "transaction.claimed")
         await delay()

--- a/src/swaps/status_stream.rs
+++ b/src/swaps/status_stream.rs
@@ -497,13 +497,20 @@ mod tests {
         let ws = Arc::new(boltz_api_v2.ws(BoltzWsConfig::default()));
 
         // Register the offer with the server
-        boltz_api_v2
+        let register_offer_result = boltz_api_v2
             .post_bolt12_offer(CreateBolt12OfferRequest {
                 offer: offer.to_string(),
                 url: None,
             })
-            .await
-            .unwrap();
+            .await;
+        if let Err(err) = register_offer_result {
+            // Regtest backend keeps state across runs; tolerate re-registering
+            // the same static offer used by this test fixture.
+            assert!(
+                err.to_string().contains("registered already"),
+                "unexpected offer registration error: {err}"
+            );
+        }
 
         assert!(!ws.is_connected().await);
         tokio::spawn(ws.clone().run_ws_loop());

--- a/tests/regtest/submarine.rs
+++ b/tests/regtest/submarine.rs
@@ -122,21 +122,19 @@ async fn v2_submarine(chain_client: &ChainClient, underpay: bool, chain: Chain) 
         next_status(&mut rx, "transaction.mempool").await.unwrap();
         utils::mine_blocks(1).await.unwrap();
 
-        if let Chain::Liquid(_) = chain {
-            next_status(&mut rx, "transaction.claim.pending")
-                .await
-                .unwrap();
-            let response = swap_script
-                .submarine_cooperative_claim(
-                    &swap_id,
-                    &our_keys,
-                    &create_swap_req.invoice,
-                    &boltz_api_v2,
-                )
-                .await
-                .unwrap();
-            log::debug!("Received claim tx details : {response:?}");
-        }
+        next_status(&mut rx, "transaction.claim.pending")
+            .await
+            .unwrap();
+        let response = swap_script
+            .submarine_cooperative_claim(
+                &swap_id,
+                &our_keys,
+                &create_swap_req.invoice,
+                &boltz_api_v2,
+            )
+            .await
+            .unwrap();
+        log::debug!("Received claim tx details : {response:?}");
 
         next_status(&mut rx, "transaction.claimed").await.unwrap();
         log::info!("Successfully completed submarine swap");


### PR DESCRIPTION
Regtest tests were failing because the latest Boltz backend Docker image is not compatible with the old version of the regtest Docker Compose