### PR TITLE
Add `get_tx` in both LiquidClient and BitcoinClient

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Add wasm target
         run: rustup target add wasm32-unknown-unknown
       - name: Install wasm-pack
-        run: cargo install wasm-pack
+        run: cargo install wasm-pack --version 0.14.0 --locked
       - name: Create wasm project
         run: |
           wasm-pack new wasm-project

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Add wasm target
         run: rustup target add wasm32-unknown-unknown
       - name: Install wasm-pack
-        run: cargo install wasm-pack
+        run: cargo install wasm-pack --version 0.14.0 --locked
       - name: Run cargo test
         run: make cargo-test
       - name: Run wasm-pack test
@@ -48,7 +48,7 @@ jobs:
       - name: Add wasm target
         run: rustup target add wasm32-unknown-unknown
       - name: Install wasm-pack
-        run: cargo install wasm-pack
+        run: cargo install wasm-pack --version 0.14.0 --locked
       - name: Start regtest environment
         working-directory: regtest
         env:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BITCOIND_COOKIE=$(shell cat regtest/boltz/data/bitcoind/regtest/.cookie)
 REGTEST_PREFIX = LND_MACAROON_HEX=$(LND_MACAROON_HEX) BITCOIND_COOKIE=$(BITCOIND_COOKIE)
 
 init:
-	cargo install wasm-pack
+	cargo install wasm-pack --version 0.14.0 --locked
 
 build: cargo-build cargo-clippy
 

--- a/src/network/electrum.rs
+++ b/src/network/electrum.rs
@@ -252,6 +252,12 @@ impl LiquidClient for ElectrumLiquidClient {
         ))
     }
 
+    async fn get_tx(&self, txid: elements::Txid) -> Result<elements::Transaction, Error> {
+        let bitcoin_txid = bitcoin::Txid::from_raw_hash(txid.to_raw_hash());
+        let raw_tx = self.inner.transaction_get_raw(&bitcoin_txid)?;
+        Ok(elements::encode::deserialize(&raw_tx)?)
+    }
+
     async fn broadcast_tx(&self, signed_tx: &elements::Transaction) -> Result<String, Error> {
         let serialized = serialize(signed_tx);
         Ok(self

--- a/src/network/electrum.rs
+++ b/src/network/electrum.rs
@@ -149,6 +149,11 @@ impl BitcoinClient for ElectrumBitcoinClient {
         Ok(Self::extract_address_utxos(txs, &history, &spk))
     }
 
+    async fn get_tx(&self, txid: Txid) -> Result<Transaction, Error> {
+        let raw_tx = self.inner.transaction_get_raw(&txid)?;
+        Ok(bitcoin::consensus::deserialize(&raw_tx)?)
+    }
+
     async fn broadcast_tx(&self, signed_tx: &Transaction) -> Result<Txid, Error> {
         Ok(self.inner.transaction_broadcast(signed_tx)?)
     }

--- a/src/network/esplora.rs
+++ b/src/network/esplora.rs
@@ -264,6 +264,14 @@ impl LiquidClient for EsploraLiquidClient {
         Ok(elements::BlockHash::from_str(&text)?)
     }
 
+    async fn get_tx(&self, txid: elements::Txid) -> Result<elements::Transaction, Error> {
+        let url = format!("{}/tx/{txid}/raw", self.base_url);
+        let response = get_with_retry(&self.client, &url, self.timeout).await?;
+        let raw_tx = response.bytes().await?;
+
+        Ok(elements::encode::deserialize(&raw_tx)?)
+    }
+
     async fn broadcast_tx(&self, signed_tx: &elements::Transaction) -> Result<String, Error> {
         let url = format!("{}/tx", self.base_url);
         let tx_hex = signed_tx.serialize().to_hex();

--- a/src/network/esplora.rs
+++ b/src/network/esplora.rs
@@ -151,6 +151,14 @@ impl BitcoinClient for EsploraBitcoinClient {
         Self::extract_address_utxos(&txs, &address.to_string())
     }
 
+    async fn get_tx(&self, txid: bitcoin::Txid) -> Result<bitcoin::Transaction, Error> {
+        let url = format!("{}/tx/{txid}/raw", self.base_url);
+        let response = get_with_retry(&self.client, &url, self.timeout).await?;
+        let raw_tx = response.bytes().await?;
+
+        Ok(bitcoin::consensus::deserialize(&raw_tx)?)
+    }
+
     async fn broadcast_tx(&self, signed_tx: &bitcoin::Transaction) -> Result<bitcoin::Txid, Error> {
         let tx_hex = signed_tx.serialize().to_hex();
         let response = self

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -140,6 +140,8 @@ pub trait BitcoinClient: Send + Sync {
         address: &bitcoin::Address,
     ) -> Result<Vec<(bitcoin::OutPoint, bitcoin::TxOut)>, Error>;
 
+    async fn get_tx(&self, txid: bitcoin::Txid) -> Result<bitcoin::Transaction, Error>;
+
     async fn broadcast_tx(&self, signed_tx: &bitcoin::Transaction) -> Result<bitcoin::Txid, Error>;
 
     fn network(&self) -> BitcoinChain;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -156,6 +156,8 @@ pub trait LiquidClient: Send + Sync {
 
     async fn get_genesis_hash(&self) -> Result<elements::BlockHash, Error>;
 
+    async fn get_tx(&self, txid: elements::Txid) -> Result<elements::Transaction, Error>;
+
     async fn broadcast_tx(&self, signed_tx: &elements::Transaction) -> Result<String, Error>;
 
     fn network(&self) -> LiquidChain;


### PR DESCRIPTION
We want to double check the lockup_tx returned by boltz exist for our client