### PR TITLE
Support bolt12 in `submarine_cooperative_claim`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ bip39 = "2.0.0"
 lightning-invoice = "0.32.0"
 url = "2.5.0"
 log = "^0.4"
-env_logger = "0.7"
+env_logger = "0.11.8"
 hex = "0.4"
 lnurl-rs = { version = "0.9.0", default-features = false, features = ["async", "async-https"], optional = true }
 reqwest = { version = "0.12.12" , default-features = false, features = ["json", "rustls-tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ macros = { version = "1.0.0", package = "boltz-client-macros" }
 futures-util = "0.3.31"
 tokio-tungstenite-wasm = { version = "0.6.0", features = ["rustls-tls-webpki-roots"], optional = true }
 bip85_extended = "1.1.0"
+lightning = "0.2.2"
+bech32 = "0.9.1"
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 electrum-client = { version = "0.21.0", default-features = false, features = ["use-rustls-ring", "proxy"], optional = true }
@@ -68,6 +70,7 @@ js-sys = "0.3.77"
 web-sys = "0.3.77"
 wasm-bindgen-futures = "0.4.50"
 gloo-timers = { version = "0.3.0", features = ["futures"] }
+
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ futures-util = "0.3.31"
 tokio-tungstenite-wasm = { version = "0.6.0", features = ["rustls-tls-webpki-roots"], optional = true }
 bip85_extended = "1.1.0"
 lightning = "0.2.2"
-bech32 = "0.9.1"
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 electrum-client = { version = "0.21.0", default-features = false, features = ["use-rustls-ring", "proxy"], optional = true }

--- a/src/swaps/wrappers.rs
+++ b/src/swaps/wrappers.rs
@@ -21,6 +21,7 @@ use crate::network::{BitcoinClient, Chain, LiquidChain, LiquidClient, Network};
 use crate::swaps::bitcoin::{BtcSwapScript, BtcSwapTx};
 use crate::swaps::fees::estimate_claim_fee;
 use crate::swaps::liquid::{LBtcSwapScript, LBtcSwapTx};
+use crate::util::bolt12::parse_bolt12_invoice;
 use crate::util::fees::Fee;
 use crate::util::secrets::Preimage;
 
@@ -381,9 +382,21 @@ impl SwapScript {
 
         // Verify preimage matches invoice payment hash
         let preimage_hash = sha256::Hash::hash(&preimage);
-        let invoice = Bolt11Invoice::from_str(invoice)?;
-        let invoice_payment_hash = invoice.payment_hash();
-        if invoice_payment_hash.to_string() != preimage_hash.to_string() {
+        let invoice_payment_hash_string = match Bolt11Invoice::from_str(invoice) {
+            Ok(invoice) => invoice.payment_hash().to_string(),
+            Err(e1) => {
+                // try bolt12
+                match parse_bolt12_invoice(invoice) {
+                    Ok(invoice) => invoice.payment_hash().to_string(),
+                    Err(e2) => {
+                        return Err(Error::Generic(format!(
+                            "Invalid invoice (neither bolt11 nor bolt12) {e1:?} {e2:?}"
+                        )))
+                    }
+                }
+            }
+        };
+        if invoice_payment_hash_string != preimage_hash.to_string() {
             return Err(Error::Protocol(
                 "Preimage does not match invoice payment hash".to_string(),
             ));

--- a/src/swaps/wrappers.rs
+++ b/src/swaps/wrappers.rs
@@ -7,7 +7,6 @@ use bitcoin::key::Secp256k1;
 use bitcoin::secp256k1::Keypair;
 use bitcoin::{consensus, Amount, Transaction as BtcTransaction};
 use elements::{confidential, Transaction as LbtcTransaction};
-use lightning_invoice::Bolt11Invoice;
 use secp256k1_musig::musig;
 use serde_json::Value;
 
@@ -21,8 +20,8 @@ use crate::network::{BitcoinClient, Chain, LiquidChain, LiquidClient, Network};
 use crate::swaps::bitcoin::{BtcSwapScript, BtcSwapTx};
 use crate::swaps::fees::estimate_claim_fee;
 use crate::swaps::liquid::{LBtcSwapScript, LBtcSwapTx};
-use crate::util::bolt12::parse_bolt12_invoice;
 use crate::util::fees::Fee;
+use crate::util::invoice::LightningInvoice;
 use crate::util::secrets::Preimage;
 
 #[derive(Clone, Debug)]
@@ -382,21 +381,8 @@ impl SwapScript {
 
         // Verify preimage matches invoice payment hash
         let preimage_hash = sha256::Hash::hash(&preimage);
-        let invoice_payment_hash_string = match Bolt11Invoice::from_str(invoice) {
-            Ok(invoice) => invoice.payment_hash().to_string(),
-            Err(e1) => {
-                // try bolt12
-                match parse_bolt12_invoice(invoice) {
-                    Ok(invoice) => invoice.payment_hash().to_string(),
-                    Err(e2) => {
-                        return Err(Error::Generic(format!(
-                            "Invalid invoice (neither bolt11 nor bolt12) {e1:?} {e2:?}"
-                        )))
-                    }
-                }
-            }
-        };
-        if invoice_payment_hash_string != preimage_hash.to_string() {
+        let invoice = LightningInvoice::from_str(invoice)?;
+        if invoice.payment_hash() != preimage_hash.to_string() {
             return Err(Error::Protocol(
                 "Preimage does not match invoice payment hash".to_string(),
             ));

--- a/src/util/bolt12.rs
+++ b/src/util/bolt12.rs
@@ -1,0 +1,18 @@
+use bech32::FromBase32;
+use lightning::offers::invoice::Bolt12Invoice;
+
+use crate::error::Error;
+
+const BECH32_BOLT12_INVOICE_HRP: &str = "lni";
+pub fn parse_bolt12_invoice(bolt12_invoice: &str) -> Result<Bolt12Invoice, Error> {
+    // TODO: for some reason, upstream Bolt12Invoice::from_str is not supported, thus we do it manually
+    let (hrp, data) = bech32::decode_without_checksum(bolt12_invoice)
+        .map_err(|e| Error::Generic(e.to_string()))?;
+    if hrp.as_str() != BECH32_BOLT12_INVOICE_HRP {
+        return Err(Error::Generic(format!("invalid hrp: {hrp}")));
+    }
+
+    let data = Vec::<u8>::from_base32(&data).map_err(|e| Error::Generic(e.to_string()))?;
+    lightning::offers::invoice::Bolt12Invoice::try_from(data)
+        .map_err(|e| Error::Generic(format!("{e:?}")))
+}

--- a/src/util/bolt12.rs
+++ b/src/util/bolt12.rs
@@ -3,7 +3,7 @@ use lightning::offers::invoice::Bolt12Invoice;
 
 use crate::error::Error;
 
-const BECH32_BOLT12_INVOICE_HRP: &str = "lni";
+pub const BECH32_BOLT12_INVOICE_HRP: &str = "lni";
 pub fn parse_bolt12_invoice(bolt12_invoice: &str) -> Result<Bolt12Invoice, Error> {
     // TODO: for some reason, upstream Bolt12Invoice::from_str is not supported, thus we do it manually
     let (hrp, data) = bech32::decode_without_checksum(bolt12_invoice)

--- a/src/util/bolt12.rs
+++ b/src/util/bolt12.rs
@@ -1,18 +1,19 @@
-use bech32::FromBase32;
+use bitcoin::bech32::{primitives::decode::CheckedHrpstring, NoChecksum};
 use lightning::offers::invoice::Bolt12Invoice;
 
 use crate::error::Error;
 
 pub const BECH32_BOLT12_INVOICE_HRP: &str = "lni";
 pub fn parse_bolt12_invoice(bolt12_invoice: &str) -> Result<Bolt12Invoice, Error> {
-    // TODO: for some reason, upstream Bolt12Invoice::from_str is not supported, thus we do it manually
-    let (hrp, data) = bech32::decode_without_checksum(bolt12_invoice)
-        .map_err(|e| Error::Generic(e.to_string()))?;
-    if hrp.as_str() != BECH32_BOLT12_INVOICE_HRP {
-        return Err(Error::Generic(format!("invalid hrp: {hrp}")));
+    let dec = match CheckedHrpstring::new::<NoChecksum>(bolt12_invoice) {
+        Ok(dec) => dec,
+        Err(err) => return Err(Error::Generic(format!("{err:?}"))),
+    };
+    if dec.hrp().to_lowercase() != BECH32_BOLT12_INVOICE_HRP {
+        return Err(Error::Generic(format!("invalid hrp: {}", dec.hrp())));
     }
 
-    let data = Vec::<u8>::from_base32(&data).map_err(|e| Error::Generic(e.to_string()))?;
+    let data = dec.byte_iter().collect::<Vec<_>>();
     lightning::offers::invoice::Bolt12Invoice::try_from(data)
-        .map_err(|e| Error::Generic(format!("{e:?}")))
+        .map_err(|err| Error::Generic(format!("{err:?}")))
 }

--- a/src/util/bolt12.rs
+++ b/src/util/bolt12.rs
@@ -17,3 +17,34 @@ pub fn parse_bolt12_invoice(bolt12_invoice: &str) -> Result<Bolt12Invoice, Error
     lightning::offers::invoice::Bolt12Invoice::try_from(data)
         .map_err(|err| Error::Generic(format!("{err:?}")))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::parse_bolt12_invoice;
+
+    #[test]
+    fn test_parse_bolt12_invoice_example_1() {
+        let invoice_str = "lni1qqg0ec390prlx7twmetwtsutqlkjkq3qqc3xu3s3rg94nj40zfsy866mhu5vxne6tcej5878k2mneuvgjy83vggzcncmzqua57ytd2r5l00ka7n599v57rctrwqa5rpn57gqhvgrxph4qgqxyfhyvyg6pdvu4tcjvpp7kkal9rp57wj7xv4pl3ajku70rzy3pafq8xyksp2qqkppqfyczd00f00puf4x6leqj8fpsg57yk70vp2mjqhtea4x0e8rwuf9egycqtz0rvgrnknc3d4gwnaa7mh6ws54jnc0pvdcrksvxwneqza3qvcx7q5rtnnrrl78j37an98k7ffqpr5x2ha9mdwgmqt62269cqpdwqkv2cqs92fuq9z94zjpztk5phdr8cvh6669ca344fgzlrwza6v9tuuedls3qqezmqareeuj86qssuck00fxs4ysrmzzj2fy6qjkquxpavnjnmntxzf6ptxkv54e6r9f65q526cnxnpnk056y8qqqqqqqqqqqqqqqysqqqqqqqqqqqqp6f9jm7k9yqqqqqq2gprfegm0l2pqtxd3nlg5qgcax3mu7n4xjassnt5sy6yhvthctf8duvh5gsw0muu65qucj6q2uqczqqqtqggzcncmzqua57ytd2r5l00ka7n599v57rctrwqa5rpn57gqhvgrxphlqsyn7q548cgapx4z4x9sjfr2fmz9mqtgsqrnyjwl6fzfdgls3tu97w29jcnfedyvzfqm8qlr5g279a0xep6w3w67y0we8kk83kzwrvhtw";
+
+        let invoice = parse_bolt12_invoice(invoice_str).unwrap();
+
+        assert_eq!(
+            invoice.payment_hash().to_string(),
+            "599b19fd140231d3477cf4ea6976109ae902689762ef85a4ede32f4441cfdf39"
+        );
+        assert_eq!(invoice.amount_msats(), 10_000_000);
+    }
+
+    #[test]
+    fn test_parse_bolt12_invoice_example_2() {
+        let invoice_str = "lni1qqg99wlxfjy9xt6fqae765px3an7vzsqzrhq8pjw7qjlm68mtp7e3yvxee4y5xrgjhhyf2fxhlphpckrvevh50u0qgw9suh47dqt052gn4sznndrfjpe0u23895kf6sawlyaep5hpnxp5qszjlapxvh7xp6lxnmt66yzyucchmsjkn2t3dgxvldvy94zf8rxplfqqvcc633sg8spja2d7xaqwjymxxaa2fzxwzk6wlu6jtqjfnkdgwraxtct7z95nng5rn83elaae6352smcj3tyqdmagvuj8xrtzlkgegxnh8gkzk4lrpm4yvxztncx8g4t7e8chgl7vqpj7dagt698qxnfwunqqx5zzrjjpygn809dp48m7tnvnsfk88qesfjejegp6d28flc75ar5z22vq3yg5r092gpsmrxq2sq9sggrj8927agtlmqlp0wqq3g0a9n86tkd0v79e96v09rhqypev9u4llt2plgpvgpcvnhsyh77376c0kvfrpkwdf9ps6y4aez2jf4lcdcw9smxt9arlrcrvheggdr20rhf3njfjvk26x0jscgnun2nm2ayar2647zk6yy82k9qyq6zkcxa55yqx79akzku0u82e85e3r2qfg54gmrdk6dg87y4z30v4qqyt6acldfnw3azw6ykskffzp7ngsuq3nqf89v288uxrxaad7uuxuk87gvt36ga3hwyt3uxe7tu62n43cwwzh6d234f4xuuj5d8558g2w4vakhd8zuqy08cc9wrlvysmd4q0dlr8d2c5uedds7hxz4qlfu64mnrsdm9tq2aqz2fm2zf0npju4vvzvtm8hujdl7pjycu377sp9vqluvrw3z85l6vz8el74npwudhtz2frtqw5uyczw75juxfjrr4y0j74ew0yw2u50q364hh3zuza3ed9l36l940rdk83rtrxnwaz84j0x3yemtvaued2u5glatxp0km7d6jm0ky58t26mew73t9egly4q34fh9yldhlypwa9kx27pf9d7xnwhdj6wp6em3nm4ajlnkcad025gwqqqqraqqqqqryqysqqqqqqqqqqqlgqqqqqqqqrvvcqqqq5szxnj3hhwnqxq23sz5zqzs2h6gaty8fkx3vvnp2sdnhlrlsnc2h8696zr37veaw5p4kt9664gpsmrxq4cpsyqqqkqssxa75xwfrnp430myv5rfmn5tpt2l3sa6jxrp9eurr524lvnut50lx7pqqn286x7t92kumtpd02ycv5nsalz6gfx0zqyc0d6jsu6ytvvt4l6ua9evzr8fqksc023v9ypjd98zwc22f2gmsad4e4m2mrjv9yv34lu";
+
+        let invoice = parse_bolt12_invoice(invoice_str).unwrap();
+
+        assert_eq!(
+            invoice.payment_hash().to_string(),
+            "0a0abe91d590e9b1a2c64c2a83677f8ff09e1573e8ba10e3e667aea06b65975a"
+        );
+        assert_eq!(invoice.amount_msats(), 888_000);
+    }
+}

--- a/src/util/invoice.rs
+++ b/src/util/invoice.rs
@@ -23,7 +23,7 @@ impl FromStr for LightningInvoice {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.starts_with(BECH32_BOLT12_INVOICE_HRP) {
+        if s.to_lowercase().starts_with(BECH32_BOLT12_INVOICE_HRP) {
             Ok(LightningInvoice::Bolt12(Box::new(parse_bolt12_invoice(s)?)))
         } else {
             Ok(LightningInvoice::Bolt11(Box::new(

--- a/src/util/invoice.rs
+++ b/src/util/invoice.rs
@@ -1,0 +1,34 @@
+use crate::error::Error;
+use crate::util::bolt12::{parse_bolt12_invoice, BECH32_BOLT12_INVOICE_HRP};
+use lightning::offers::invoice::Bolt12Invoice;
+use lightning_invoice::Bolt11Invoice;
+use std::str::FromStr;
+
+#[derive(Clone, Debug)]
+pub enum LightningInvoice {
+    Bolt11(Box<Bolt11Invoice>),
+    Bolt12(Box<Bolt12Invoice>),
+}
+
+impl LightningInvoice {
+    pub fn payment_hash(&self) -> String {
+        match self {
+            LightningInvoice::Bolt11(i) => i.payment_hash().to_string(),
+            LightningInvoice::Bolt12(i) => i.payment_hash().to_string(),
+        }
+    }
+}
+
+impl FromStr for LightningInvoice {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with(BECH32_BOLT12_INVOICE_HRP) {
+            Ok(LightningInvoice::Bolt12(Box::new(parse_bolt12_invoice(s)?)))
+        } else {
+            Ok(LightningInvoice::Bolt11(Box::new(
+                Bolt11Invoice::from_str(s).map_err(Error::Bolt11)?,
+            )))
+        }
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 pub mod bolt12;
 pub mod ec;
 pub mod fees;
+pub mod invoice;
 #[cfg(feature = "lnurl")]
 pub mod lnurl;
 pub mod secrets;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,7 @@
 use bitcoin::hex::FromHex;
 use std::time::Duration;
 
+pub mod bolt12;
 pub mod ec;
 pub mod fees;
 #[cfg(feature = "lnurl")]


### PR DESCRIPTION
Unfortunately `lightning` crate doesn't parse bolt12 invoice from string, thus I've to implement it manually, using an older bech32 dep that parse without checksum