### PR TITLE
Support multiple payment outputs on claim and refund transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - Unreleased
+
+Must ship as `0.5.0`: this release is source-breaking and must not be
+published on the `0.4.x` compatibility line. The version bump itself is left
+to the release PR.
+
+### Added
+- Multi-output claim and refund transactions. `BtcSwapTx` and `LBtcSwapTx`
+  gained a `with_additional_outputs` builder taking `(address, satoshis)`
+  pairs; `TransactionOptions::with_additional_outputs` forwards
+  `(String, u64)` pairs through `construct_claim` / `construct_refund`. The
+  primary output receives the remainder (input - fee - sum of additional
+  outputs); additional outputs pay their fixed amounts in the given order.
+  Output ordering: Bitcoin keeps the primary at index 0; Liquid claims order
+  outputs [primary, additions.., fee] and refunds [fee, primary, additions..].
+  Cooperative signing commits to every output.
+
+### Changed
+- Bitcoin transaction construction no longer rejects zero-valued outputs:
+  construction enforces balance (overflow, overspend) but not dust or relay
+  policy, which belongs to the broadcaster.
+- Liquid transaction construction now rejects a zero-valued primary output
+  up front with a clear protocol error (previously it failed deep inside
+  blinding); confidential outputs cannot carry less than 1 satoshi.
+- The wrapper conversions of additional-output address strings validate the
+  address network on Bitcoin and require confidential addresses on Liquid.
+- Fixed `BtcSwapTx::new_claim_with_utxo` silently discarding the result of
+  its claim-address network check; an address for the wrong network is now
+  rejected.
+
+### Breaking
+- `BtcSwapTx` and `LBtcSwapTx` gained a public `additional_outputs` field;
+  struct-literal construction of these types must be updated (the
+  constructors initialize it to an empty vector).
+
 ## [0.4.1]
 
 ### Added

--- a/examples/multiout_battletest.rs
+++ b/examples/multiout_battletest.rs
@@ -1,0 +1,563 @@
+//! Mainnet battle-test for multi-output reverse-swap claims (PR #162).
+//!
+//! Creates a reverse swap with production Boltz, persists all recovery
+//! material to a state file BEFORE printing the bolt11, then waits for the
+//! lockup and broadcasts a claim that pays two outputs: the primary address
+//! receives the remainder, the extra address a fixed amount.
+//!
+//! Usage:
+//!   create <BTC|L-BTC> <invoice_amount_sat> <primary_addr> <extra_addr> <extra_amount_sat> [claim_fee_sat]
+//!   claim  <state_file>
+//!
+//! `create` runs the whole flow; if it is interrupted after the invoice is
+//! paid, resume with `claim` and the state file it wrote.
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use bitcoin::key::rand::thread_rng;
+use bitcoin::secp256k1::{Keypair, Secp256k1};
+use bitcoin::PublicKey;
+use boltz_client::boltz::{
+    BoltzApiClientV2, CreateChainRequest, CreateChainResponse, CreateReverseRequest,
+    CreateReverseResponse, Side, BOLTZ_MAINNET_URL_V2,
+};
+use boltz_client::fees::Fee;
+use boltz_client::network::esplora::{EsploraBitcoinClient, EsploraLiquidClient};
+use boltz_client::network::{BitcoinChain, Chain, LiquidChain};
+use boltz_client::swaps::{ChainClient, SwapScript, SwapTransactionParams, TransactionOptions};
+use boltz_client::util::secrets::Preimage;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct ChainState {
+    from_chain: String,
+    to_chain: String,
+    swap_id: String,
+    claim_secret_key: String,
+    refund_secret_key: String,
+    preimage: String,
+    swap_response: CreateChainResponse,
+    primary_address: String,
+    extra_address: String,
+    extra_amount_sat: u64,
+    claim_fee_sat: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct State {
+    chain: String,
+    swap_id: String,
+    claim_secret_key: String,
+    preimage: String,
+    swap_response: CreateReverseResponse,
+    primary_address: String,
+    extra_address: String,
+    extra_amount_sat: u64,
+    claim_fee_sat: u64,
+}
+
+fn parse_chain(s: &str) -> Chain {
+    match s {
+        "BTC" => Chain::Bitcoin(BitcoinChain::Bitcoin),
+        "L-BTC" => Chain::Liquid(LiquidChain::Liquid),
+        other => panic!("unsupported chain {other:?}, use BTC or L-BTC"),
+    }
+}
+
+fn chain_client(chain: Chain) -> ChainClient {
+    match chain {
+        Chain::Bitcoin(c) => {
+            ChainClient::new().with_bitcoin(EsploraBitcoinClient::default(c, None))
+        }
+        Chain::Liquid(c) => ChainClient::new().with_liquid(EsploraLiquidClient::default(c, None)),
+    }
+}
+
+/// Reject bad destination addresses before any money moves.
+fn validate_address(chain: Chain, address: &str) {
+    match chain {
+        Chain::Bitcoin(_) => {
+            let addr = bitcoin::Address::from_str(address).expect("invalid bitcoin address");
+            assert!(
+                addr.is_valid_for_network(bitcoin::Network::Bitcoin),
+                "{address} is not a mainnet bitcoin address"
+            );
+        }
+        Chain::Liquid(_) => {
+            let addr =
+                elements::Address::parse_with_params(address, &elements::AddressParams::LIQUID)
+                    .expect("invalid mainnet liquid address");
+            assert!(
+                addr.blinding_pubkey.is_some(),
+                "{address} is not confidential; liquid outputs must be blinded"
+            );
+        }
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    boltz_client::util::setup_logger();
+    let args: Vec<String> = std::env::args().collect();
+
+    match args.get(1).map(String::as_str) {
+        Some("create") => {
+            let chain_str = args[2].clone();
+            let invoice_amount: u64 = args[3].parse().unwrap();
+            let primary = args[4].clone();
+            let extra = args[5].clone();
+            let extra_amount: u64 = args[6].parse().unwrap();
+            let claim_fee: u64 = args.get(7).map(|f| f.parse().unwrap()).unwrap_or(1_000);
+            let chain = parse_chain(&chain_str);
+
+            validate_address(chain, &primary);
+            validate_address(chain, &extra);
+            assert!(
+                extra_amount + claim_fee < invoice_amount,
+                "extra amount + fee must leave a primary remainder"
+            );
+
+            let secp = Secp256k1::new();
+            let keys = Keypair::new(&secp, &mut thread_rng());
+            let preimage = Preimage::random();
+            let claim_public_key = PublicKey {
+                compressed: true,
+                inner: keys.public_key(),
+            };
+
+            let api = BoltzApiClientV2::new(BOLTZ_MAINNET_URL_V2.to_string(), None);
+            let resp = api
+                .post_reverse_req(CreateReverseRequest {
+                    from: "BTC".to_string(),
+                    to: chain_str.clone(),
+                    invoice: None,
+                    invoice_amount: Some(invoice_amount),
+                    preimage_hash: Some(preimage.sha256),
+                    description: Some("boltz-rust PR162 multi-output battle test".to_string()),
+                    description_hash: None,
+                    address_signature: None,
+                    address: None,
+                    claim_public_key,
+                    referral_id: None,
+                    webhook: None,
+                })
+                .await
+                .unwrap();
+            resp.validate(&preimage, &claim_public_key, chain).unwrap();
+
+            let state = State {
+                chain: chain_str,
+                swap_id: resp.id.clone(),
+                claim_secret_key: keys.display_secret().to_string(),
+                preimage: hex::encode(preimage.bytes.unwrap()),
+                swap_response: resp.clone(),
+                primary_address: primary,
+                extra_address: extra,
+                extra_amount_sat: extra_amount,
+                claim_fee_sat: claim_fee,
+            };
+            let state_file = format!("multiout-swap-{}.json", resp.id);
+            std::fs::write(&state_file, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+            println!(
+                "\n=== swap {} created, recovery state saved to {state_file} ===",
+                resp.id
+            );
+            println!("=== KEEP {state_file} UNTIL THE SWAP SETTLES — it holds the claim keys ===");
+            println!("onchain lockup will be {} sat", resp.onchain_amount);
+            println!("\nPAY THIS INVOICE:\n\n{}\n", resp.invoice.clone().unwrap());
+
+            wait_and_claim(state).await;
+        }
+        Some("claim") => {
+            let state: State =
+                serde_json::from_str(&std::fs::read_to_string(&args[2]).unwrap()).unwrap();
+            wait_and_claim(state).await;
+        }
+        Some("create-chain") => {
+            let from_str = args[2].clone();
+            let to_str = args[3].clone();
+            let user_lock_amount: u64 = args[4].parse().unwrap();
+            let primary = args[5].clone();
+            let extra = args[6].clone();
+            let extra_amount: u64 = args[7].parse().unwrap();
+            let claim_fee: u64 = args.get(8).map(|f| f.parse().unwrap()).unwrap_or(500);
+            let from = parse_chain(&from_str);
+            let to = parse_chain(&to_str);
+
+            validate_address(to, &primary);
+            validate_address(to, &extra);
+
+            let secp = Secp256k1::new();
+            let claim_keys = Keypair::new(&secp, &mut thread_rng());
+            let refund_keys = Keypair::new(&secp, &mut thread_rng());
+            let preimage = Preimage::random();
+            let claim_public_key = PublicKey {
+                compressed: true,
+                inner: claim_keys.public_key(),
+            };
+            let refund_public_key = PublicKey {
+                compressed: true,
+                inner: refund_keys.public_key(),
+            };
+
+            let api = BoltzApiClientV2::new(BOLTZ_MAINNET_URL_V2.to_string(), None);
+            let resp = api
+                .post_chain_req(CreateChainRequest {
+                    from: from_str.clone(),
+                    to: to_str.clone(),
+                    preimage_hash: preimage.sha256,
+                    claim_public_key: Some(claim_public_key),
+                    refund_public_key: Some(refund_public_key),
+                    referral_id: None,
+                    user_lock_amount: Some(user_lock_amount),
+                    server_lock_amount: None,
+                    pair_hash: None,
+                    webhook: None,
+                })
+                .await
+                .unwrap();
+            resp.validate(&claim_public_key, &refund_public_key, from, to)
+                .unwrap();
+            assert!(
+                extra_amount + claim_fee < resp.claim_details.amount,
+                "extra amount + fee must leave a primary remainder from the {} sat server lockup",
+                resp.claim_details.amount
+            );
+
+            let state = ChainState {
+                from_chain: from_str,
+                to_chain: to_str,
+                swap_id: resp.id.clone(),
+                claim_secret_key: claim_keys.display_secret().to_string(),
+                refund_secret_key: refund_keys.display_secret().to_string(),
+                preimage: hex::encode(preimage.bytes.unwrap()),
+                swap_response: resp.clone(),
+                primary_address: primary,
+                extra_address: extra,
+                extra_amount_sat: extra_amount,
+                claim_fee_sat: claim_fee,
+            };
+            let state_file = format!("multiout-chainswap-{}.json", resp.id);
+            std::fs::write(&state_file, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+            println!(
+                "\n=== chain swap {} created, recovery state saved to {state_file} ===",
+                resp.id
+            );
+            println!("=== KEEP {state_file} — it holds claim AND refund keys ===");
+            println!(
+                "server will lock {} sat, claim splits: primary {} sat + extra {} sat (fee {} sat)",
+                resp.claim_details.amount,
+                resp.claim_details.amount - claim_fee - extra_amount,
+                extra_amount,
+                claim_fee,
+            );
+            println!(
+                "\nSEND EXACTLY {} sat ({}) TO:\n\n{}\n",
+                resp.lockup_details.amount, state.from_chain, resp.lockup_details.lockup_address,
+            );
+
+            wait_and_claim_chain(state).await;
+        }
+        Some("claim-chain") => {
+            let state: ChainState =
+                serde_json::from_str(&std::fs::read_to_string(&args[2]).unwrap()).unwrap();
+            wait_and_claim_chain(state).await;
+        }
+        Some("refund-chain") => {
+            let state: ChainState =
+                serde_json::from_str(&std::fs::read_to_string(&args[2]).unwrap()).unwrap();
+            let refund_address = args[3].clone();
+            let from = parse_chain(&state.from_chain);
+            validate_address(from, &refund_address);
+
+            let secp = Secp256k1::new();
+            let refund_keys = Keypair::from_seckey_str(&secp, &state.refund_secret_key).unwrap();
+            let refund_public_key = PublicKey {
+                compressed: true,
+                inner: refund_keys.public_key(),
+            };
+            let api = BoltzApiClientV2::new(BOLTZ_MAINNET_URL_V2.to_string(), None);
+            let client = chain_client(from);
+            let lockup_script = SwapScript::chain_from_swap_resp(
+                from,
+                Side::Lockup,
+                state.swap_response.lockup_details.clone(),
+                refund_public_key,
+            )
+            .unwrap();
+
+            let tx = lockup_script
+                .construct_refund(SwapTransactionParams {
+                    swap_id: state.swap_id.clone(),
+                    keys: refund_keys,
+                    fee: Fee::Absolute(state.claim_fee_sat),
+                    output_address: refund_address,
+                    chain_client: &client,
+                    boltz_client: &api,
+                    options: None,
+                })
+                .await
+                .unwrap();
+            let txid = client.broadcast_tx(&tx).await.unwrap();
+            println!("=== refund broadcast: {txid} ===");
+        }
+        _ => {
+            eprintln!("usage: create <BTC|L-BTC> <invoice_amount_sat> <primary_addr> <extra_addr> <extra_amount_sat> [claim_fee_sat]");
+            eprintln!("       claim <state_file>");
+            eprintln!("       create-chain <from> <to> <user_lock_amount_sat> <primary_addr> <extra_addr> <extra_amount_sat> [claim_fee_sat]");
+            eprintln!("       claim-chain <state_file>");
+            eprintln!("       refund-chain <state_file> <refund_addr>");
+            std::process::exit(1);
+        }
+    }
+}
+
+async fn wait_and_claim_chain(state: ChainState) {
+    let from = parse_chain(&state.from_chain);
+    let to = parse_chain(&state.to_chain);
+    let secp = Secp256k1::new();
+    let claim_keys = Keypair::from_seckey_str(&secp, &state.claim_secret_key).unwrap();
+    let refund_keys = Keypair::from_seckey_str(&secp, &state.refund_secret_key).unwrap();
+    let preimage = Preimage::from_str(&state.preimage).unwrap();
+    let claim_public_key = PublicKey {
+        compressed: true,
+        inner: claim_keys.public_key(),
+    };
+    let refund_public_key = PublicKey {
+        compressed: true,
+        inner: refund_keys.public_key(),
+    };
+
+    let api = BoltzApiClientV2::new(BOLTZ_MAINNET_URL_V2.to_string(), None);
+    let client = match (from, to) {
+        (Chain::Liquid(l), Chain::Bitcoin(b)) | (Chain::Bitcoin(b), Chain::Liquid(l)) => {
+            ChainClient::new()
+                .with_bitcoin(EsploraBitcoinClient::default(b, None))
+                .with_liquid(EsploraLiquidClient::default(l, None))
+        }
+        _ => panic!("chain swap must be between BTC and L-BTC"),
+    };
+
+    let lockup_script = SwapScript::chain_from_swap_resp(
+        from,
+        Side::Lockup,
+        state.swap_response.lockup_details.clone(),
+        refund_public_key,
+    )
+    .unwrap();
+    let claim_script = SwapScript::chain_from_swap_resp(
+        to,
+        Side::Claim,
+        state.swap_response.claim_details.clone(),
+        claim_public_key,
+    )
+    .unwrap();
+
+    println!(
+        "waiting for the server lockup of chain swap {} ...",
+        state.swap_id
+    );
+    let mut last_status = String::new();
+    loop {
+        match api.get_swap(&state.swap_id).await.map(|s| s.status) {
+            Ok(status) => {
+                if status != last_status {
+                    println!("swap status: {status}");
+                    last_status = status.clone();
+                }
+                match status.as_str() {
+                    "transaction.server.mempool" | "transaction.server.confirmed" => break,
+                    "transaction.claimed" => {
+                        println!("swap already claimed, nothing to do");
+                        return;
+                    }
+                    "transaction.lockupFailed"
+                    | "swap.expired"
+                    | "transaction.failed"
+                    | "transaction.refunded" => {
+                        panic!(
+                            "swap ended without a server lockup: {status} — \
+                             recover the user lockup with: refund-chain <state_file> <{}_address>",
+                            state.from_chain
+                        );
+                    }
+                    _ => {}
+                }
+            }
+            Err(e) => println!("status poll failed (will retry): {e:?}"),
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+
+    println!(
+        "server lockup detected, claiming cooperatively to primary {} + {} sat to {} (fee {} sat)",
+        state.primary_address, state.extra_amount_sat, state.extra_address, state.claim_fee_sat,
+    );
+
+    let mut attempts = 0;
+    let tx = loop {
+        let params = SwapTransactionParams {
+            swap_id: state.swap_id.clone(),
+            keys: claim_keys,
+            fee: Fee::Absolute(state.claim_fee_sat),
+            output_address: state.primary_address.clone(),
+            chain_client: &client,
+            boltz_client: &api,
+            options: Some(
+                TransactionOptions::default()
+                    .with_chain_claim(refund_keys, lockup_script.clone())
+                    .with_additional_outputs(vec![(
+                        state.extra_address.clone(),
+                        state.extra_amount_sat,
+                    )]),
+            ),
+        };
+        match claim_script.construct_claim(&preimage, params).await {
+            Ok(tx) => break tx,
+            Err(e) => {
+                attempts += 1;
+                assert!(attempts < 24, "claim construction kept failing: {e:?}");
+                println!("claim construction failed (attempt {attempts}, will retry): {e:?}");
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        }
+    };
+
+    let txid = client.broadcast_tx(&tx).await.unwrap();
+    println!(
+        "\n=== claim broadcast: {txid} ===\nprimary gets {} sat (server lockup {} - fee {} - extra {})",
+        state.swap_response.claim_details.amount - state.claim_fee_sat - state.extra_amount_sat,
+        state.swap_response.claim_details.amount,
+        state.claim_fee_sat,
+        state.extra_amount_sat,
+    );
+
+    loop {
+        if let Ok(s) = api.get_swap(&state.swap_id).await {
+            if s.status != last_status {
+                println!("swap status: {}", s.status);
+                last_status = s.status.clone();
+            }
+            if s.status == "transaction.claimed" {
+                println!("=== chain swap claimed — battle test complete ===");
+                return;
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn wait_and_claim(state: State) {
+    let chain = parse_chain(&state.chain);
+    let secp = Secp256k1::new();
+    let keys = Keypair::from_seckey_str(&secp, &state.claim_secret_key).unwrap();
+    let preimage = Preimage::from_str(&state.preimage).unwrap();
+    let claim_public_key = PublicKey {
+        compressed: true,
+        inner: keys.public_key(),
+    };
+
+    let api = BoltzApiClientV2::new(BOLTZ_MAINNET_URL_V2.to_string(), None);
+    let client = chain_client(chain);
+    let swap_script =
+        SwapScript::reverse_from_swap_resp(chain, &state.swap_response, claim_public_key).unwrap();
+
+    println!("waiting for lockup of swap {} ...", state.swap_id);
+    let mut last_status = String::new();
+    loop {
+        let status = api.get_swap(&state.swap_id).await.map(|s| s.status);
+        match status {
+            Ok(status) => {
+                if status != last_status {
+                    println!("swap status: {status}");
+                    last_status = status.clone();
+                }
+                match status.as_str() {
+                    "transaction.mempool" | "transaction.confirmed" => break,
+                    "invoice.settled" => {
+                        println!("swap already settled, nothing to claim");
+                        return;
+                    }
+                    "swap.expired"
+                    | "invoice.expired"
+                    | "transaction.failed"
+                    | "transaction.refunded" => {
+                        panic!("swap ended without lockup: {status}");
+                    }
+                    _ => {}
+                }
+            }
+            Err(e) => println!("status poll failed (will retry): {e:?}"),
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+
+    let cooperative = std::env::var("NONCOOP").is_err();
+    println!(
+        "lockup detected, claiming ({}) to primary {} + {} sat to {} (fee {} sat)",
+        if cooperative {
+            "cooperative"
+        } else {
+            "script path"
+        },
+        state.primary_address,
+        state.extra_amount_sat,
+        state.extra_address,
+        state.claim_fee_sat,
+    );
+
+    let mut attempts = 0;
+    let tx = loop {
+        let params = SwapTransactionParams {
+            swap_id: state.swap_id.clone(),
+            keys,
+            fee: Fee::Absolute(state.claim_fee_sat),
+            output_address: state.primary_address.clone(),
+            chain_client: &client,
+            boltz_client: &api,
+            options: Some(
+                TransactionOptions::default()
+                    .with_cooperative(cooperative)
+                    .with_additional_outputs(vec![(
+                        state.extra_address.clone(),
+                        state.extra_amount_sat,
+                    )]),
+            ),
+        };
+        match swap_script.construct_claim(&preimage, params).await {
+            Ok(tx) => break tx,
+            Err(e) => {
+                attempts += 1;
+                assert!(attempts < 24, "claim construction kept failing: {e:?}");
+                println!("claim construction failed (attempt {attempts}, will retry): {e:?}");
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        }
+    };
+
+    let txid = client.broadcast_tx(&tx).await.unwrap();
+    println!(
+        "\n=== claim broadcast: {txid} ===\nprimary gets {} sat (lockup {} - fee {} - extra {})",
+        state.swap_response.onchain_amount - state.claim_fee_sat - state.extra_amount_sat,
+        state.swap_response.onchain_amount,
+        state.claim_fee_sat,
+        state.extra_amount_sat,
+    );
+
+    loop {
+        if let Ok(s) = api.get_swap(&state.swap_id).await {
+            if s.status != last_status {
+                println!("swap status: {}", s.status);
+                last_status = s.status.clone();
+            }
+            if s.status == "invoice.settled" {
+                println!("=== invoice settled — battle test complete ===");
+                return;
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}

--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -558,8 +558,9 @@ impl BtcSwapTx {
         }
 
         let address = Address::from_str(&claim_address)?;
-
-        address.is_valid_for_network(bitcoin_client.network().into());
+        if !address.is_valid_for_network(bitcoin_client.network().into()) {
+            return Err(Error::Address("Address validation failed".to_string()));
+        };
 
         Ok(BtcSwapTx {
             kind: SwapTxKind::Claim,
@@ -570,10 +571,16 @@ impl BtcSwapTx {
         })
     }
 
-    /// Add fixed-amount outputs paid in addition to the primary output address.
-    /// The primary output receives the remainder (input - fee - sum of additional
-    /// outputs) and stays at output index 0. All amounts must be non-zero;
-    /// violations error when the transaction is built.
+    /// Add fixed-amount outputs (in satoshis) paid in addition to the primary
+    /// output address. The primary output receives the remainder
+    /// (input - fee - sum of additional outputs) and stays at output index 0,
+    /// with the additional outputs following in the given order.
+    ///
+    /// Calling this again replaces the previously set list. Construction only
+    /// enforces balance (no overflow, no overspend): zero-valued outputs are
+    /// accepted, so meeting dust and relay policy is the broadcaster's
+    /// responsibility. Cooperative signing commits to every output, including
+    /// the additional ones.
     pub fn with_additional_outputs(mut self, additional_outputs: Vec<(Address, u64)>) -> Self {
         self.additional_outputs = additional_outputs;
         self
@@ -813,6 +820,10 @@ impl BtcSwapTx {
 
     /// Build the payment outputs: the primary output (which receives the
     /// remainder) at index 0, followed by any additional fixed-amount outputs.
+    ///
+    /// Zero-valued outputs are consensus-valid and accepted here; construction
+    /// does not guarantee relayability. Meeting node dust and relay policy is
+    /// the broadcaster's responsibility.
     fn create_payment_outputs(
         &self,
         input_value: Amount,
@@ -822,11 +833,6 @@ impl BtcSwapTx {
             self.additional_outputs
                 .iter()
                 .try_fold(0u64, |sum, (_, amount)| {
-                    if *amount == 0 {
-                        return Err(Error::Protocol(
-                            "Additional output amount must be greater than zero.".to_string(),
-                        ));
-                    }
                     sum.checked_add(*amount).ok_or(Error::Protocol(
                         "Additional output amounts overflow.".to_string(),
                     ))
@@ -839,14 +845,6 @@ impl BtcSwapTx {
                 "Output value {} is less than fees {absolute_fees} plus additional outputs {total_additional}",
                 input_value.to_sat()
             )))?;
-
-        // A zero remainder is rejected only when caused by additional outputs;
-        // the historical single-output behavior (input == fee) is preserved.
-        if !self.additional_outputs.is_empty() && primary_value == Amount::ZERO {
-            return Err(Error::Protocol(
-                "Primary output value is zero after fees and additional outputs".to_string(),
-            ));
-        }
 
         let mut outputs = Vec::with_capacity(1 + self.additional_outputs.len());
         outputs.push(TxOut {
@@ -1476,16 +1474,73 @@ mod tests {
     }
 
     #[macros::test_all]
-    fn test_additional_output_zero_amount_rejected() {
+    fn test_additional_output_zero_amount_allowed() {
         let (swap_tx, keys, preimage) =
             swap_tx_fixture(SwapType::ReverseSubmarine, SwapTxKind::Claim);
         let secp = Secp256k1::new();
 
         let extra_address = p2wpkh_address(&secp);
+        let tx = swap_tx
+            .with_additional_outputs(vec![(extra_address.clone(), 0)])
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap();
+
+        assert_eq!(tx.output.len(), 2);
+        assert_eq!(tx.output[0].value.to_sat(), FUNDING_SAT - FEE_SAT);
+        assert_eq!(tx.output[1].value.to_sat(), 0);
+        assert_eq!(tx.output[1].script_pubkey, extra_address.script_pubkey());
+    }
+
+    #[macros::test_all]
+    fn test_additional_output_one_satoshi_allowed() {
+        let (swap_tx, keys, preimage) =
+            swap_tx_fixture(SwapType::ReverseSubmarine, SwapTxKind::Claim);
+        let secp = Secp256k1::new();
+
+        let extra_address = p2wpkh_address(&secp);
+        let tx = swap_tx
+            .with_additional_outputs(vec![(extra_address.clone(), 1)])
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap();
+
+        assert_eq!(tx.output.len(), 2);
+        assert_eq!(tx.output[0].value.to_sat(), FUNDING_SAT - FEE_SAT - 1);
+        assert_eq!(tx.output[1].value.to_sat(), 1);
+    }
+
+    #[macros::test_all]
+    fn test_zero_primary_remainder_allowed() {
+        let (swap_tx, keys, preimage) =
+            swap_tx_fixture(SwapType::ReverseSubmarine, SwapTxKind::Claim);
+        let secp = Secp256k1::new();
+
+        let extra_address = p2wpkh_address(&secp);
+        let primary_script = swap_tx.output_address.script_pubkey();
+        let tx = swap_tx
+            .with_additional_outputs(vec![(extra_address.clone(), FUNDING_SAT - FEE_SAT)])
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap();
+
+        assert_eq!(tx.output.len(), 2);
+        assert_eq!(tx.output[0].value.to_sat(), 0);
+        assert_eq!(tx.output[0].script_pubkey, primary_script);
+        assert_eq!(tx.output[1].value.to_sat(), FUNDING_SAT - FEE_SAT);
+        assert_eq!(tx.output[1].script_pubkey, extra_address.script_pubkey());
+    }
+
+    #[macros::test_all]
+    fn test_additional_outputs_overflow() {
+        let (swap_tx, keys, preimage) =
+            swap_tx_fixture(SwapType::ReverseSubmarine, SwapTxKind::Claim);
+        let secp = Secp256k1::new();
+
         let err = swap_tx
-            .with_additional_outputs(vec![(extra_address, 0)])
+            .with_additional_outputs(vec![
+                (p2wpkh_address(&secp), u64::MAX),
+                (p2wpkh_address(&secp), 1),
+            ])
             .create_claim(&keys, &preimage, FEE_SAT, false)
             .unwrap_err();
-        assert!(err.message().contains("greater than zero"));
+        assert!(err.message().contains("overflow"));
     }
 }

--- a/src/swaps/bitcoin.rs
+++ b/src/swaps/bitcoin.rs
@@ -513,6 +513,10 @@ pub struct BtcSwapTx {
     pub kind: SwapTxKind, // These fields needs to be public to do manual creation in IT.
     pub swap_script: BtcSwapScript,
     pub output_address: Address,
+    /// Extra fixed-amount outputs paid in addition to `output_address`.
+    /// `output_address` receives the remainder (input - fee - sum of these)
+    /// and always stays at output index 0.
+    pub additional_outputs: Vec<(Address, u64)>,
     /// All utxos for the script_pubkey of this swap, at this point in time:
     /// - the initial lockup utxo, if not yet spent (claimed or refunded)
     /// - any further utxos, if not yet spent
@@ -561,8 +565,18 @@ impl BtcSwapTx {
             kind: SwapTxKind::Claim,
             swap_script,
             output_address: address.assume_checked(),
+            additional_outputs: Vec::new(),
             utxos: vec![utxo], // When claiming, we only consider the first utxo
         })
+    }
+
+    /// Add fixed-amount outputs paid in addition to the primary output address.
+    /// The primary output receives the remainder (input - fee - sum of additional
+    /// outputs) and stays at output index 0. All amounts must be non-zero;
+    /// violations error when the transaction is built.
+    pub fn with_additional_outputs(mut self, additional_outputs: Vec<(Address, u64)>) -> Self {
+        self.additional_outputs = additional_outputs;
+        self
     }
 
     /// Construct a RefundTX corresponding to the swap_script. Only works for Submarine and Chain Swaps.
@@ -612,6 +626,7 @@ impl BtcSwapTx {
                 kind: SwapTxKind::Refund,
                 swap_script,
                 output_address: address.assume_checked(),
+                additional_outputs: Vec::new(),
                 utxos,
             }),
         }
@@ -796,6 +811,58 @@ impl BtcSwapTx {
         Ok(claim_tx)
     }
 
+    /// Build the payment outputs: the primary output (which receives the
+    /// remainder) at index 0, followed by any additional fixed-amount outputs.
+    fn create_payment_outputs(
+        &self,
+        input_value: Amount,
+        absolute_fees: u64,
+    ) -> Result<Vec<TxOut>, Error> {
+        let total_additional =
+            self.additional_outputs
+                .iter()
+                .try_fold(0u64, |sum, (_, amount)| {
+                    if *amount == 0 {
+                        return Err(Error::Protocol(
+                            "Additional output amount must be greater than zero.".to_string(),
+                        ));
+                    }
+                    sum.checked_add(*amount).ok_or(Error::Protocol(
+                        "Additional output amounts overflow.".to_string(),
+                    ))
+                })?;
+
+        let primary_value = input_value
+            .checked_sub(Amount::from_sat(absolute_fees))
+            .and_then(|value| value.checked_sub(Amount::from_sat(total_additional)))
+            .ok_or(Error::Protocol(format!(
+                "Output value {} is less than fees {absolute_fees} plus additional outputs {total_additional}",
+                input_value.to_sat()
+            )))?;
+
+        // A zero remainder is rejected only when caused by additional outputs;
+        // the historical single-output behavior (input == fee) is preserved.
+        if !self.additional_outputs.is_empty() && primary_value == Amount::ZERO {
+            return Err(Error::Protocol(
+                "Primary output value is zero after fees and additional outputs".to_string(),
+            ));
+        }
+
+        let mut outputs = Vec::with_capacity(1 + self.additional_outputs.len());
+        outputs.push(TxOut {
+            script_pubkey: self.output_address.script_pubkey(),
+            value: primary_value,
+        });
+        for (address, amount) in &self.additional_outputs {
+            outputs.push(TxOut {
+                script_pubkey: address.script_pubkey(),
+                value: Amount::from_sat(*amount),
+            });
+        }
+
+        Ok(outputs)
+    }
+
     fn create_claim(
         &self,
         keys: &Keypair,
@@ -821,27 +888,13 @@ impl BtcSwapTx {
             witness: Witness::new(),
         };
 
-        let destination_spk = self.output_address.script_pubkey();
-
-        let output_value = utxo
-            .1
-            .value
-            .checked_sub(Amount::from_sat(absolute_fees))
-            .ok_or(Error::Protocol(format!(
-                "Claim output value {} is less than fees {}",
-                utxo.1.value, absolute_fees
-            )))?;
-
-        let txout = TxOut {
-            script_pubkey: destination_spk,
-            value: output_value,
-        };
+        let output = self.create_payment_outputs(utxo.1.value, absolute_fees)?;
 
         let mut claim_tx = Transaction {
             version: Version::TWO,
             lock_time: LockTime::ZERO,
             input: vec![txin],
-            output: vec![txout],
+            output,
         };
 
         if is_cooperative {
@@ -1059,17 +1112,7 @@ impl BtcSwapTx {
             .utxos
             .iter()
             .fold(Amount::ZERO, |acc, (_, txo)| acc + txo.value);
-        let absolute_fees_amount = Amount::from_sat(absolute_fees);
-        let output_amount =
-            utxos_amount
-                .checked_sub(absolute_fees_amount)
-                .ok_or(Error::Protocol(format!(
-                    "Refund output value {utxos_amount} is less than fees {absolute_fees_amount}"
-                )))?;
-        let output: TxOut = TxOut {
-            script_pubkey: self.output_address.script_pubkey(),
-            value: output_amount,
-        };
+        let output = self.create_payment_outputs(utxos_amount, absolute_fees)?;
 
         let unsigned_inputs = self
             .utxos
@@ -1114,7 +1157,7 @@ impl BtcSwapTx {
             version: Version::TWO,
             lock_time,
             input: unsigned_inputs,
-            output: vec![output],
+            output,
         };
 
         let tx_outs: Vec<&TxOut> = self.utxos.iter().map(|(_, out)| out).collect();
@@ -1281,4 +1324,168 @@ fn convert_schnorr_signature(
 ) -> bitcoin::secp256k1::schnorr::Signature {
     bitcoin::secp256k1::schnorr::Signature::from_slice(schnorr_sig.as_byte_array())
         .expect("signature size matches")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::secrets::Preimage;
+    use bitcoin::key::rand::thread_rng;
+    use bitcoin::{CompressedPublicKey, Network, TxOut};
+
+    const FUNDING_SAT: u64 = 100_000;
+    const FEE_SAT: u64 = 500;
+
+    fn p2wpkh_address(secp: &Secp256k1<bitcoin::secp256k1::All>) -> Address {
+        let keypair = Keypair::new(secp, &mut thread_rng());
+        Address::p2wpkh(&CompressedPublicKey(keypair.public_key()), Network::Bitcoin)
+    }
+
+    fn swap_tx_fixture(swap_type: SwapType, kind: SwapTxKind) -> (BtcSwapTx, Keypair, Preimage) {
+        let secp = Secp256k1::new();
+        let preimage = Preimage::random();
+        let recvr_keypair = Keypair::new(&secp, &mut thread_rng());
+        let sender_keypair = Keypair::new(&secp, &mut thread_rng());
+
+        let swap_script = BtcSwapScript {
+            swap_type,
+            side: None,
+            funding_addrs: None,
+            hashlock: preimage.hash160,
+            receiver_pubkey: PublicKey {
+                compressed: true,
+                inner: recvr_keypair.public_key(),
+            },
+            locktime: LockTime::from_height(200).unwrap(),
+            sender_pubkey: PublicKey {
+                compressed: true,
+                inner: sender_keypair.public_key(),
+            },
+        };
+
+        let utxo = (
+            OutPoint::default(),
+            TxOut {
+                value: Amount::from_sat(FUNDING_SAT),
+                script_pubkey: ScriptBuf::new(),
+            },
+        );
+
+        let signing_keys = match kind {
+            SwapTxKind::Claim => recvr_keypair,
+            SwapTxKind::Refund => sender_keypair,
+        };
+
+        let swap_tx = BtcSwapTx {
+            kind,
+            swap_script,
+            output_address: p2wpkh_address(&secp),
+            additional_outputs: Vec::new(),
+            utxos: vec![utxo],
+        };
+
+        (swap_tx, signing_keys, preimage)
+    }
+
+    #[macros::test_all]
+    fn test_claim_single_output() {
+        let (swap_tx, keys, preimage) =
+            swap_tx_fixture(SwapType::ReverseSubmarine, SwapTxKind::Claim);
+
+        let tx = swap_tx
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap();
+
+        assert_eq!(tx.output.len(), 1);
+        assert_eq!(tx.output[0].value.to_sat(), FUNDING_SAT - FEE_SAT);
+        assert_eq!(
+            tx.output[0].script_pubkey,
+            swap_tx.output_address.script_pubkey()
+        );
+    }
+
+    #[macros::test_all]
+    fn test_claim_with_additional_outputs() {
+        let (swap_tx, keys, preimage) =
+            swap_tx_fixture(SwapType::ReverseSubmarine, SwapTxKind::Claim);
+        let secp = Secp256k1::new();
+
+        let extra_address_1 = p2wpkh_address(&secp);
+        let extra_address_2 = p2wpkh_address(&secp);
+
+        let swap_tx = swap_tx.with_additional_outputs(vec![
+            (extra_address_1.clone(), 800),
+            (extra_address_2.clone(), 1_200),
+        ]);
+
+        let tx = swap_tx
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap();
+
+        assert_eq!(tx.output.len(), 3);
+
+        // Primary output keeps index 0 and receives the remainder.
+        assert_eq!(
+            tx.output[0].value.to_sat(),
+            FUNDING_SAT - FEE_SAT - 800 - 1_200
+        );
+        assert_eq!(
+            tx.output[0].script_pubkey,
+            swap_tx.output_address.script_pubkey()
+        );
+
+        assert_eq!(tx.output[1].value.to_sat(), 800);
+        assert_eq!(tx.output[1].script_pubkey, extra_address_1.script_pubkey());
+        assert_eq!(tx.output[2].value.to_sat(), 1_200);
+        assert_eq!(tx.output[2].script_pubkey, extra_address_2.script_pubkey());
+    }
+
+    #[macros::test_all]
+    fn test_refund_with_additional_outputs() {
+        let (swap_tx, keys, _) = swap_tx_fixture(SwapType::Submarine, SwapTxKind::Refund);
+        let secp = Secp256k1::new();
+
+        let extra_address = p2wpkh_address(&secp);
+        let swap_tx = swap_tx.with_additional_outputs(vec![(extra_address.clone(), 700)]);
+
+        let tx = swap_tx.create_refund(&keys, FEE_SAT, false).unwrap();
+
+        assert_eq!(tx.output.len(), 2);
+        assert_eq!(tx.output[0].value.to_sat(), FUNDING_SAT - FEE_SAT - 700);
+        assert_eq!(
+            tx.output[0].script_pubkey,
+            swap_tx.output_address.script_pubkey()
+        );
+        assert_eq!(tx.output[1].value.to_sat(), 700);
+        assert_eq!(tx.output[1].script_pubkey, extra_address.script_pubkey());
+    }
+
+    #[macros::test_all]
+    fn test_claim_additional_outputs_exceed_input() {
+        let (swap_tx, keys, preimage) =
+            swap_tx_fixture(SwapType::ReverseSubmarine, SwapTxKind::Claim);
+        let secp = Secp256k1::new();
+
+        let extra_address = p2wpkh_address(&secp);
+        let swap_tx = swap_tx.with_additional_outputs(vec![(extra_address, FUNDING_SAT)]);
+
+        let err = swap_tx
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap_err();
+        assert!(err.message().contains("less than fees"));
+    }
+
+    #[macros::test_all]
+    fn test_additional_output_zero_amount_rejected() {
+        let (swap_tx, keys, preimage) =
+            swap_tx_fixture(SwapType::ReverseSubmarine, SwapTxKind::Claim);
+        let secp = Secp256k1::new();
+
+        let extra_address = p2wpkh_address(&secp);
+        let err = swap_tx
+            .with_additional_outputs(vec![(extra_address, 0)])
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap_err();
+        assert!(err.message().contains("greater than zero"));
+    }
 }

--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -576,11 +576,18 @@ impl LBtcSwapTx {
         })
     }
 
-    /// Add fixed-amount outputs paid in addition to the primary output address.
-    /// The primary output receives the remainder (input - fee - sum of additional
-    /// outputs) and remains the first payment output. All addresses must be
-    /// confidential and all amounts non-zero; violations error when the
-    /// transaction is built.
+    /// Add fixed-amount outputs (in satoshis) paid in addition to the primary
+    /// output address. The primary output receives the remainder
+    /// (input - fee - sum of additional outputs) and remains the first payment
+    /// output, with the additional outputs following in the given order:
+    /// claims order outputs [primary, additions.., fee], refunds
+    /// [fee, primary, additions..].
+    ///
+    /// Calling this again replaces the previously set list. All addresses must
+    /// be confidential and all amounts positive (the rangeproof cannot prove a
+    /// zero value); violations error when the transaction is built.
+    /// Cooperative signing commits to every output, including the additional
+    /// ones.
     pub fn with_additional_outputs(mut self, additional_outputs: Vec<(Address, u64)>) -> Self {
         self.additional_outputs = additional_outputs;
         self
@@ -823,6 +830,11 @@ impl LBtcSwapTx {
     /// the remainder) first, followed by any additional fixed-amount outputs.
     /// The last payment output balances the confidential-transaction blinding
     /// against the input and the explicit fee output.
+    ///
+    /// All payment outputs are confidential and must carry at least 1 satoshi:
+    /// the rangeproof constructor (`TxOut::RANGEPROOF_MIN_VALUE`) cannot prove
+    /// a zero value, so zero-valued outputs are rejected up front with a clear
+    /// error instead of failing deep inside blinding.
     fn create_payment_outputs(
         &self,
         secp: &Secp256k1<elements::secp256k1_zkp::All>,
@@ -854,9 +866,9 @@ impl LBtcSwapTx {
                 unblinded_utxo.value, absolute_fees, total_additional
             )))?;
 
-        // A zero remainder is rejected only when caused by additional outputs;
-        // the historical single-output behavior (input == fee) is preserved.
-        if !self.additional_outputs.is_empty() && primary_value == Amount::ZERO {
+        // A zero primary cannot be blinded (rangeproof minimum is 1 satoshi),
+        // so fail here with a protocol error rather than inside blinding.
+        if primary_value == Amount::ZERO {
             return Err(Error::Protocol(
                 "Primary output value is zero after fees and additional outputs".to_string(),
             ));
@@ -1710,5 +1722,71 @@ mod tests {
             .create_claim(&keys, &preimage, FEE_SAT, false)
             .unwrap_err();
         assert!(err.message().contains("blinding key"));
+    }
+
+    #[macros::test_all]
+    fn test_zero_primary_rejected_without_additional_outputs() {
+        let (swap_tx, keys, preimage, ..) = claim_fixture();
+
+        // input == fee leaves a zero primary, which cannot be blinded.
+        let err = swap_tx
+            .create_claim(&keys, &preimage, FUNDING_SAT, false)
+            .unwrap_err();
+        assert!(err.message().contains("Primary output value is zero"));
+    }
+
+    #[macros::test_all]
+    fn test_zero_primary_rejected_with_additional_outputs() {
+        let (swap_tx, keys, preimage, ..) = claim_fixture();
+        let secp = Secp256k1::new();
+
+        let (extra_address, _) = confidential_address(&secp);
+        let err = swap_tx
+            .with_additional_outputs(vec![(extra_address, FUNDING_SAT - FEE_SAT)])
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap_err();
+        assert!(err.message().contains("Primary output value is zero"));
+    }
+
+    #[macros::test_all]
+    fn test_additional_output_one_satoshi_blinds_and_verifies() {
+        let (swap_tx, keys, preimage, primary_blinder, asset_id) = claim_fixture();
+        let secp = Secp256k1::new();
+
+        let (extra_address, extra_blinder) = confidential_address(&secp);
+        let swap_tx = swap_tx.with_additional_outputs(vec![(extra_address.clone(), 1)]);
+
+        let tx = swap_tx
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap();
+
+        tx.verify_tx_amt_proofs(&secp, &[swap_tx.funding_utxo.clone()])
+            .unwrap();
+
+        assert_eq!(tx.output[1].script_pubkey, extra_address.script_pubkey());
+        let extra = tx.output[1]
+            .unblind(&secp, extra_blinder.secret_key())
+            .unwrap();
+        assert_eq!(extra.value, 1);
+        assert_eq!(extra.asset, asset_id);
+
+        let primary = tx.output[0]
+            .unblind(&secp, primary_blinder.secret_key())
+            .unwrap();
+        assert_eq!(primary.value, FUNDING_SAT - FEE_SAT - 1);
+    }
+
+    #[macros::test_all]
+    fn test_additional_outputs_overflow() {
+        let (swap_tx, keys, preimage, ..) = claim_fixture();
+        let secp = Secp256k1::new();
+
+        let (extra_1, _) = confidential_address(&secp);
+        let (extra_2, _) = confidential_address(&secp);
+        let err = swap_tx
+            .with_additional_outputs(vec![(extra_1, u64::MAX), (extra_2, 1)])
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap_err();
+        assert!(err.message().contains("overflow"));
     }
 }

--- a/src/swaps/liquid.rs
+++ b/src/swaps/liquid.rs
@@ -541,6 +541,10 @@ pub struct LBtcSwapTx {
     pub kind: SwapTxKind,
     pub swap_script: LBtcSwapScript,
     pub output_address: Address,
+    /// Extra fixed-amount outputs paid in addition to `output_address`.
+    /// `output_address` receives the remainder (input - fee - sum of these)
+    /// and remains the first payment output.
+    pub additional_outputs: Vec<(Address, u64)>,
     pub funding_outpoint: OutPoint,
     pub funding_utxo: TxOut, // there should only ever be one outpoint in a swap
     pub genesis_hash: BlockHash, // Required to calculate sighash
@@ -565,10 +569,21 @@ impl LBtcSwapTx {
             kind: SwapTxKind::Claim,
             swap_script,
             output_address: Address::from_str(&output_address)?,
+            additional_outputs: Vec::new(),
             funding_outpoint: utxo.0,
             funding_utxo: utxo.1,
             genesis_hash,
         })
+    }
+
+    /// Add fixed-amount outputs paid in addition to the primary output address.
+    /// The primary output receives the remainder (input - fee - sum of additional
+    /// outputs) and remains the first payment output. All addresses must be
+    /// confidential and all amounts non-zero; violations error when the
+    /// transaction is built.
+    pub fn with_additional_outputs(mut self, additional_outputs: Vec<(Address, u64)>) -> Self {
+        self.additional_outputs = additional_outputs;
+        self
     }
 
     /// Craft a new ClaimTx. Only works for Reverse and Chain Swaps.
@@ -623,6 +638,7 @@ impl LBtcSwapTx {
             kind: SwapTxKind::Refund,
             swap_script,
             output_address: address,
+            additional_outputs: Vec::new(),
             funding_outpoint,
             funding_utxo,
             genesis_hash,
@@ -803,6 +819,126 @@ impl LBtcSwapTx {
         Ok(claim_tx)
     }
 
+    /// Build the blinded payment outputs: the primary output (which receives
+    /// the remainder) first, followed by any additional fixed-amount outputs.
+    /// The last payment output balances the confidential-transaction blinding
+    /// against the input and the explicit fee output.
+    fn create_payment_outputs(
+        &self,
+        secp: &Secp256k1<elements::secp256k1_zkp::All>,
+        unblinded_utxo: TxOutSecrets,
+        absolute_fees: u64,
+    ) -> Result<Vec<TxOut>, Error> {
+        let mut rng = OsRng;
+        let asset_id = unblinded_utxo.asset;
+
+        let total_additional =
+            self.additional_outputs
+                .iter()
+                .try_fold(0u64, |sum, (_, amount)| {
+                    if *amount == 0 {
+                        return Err(Error::Protocol(
+                            "Additional output amount must be greater than zero.".to_string(),
+                        ));
+                    }
+                    sum.checked_add(*amount).ok_or(Error::Protocol(
+                        "Additional output amounts overflow.".to_string(),
+                    ))
+                })?;
+
+        let primary_value = Amount::from_sat(unblinded_utxo.value)
+            .checked_sub(Amount::from_sat(absolute_fees))
+            .and_then(|value| value.checked_sub(Amount::from_sat(total_additional)))
+            .ok_or(Error::Protocol(format!(
+                "Output value {} is less than fees {} plus additional outputs {}",
+                unblinded_utxo.value, absolute_fees, total_additional
+            )))?;
+
+        // A zero remainder is rejected only when caused by additional outputs;
+        // the historical single-output behavior (input == fee) is preserved.
+        if !self.additional_outputs.is_empty() && primary_value == Amount::ZERO {
+            return Err(Error::Protocol(
+                "Primary output value is zero after fees and additional outputs".to_string(),
+            ));
+        }
+
+        let input_blinding_factors = [(
+            unblinded_utxo.value,
+            unblinded_utxo.asset_bf,
+            unblinded_utxo.value_bf,
+        )];
+        // The explicit fee output participates in the blinding balance with zero factors.
+        let mut output_blinding_factors: Vec<(u64, AssetBlindingFactor, ValueBlindingFactor)> =
+            vec![(
+                absolute_fees,
+                AssetBlindingFactor::zero(),
+                ValueBlindingFactor::zero(),
+            )];
+
+        let last_index = self.additional_outputs.len();
+        let destinations = std::iter::once((&self.output_address, primary_value.to_sat()))
+            .chain(self.additional_outputs.iter().map(|(a, v)| (a, *v)));
+        let mut payment_outputs = Vec::with_capacity(last_index + 1);
+
+        for (i, (address, value)) in destinations.enumerate() {
+            let out_abf = AssetBlindingFactor::new(&mut rng);
+            let exp_asset = Asset::Explicit(asset_id);
+
+            let (blinded_asset, asset_surjection_proof) =
+                exp_asset.blind(&mut rng, secp, out_abf, &[unblinded_utxo])?;
+
+            // The last payment output balances the blinding equation;
+            // the others get random blinding factors.
+            let out_vbf = if i == last_index {
+                ValueBlindingFactor::last(
+                    secp,
+                    value,
+                    out_abf,
+                    &input_blinding_factors,
+                    &output_blinding_factors,
+                )
+            } else {
+                ValueBlindingFactor::new(&mut rng)
+            };
+
+            let explicit_value = elements::confidential::Value::Explicit(value);
+            let msg = elements::RangeProofMessage {
+                asset: asset_id,
+                bf: out_abf,
+            };
+            let ephemeral_sk = SecretKey::new(&mut rng);
+
+            let blinding_key = address
+                .blinding_pubkey
+                .ok_or(Error::Protocol("No blinding key in tx.".to_string()))?;
+            let (blinded_value, nonce, rangeproof) = explicit_value.blind(
+                secp,
+                out_vbf,
+                blinding_key,
+                ephemeral_sk,
+                &address.script_pubkey(),
+                &msg,
+            )?;
+
+            if i != last_index {
+                output_blinding_factors.push((value, out_abf, out_vbf));
+            }
+
+            payment_outputs.push(TxOut {
+                script_pubkey: address.script_pubkey(),
+                value: blinded_value,
+                asset: blinded_asset,
+                nonce,
+                witness: TxOutWitness {
+                    surjection_proof: Some(Box::new(asset_surjection_proof)), // from asset blinding
+                    rangeproof: Some(Box::new(rangeproof)),                   // from value blinding
+                },
+            });
+        }
+
+        Ok(payment_outputs)
+    }
+
     fn create_claim(
         &self,
         keys: &Keypair,
@@ -824,79 +960,20 @@ impl LBtcSwapTx {
         };
 
         let secp = Secp256k1::new();
-        let mut rng = OsRng;
 
         let unblined_utxo = self
             .funding_utxo
             .unblind(&secp, self.swap_script.blinding_key.secret_key())?;
         let asset_id = unblined_utxo.asset;
-        let out_abf = AssetBlindingFactor::new(&mut rng);
-        let exp_asset = Asset::Explicit(asset_id);
 
-        let (blinded_asset, asset_surjection_proof) =
-            exp_asset.blind(&mut rng, &secp, out_abf, &[unblined_utxo])?;
-
-        let output_value = Amount::from_sat(unblined_utxo.value)
-            .checked_sub(Amount::from_sat(absolute_fees))
-            .ok_or(Error::Protocol(format!(
-                "Output value {} is less than fees {}",
-                unblined_utxo.value, absolute_fees
-            )))?;
-
-        let final_vbf = ValueBlindingFactor::last(
-            &secp,
-            output_value.to_sat(),
-            out_abf,
-            &[(
-                unblined_utxo.value,
-                unblined_utxo.asset_bf,
-                unblined_utxo.value_bf,
-            )],
-            &[(
-                absolute_fees,
-                AssetBlindingFactor::zero(),
-                ValueBlindingFactor::zero(),
-            )],
-        );
-        let explicit_value = elements::confidential::Value::Explicit(output_value.to_sat());
-        let msg = elements::RangeProofMessage {
-            asset: asset_id,
-            bf: out_abf,
-        };
-        let ephemeral_sk = SecretKey::new(&mut rng);
-
-        // assuming we always use a blinded address that has an extractable blinding pub
-        let blinding_key = self
-            .output_address
-            .blinding_pubkey
-            .ok_or(Error::Protocol("No blinding key in tx.".to_string()))?;
-        let (blinded_value, nonce, rangeproof) = explicit_value.blind(
-            &secp,
-            final_vbf,
-            blinding_key,
-            ephemeral_sk,
-            &self.output_address.script_pubkey(),
-            &msg,
-        )?;
-
-        let tx_out_witness = TxOutWitness {
-            surjection_proof: Some(Box::new(asset_surjection_proof)), // from asset blinding
-            rangeproof: Some(Box::new(rangeproof)),                   // from value blinding
-        };
-        let payment_output: TxOut = TxOut {
-            script_pubkey: self.output_address.script_pubkey(),
-            value: blinded_value,
-            asset: blinded_asset,
-            nonce,
-            witness: tx_out_witness,
-        };
-        let fee_output: TxOut = TxOut::new_fee(absolute_fees, asset_id);
+        let mut output = self.create_payment_outputs(&secp, unblined_utxo, absolute_fees)?;
+        output.push(TxOut::new_fee(absolute_fees, asset_id));
 
         let mut claim_tx = Transaction {
             version: 2,
             lock_time: LockTime::ZERO,
             input: vec![claim_txin],
-            output: vec![payment_output, fee_output],
+            output,
         };
 
         if is_cooperative {
@@ -1116,73 +1193,14 @@ impl LBtcSwapTx {
         };
 
         let secp = Secp256k1::new();
-        let mut rng = OsRng;
 
         let unblined_utxo = self
             .funding_utxo
             .unblind(&secp, self.swap_script.blinding_key.secret_key())?;
         let asset_id = unblined_utxo.asset;
-        let out_abf = AssetBlindingFactor::new(&mut rng);
-        let exp_asset = Asset::Explicit(asset_id);
 
-        let (blinded_asset, asset_surjection_proof) =
-            exp_asset.blind(&mut rng, &secp, out_abf, &[unblined_utxo])?;
-
-        let output_value = Amount::from_sat(unblined_utxo.value)
-            .checked_sub(Amount::from_sat(absolute_fees))
-            .ok_or(Error::Protocol(format!(
-                "Output value {} is less than fees {}",
-                unblined_utxo.value, absolute_fees
-            )))?;
-
-        let final_vbf = ValueBlindingFactor::last(
-            &secp,
-            output_value.to_sat(),
-            out_abf,
-            &[(
-                unblined_utxo.value,
-                unblined_utxo.asset_bf,
-                unblined_utxo.value_bf,
-            )],
-            &[(
-                absolute_fees,
-                AssetBlindingFactor::zero(),
-                ValueBlindingFactor::zero(),
-            )],
-        );
-        let explicit_value = elements::confidential::Value::Explicit(output_value.to_sat());
-        let msg = elements::RangeProofMessage {
-            asset: asset_id,
-            bf: out_abf,
-        };
-        let ephemeral_sk = SecretKey::new(&mut rng);
-
-        // assuming we always use a blinded address that has an extractable blinding pub
-        let blinding_key = self
-            .output_address
-            .blinding_pubkey
-            .ok_or(Error::Protocol("No blinding key in tx.".to_string()))?;
-        let (blinded_value, nonce, rangeproof) = explicit_value.blind(
-            &secp,
-            final_vbf,
-            blinding_key,
-            ephemeral_sk,
-            &self.output_address.script_pubkey(),
-            &msg,
-        )?;
-
-        let tx_out_witness = TxOutWitness {
-            surjection_proof: Some(Box::new(asset_surjection_proof)), // from asset blinding
-            rangeproof: Some(Box::new(rangeproof)),                   // from value blinding
-        };
-        let payment_output: TxOut = TxOut {
-            script_pubkey: self.output_address.script_pubkey(),
-            value: blinded_value,
-            asset: blinded_asset,
-            nonce,
-            witness: tx_out_witness,
-        };
-        let fee_output: TxOut = TxOut::new_fee(absolute_fees, asset_id);
+        let mut output = vec![TxOut::new_fee(absolute_fees, asset_id)];
+        output.extend(self.create_payment_outputs(&secp, unblined_utxo, absolute_fees)?);
 
         let refund_script = self.swap_script.refund_script();
 
@@ -1214,7 +1232,7 @@ impl LBtcSwapTx {
             version: 2,
             lock_time,
             input: vec![refund_txin],
-            output: vec![fee_output, payment_output],
+            output,
         };
 
         if is_cooperative {
@@ -1410,5 +1428,287 @@ mod tests {
 
         assert_eq!(tx_size(&tx, false), 1333);
         assert_eq!(tx_size(&tx, true), 216);
+    }
+
+    use crate::util::secrets::Preimage;
+    use bitcoin::key::rand::thread_rng;
+    use elements::AddressParams;
+
+    const FUNDING_SAT: u64 = 100_000;
+    const FEE_SAT: u64 = 500;
+
+    /// Build an LBtcSwapTx over a locally fabricated blinded funding utxo, so
+    /// the confidential-transaction construction can be exercised without a
+    /// chain backend. Returns the keypair that signs for the given tx kind.
+    fn swap_tx_fixture(
+        swap_type: SwapType,
+        kind: SwapTxKind,
+    ) -> (LBtcSwapTx, Keypair, Preimage, ZKKeyPair, elements::AssetId) {
+        let secp = Secp256k1::new();
+        let mut rng = OsRng;
+
+        let preimage = Preimage::random();
+        let recvr_keypair = Keypair::new(&secp, &mut thread_rng());
+        let sender_keypair = Keypair::new(&secp, &mut thread_rng());
+        let blinding_keypair = ZKKeyPair::new(&secp, &mut thread_rng());
+
+        let swap_script = LBtcSwapScript {
+            swap_type,
+            side: None,
+            funding_addrs: None,
+            hashlock: preimage.hash160,
+            receiver_pubkey: PublicKey {
+                compressed: true,
+                inner: recvr_keypair.public_key(),
+            },
+            locktime: elements::LockTime::from_height(200).unwrap(),
+            sender_pubkey: PublicKey {
+                compressed: true,
+                inner: sender_keypair.public_key(),
+            },
+            blinding_key: blinding_keypair,
+        };
+
+        let funding_spk = swap_script
+            .to_address(LiquidChain::Liquid)
+            .unwrap()
+            .script_pubkey();
+
+        // Fabricate a blinded funding utxo paying the swap script, blinded to
+        // the swap script's blinding key so create_claim can unblind it.
+        let asset_id = elements::AssetId::from_slice(&[0x11; 32]).unwrap();
+        let in_abf = AssetBlindingFactor::new(&mut rng);
+        let in_vbf = ValueBlindingFactor::new(&mut rng);
+        let surjection_domain = TxOutSecrets {
+            asset: asset_id,
+            asset_bf: AssetBlindingFactor::zero(),
+            value: FUNDING_SAT,
+            value_bf: ValueBlindingFactor::zero(),
+        };
+        let (blinded_asset, surjection_proof) = Asset::Explicit(asset_id)
+            .blind(&mut rng, &secp, in_abf, &[surjection_domain])
+            .unwrap();
+        let rp_msg = elements::RangeProofMessage {
+            asset: asset_id,
+            bf: in_abf,
+        };
+        let (blinded_value, nonce, rangeproof) =
+            elements::confidential::Value::Explicit(FUNDING_SAT)
+                .blind(
+                    &secp,
+                    in_vbf,
+                    swap_script.blinding_key.public_key(),
+                    SecretKey::new(&mut rng),
+                    &funding_spk,
+                    &rp_msg,
+                )
+                .unwrap();
+        let funding_utxo = TxOut {
+            script_pubkey: funding_spk,
+            value: blinded_value,
+            asset: blinded_asset,
+            nonce,
+            witness: TxOutWitness {
+                surjection_proof: Some(Box::new(surjection_proof)),
+                rangeproof: Some(Box::new(rangeproof)),
+            },
+        };
+
+        let (primary_address, primary_blinder) = confidential_address(&secp);
+
+        let signing_keys = match kind {
+            SwapTxKind::Claim => recvr_keypair,
+            SwapTxKind::Refund => sender_keypair,
+        };
+
+        let swap_tx = LBtcSwapTx {
+            kind,
+            swap_script,
+            output_address: primary_address,
+            additional_outputs: Vec::new(),
+            funding_outpoint: OutPoint::default(),
+            funding_utxo,
+            genesis_hash: BlockHash::all_zeros(),
+        };
+
+        (swap_tx, signing_keys, preimage, primary_blinder, asset_id)
+    }
+
+    fn claim_fixture() -> (LBtcSwapTx, Keypair, Preimage, ZKKeyPair, elements::AssetId) {
+        swap_tx_fixture(SwapType::ReverseSubmarine, SwapTxKind::Claim)
+    }
+
+    fn confidential_address(
+        secp: &Secp256k1<elements::secp256k1_zkp::All>,
+    ) -> (Address, ZKKeyPair) {
+        let spend_keypair = Keypair::new(secp, &mut thread_rng());
+        let blinder_keypair = ZKKeyPair::new(secp, &mut thread_rng());
+        let address = Address::p2wpkh(
+            &PublicKey {
+                compressed: true,
+                inner: spend_keypair.public_key(),
+            },
+            Some(blinder_keypair.public_key()),
+            &AddressParams::LIQUID,
+        );
+        (address, blinder_keypair)
+    }
+
+    #[macros::test_all]
+    fn test_claim_single_output() {
+        let (swap_tx, keys, preimage, primary_blinder, asset_id) = claim_fixture();
+        let secp = Secp256k1::new();
+
+        let tx = swap_tx
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap();
+
+        assert_eq!(tx.output.len(), 2);
+        assert_eq!(tx.output[1].value.explicit().unwrap(), FEE_SAT);
+        assert!(tx.output[1].is_fee());
+
+        // The whole confidential transaction must balance and verify.
+        tx.verify_tx_amt_proofs(&secp, &[swap_tx.funding_utxo.clone()])
+            .unwrap();
+
+        let secrets = tx.output[0]
+            .unblind(&secp, primary_blinder.secret_key())
+            .unwrap();
+        assert_eq!(secrets.value, FUNDING_SAT - FEE_SAT);
+        assert_eq!(secrets.asset, asset_id);
+    }
+
+    #[macros::test_all]
+    fn test_claim_with_additional_outputs() {
+        let (swap_tx, keys, preimage, primary_blinder, asset_id) = claim_fixture();
+        let secp = Secp256k1::new();
+
+        let (extra_address_1, extra_blinder_1) = confidential_address(&secp);
+        let (extra_address_2, extra_blinder_2) = confidential_address(&secp);
+
+        let swap_tx = swap_tx.with_additional_outputs(vec![
+            (extra_address_1.clone(), 800),
+            (extra_address_2.clone(), 1_200),
+        ]);
+
+        let tx = swap_tx
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap();
+
+        // primary, two additional, fee
+        assert_eq!(tx.output.len(), 4);
+        assert!(tx.output[3].is_fee());
+        assert_eq!(tx.output[3].value.explicit().unwrap(), FEE_SAT);
+
+        // The whole confidential transaction must balance and verify.
+        tx.verify_tx_amt_proofs(&secp, &[swap_tx.funding_utxo.clone()])
+            .unwrap();
+
+        // Primary output keeps index 0 and receives the remainder.
+        assert_eq!(
+            tx.output[0].script_pubkey,
+            swap_tx.output_address.script_pubkey()
+        );
+        let primary = tx.output[0]
+            .unblind(&secp, primary_blinder.secret_key())
+            .unwrap();
+        assert_eq!(primary.value, FUNDING_SAT - FEE_SAT - 800 - 1_200);
+        assert_eq!(primary.asset, asset_id);
+
+        // Each additional output pays its fixed amount to its own address.
+        assert_eq!(tx.output[1].script_pubkey, extra_address_1.script_pubkey());
+        let extra_1 = tx.output[1]
+            .unblind(&secp, extra_blinder_1.secret_key())
+            .unwrap();
+        assert_eq!(extra_1.value, 800);
+        assert_eq!(extra_1.asset, asset_id);
+
+        assert_eq!(tx.output[2].script_pubkey, extra_address_2.script_pubkey());
+        let extra_2 = tx.output[2]
+            .unblind(&secp, extra_blinder_2.secret_key())
+            .unwrap();
+        assert_eq!(extra_2.value, 1_200);
+        assert_eq!(extra_2.asset, asset_id);
+    }
+
+    #[macros::test_all]
+    fn test_refund_with_additional_outputs() {
+        let (swap_tx, keys, _, primary_blinder, asset_id) =
+            swap_tx_fixture(SwapType::Submarine, SwapTxKind::Refund);
+        let secp = Secp256k1::new();
+
+        let (extra_address, extra_blinder) = confidential_address(&secp);
+        let swap_tx = swap_tx.with_additional_outputs(vec![(extra_address.clone(), 700)]);
+
+        let tx = swap_tx.create_refund(&keys, FEE_SAT, false).unwrap();
+
+        // fee first, then primary and additional (refund output order)
+        assert_eq!(tx.output.len(), 3);
+        assert!(tx.output[0].is_fee());
+        assert_eq!(tx.output[0].value.explicit().unwrap(), FEE_SAT);
+
+        tx.verify_tx_amt_proofs(&secp, &[swap_tx.funding_utxo.clone()])
+            .unwrap();
+
+        assert_eq!(
+            tx.output[1].script_pubkey,
+            swap_tx.output_address.script_pubkey()
+        );
+        let primary = tx.output[1]
+            .unblind(&secp, primary_blinder.secret_key())
+            .unwrap();
+        assert_eq!(primary.value, FUNDING_SAT - FEE_SAT - 700);
+        assert_eq!(primary.asset, asset_id);
+
+        assert_eq!(tx.output[2].script_pubkey, extra_address.script_pubkey());
+        let extra = tx.output[2]
+            .unblind(&secp, extra_blinder.secret_key())
+            .unwrap();
+        assert_eq!(extra.value, 700);
+    }
+
+    #[macros::test_all]
+    fn test_claim_additional_outputs_exceed_input() {
+        let (swap_tx, keys, preimage, _, _) = claim_fixture();
+        let secp = Secp256k1::new();
+
+        let (extra_address, _) = confidential_address(&secp);
+        let swap_tx = swap_tx.with_additional_outputs(vec![(extra_address, FUNDING_SAT)]);
+
+        let err = swap_tx
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap_err();
+        assert!(err.message().contains("less than fees"));
+    }
+
+    #[macros::test_all]
+    fn test_additional_output_validation() {
+        let (swap_tx, keys, preimage, ..) = claim_fixture();
+        let secp = Secp256k1::new();
+
+        // Zero amounts are rejected.
+        let (extra_address, _) = confidential_address(&secp);
+        let err = swap_tx
+            .clone()
+            .with_additional_outputs(vec![(extra_address, 0)])
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap_err();
+        assert!(err.message().contains("greater than zero"));
+
+        // Unblinded addresses are rejected.
+        let spend_keypair = Keypair::new(&secp, &mut thread_rng());
+        let unblinded = Address::p2wpkh(
+            &PublicKey {
+                compressed: true,
+                inner: spend_keypair.public_key(),
+            },
+            None,
+            &AddressParams::LIQUID,
+        );
+        let err = swap_tx
+            .with_additional_outputs(vec![(unblinded, 800)])
+            .create_claim(&keys, &preimage, FEE_SAT, false)
+            .unwrap_err();
+        assert!(err.message().contains("blinding key"));
     }
 }

--- a/src/swaps/wrappers.rs
+++ b/src/swaps/wrappers.rs
@@ -51,6 +51,7 @@ pub struct TransactionOptions {
     cooperative: bool,
     chain_claim: Option<ChainClaim>,
     lockup_tx: Option<BtcLikeTransaction>,
+    additional_outputs: Vec<(String, u64)>,
 }
 
 impl Default for TransactionOptions {
@@ -59,6 +60,7 @@ impl Default for TransactionOptions {
             cooperative: true,
             chain_claim: None,
             lockup_tx: None,
+            additional_outputs: Vec::new(),
         }
     }
 }
@@ -83,6 +85,15 @@ impl TransactionOptions {
 
     pub fn with_lockup_tx(mut self, lockup_tx: BtcLikeTransaction) -> Self {
         self.lockup_tx = Some(lockup_tx);
+        self
+    }
+
+    /// Extra fixed-amount outputs paid in addition to the primary output address.
+    /// The primary output receives the remainder (input - fee - sum of these) and
+    /// remains the first payment output. On Liquid all addresses must be
+    /// confidential.
+    pub fn with_additional_outputs(mut self, additional_outputs: Vec<(String, u64)>) -> Self {
+        self.additional_outputs = additional_outputs;
         self
     }
 }
@@ -572,11 +583,39 @@ impl SwapScript {
         Ok(())
     }
 
+    fn additional_outputs_bitcoin(
+        additional_outputs: &[(String, u64)],
+    ) -> Result<Vec<(bitcoin::Address, u64)>, Error> {
+        additional_outputs
+            .iter()
+            .map(|(address, amount)| {
+                Ok((
+                    bitcoin::Address::from_str(address)?.assume_checked(),
+                    *amount,
+                ))
+            })
+            .collect()
+    }
+
+    fn additional_outputs_liquid(
+        additional_outputs: &[(String, u64)],
+    ) -> Result<Vec<(elements::Address, u64)>, Error> {
+        additional_outputs
+            .iter()
+            .map(|(address, amount)| Ok((elements::Address::from_str(address)?, *amount)))
+            .collect()
+    }
+
     pub async fn construct_claim(
         &self,
         preimage: &Preimage,
         params: SwapTransactionParams<'_>,
     ) -> Result<BtcLikeTransaction, Error> {
+        let additional_outputs = params
+            .options
+            .as_ref()
+            .map(|options| options.additional_outputs.clone())
+            .unwrap_or_default();
         let cooperative = self
             .get_cooperative(
                 SwapTxKind::Claim,
@@ -617,7 +656,8 @@ impl SwapScript {
                     params.output_address.clone(),
                     chain_client,
                     utxo,
-                )?;
+                )?
+                .with_additional_outputs(Self::additional_outputs_bitcoin(&additional_outputs)?);
 
                 tx.sign_claim(&params.keys, preimage, params.fee, cooperative)
                     .await
@@ -658,7 +698,8 @@ impl SwapScript {
                     chain_client,
                     utxo,
                 )
-                .await?;
+                .await?
+                .with_additional_outputs(Self::additional_outputs_liquid(&additional_outputs)?);
 
                 tx.sign_claim(&params.keys, preimage, params.fee, cooperative, true)
                     .await
@@ -671,6 +712,11 @@ impl SwapScript {
         &self,
         params: SwapTransactionParams<'_>,
     ) -> Result<BtcLikeTransaction, Error> {
+        let additional_outputs = params
+            .options
+            .as_ref()
+            .map(|options| options.additional_outputs.clone())
+            .unwrap_or_default();
         let cooperative = self
             .get_cooperative(
                 SwapTxKind::Refund,
@@ -689,7 +735,8 @@ impl SwapScript {
                     params.boltz_client,
                     params.swap_id.clone(),
                 )
-                .await?;
+                .await?
+                .with_additional_outputs(Self::additional_outputs_bitcoin(&additional_outputs)?);
                 tx.sign_refund(&params.keys, params.fee, cooperative)
                     .await
                     .map(BtcLikeTransaction::bitcoin)
@@ -702,7 +749,8 @@ impl SwapScript {
                     params.boltz_client,
                     params.swap_id.clone(),
                 )
-                .await?;
+                .await?
+                .with_additional_outputs(Self::additional_outputs_liquid(&additional_outputs)?);
                 tx.sign_refund(&params.keys, params.fee, cooperative, true)
                     .await
                     .map(BtcLikeTransaction::liquid)

--- a/src/swaps/wrappers.rs
+++ b/src/swaps/wrappers.rs
@@ -88,10 +88,19 @@ impl TransactionOptions {
         self
     }
 
-    /// Extra fixed-amount outputs paid in addition to the primary output address.
-    /// The primary output receives the remainder (input - fee - sum of these) and
-    /// remains the first payment output. On Liquid all addresses must be
-    /// confidential.
+    /// Extra fixed-amount outputs (in satoshis) paid in addition to the primary
+    /// output address. The primary output receives the remainder
+    /// (input - fee - sum of these) and remains the first payment output, with
+    /// the additional outputs following in the given order. On Bitcoin the
+    /// primary stays at output index 0; on Liquid claims order outputs
+    /// [primary, additions.., fee] and refunds [fee, primary, additions..].
+    ///
+    /// Calling this again replaces the previously set list. Addresses must be
+    /// valid for the chain client's network. On Liquid all addresses must be
+    /// confidential and all amounts positive; on Bitcoin zero-valued outputs
+    /// are accepted and dust/relay policy is the broadcaster's responsibility.
+    /// Cooperative signing commits to every output, including the additional
+    /// ones.
     pub fn with_additional_outputs(mut self, additional_outputs: Vec<(String, u64)>) -> Self {
         self.additional_outputs = additional_outputs;
         self
@@ -585,24 +594,35 @@ impl SwapScript {
 
     fn additional_outputs_bitcoin(
         additional_outputs: &[(String, u64)],
+        network: bitcoin::Network,
     ) -> Result<Vec<(bitcoin::Address, u64)>, Error> {
         additional_outputs
             .iter()
             .map(|(address, amount)| {
-                Ok((
-                    bitcoin::Address::from_str(address)?.assume_checked(),
-                    *amount,
-                ))
+                let address = bitcoin::Address::from_str(address)?;
+                if !address.is_valid_for_network(network) {
+                    return Err(Error::Address("Address validation failed".to_string()));
+                }
+                Ok((address.assume_checked(), *amount))
             })
             .collect()
     }
 
     fn additional_outputs_liquid(
         additional_outputs: &[(String, u64)],
+        params: &'static elements::AddressParams,
     ) -> Result<Vec<(elements::Address, u64)>, Error> {
         additional_outputs
             .iter()
-            .map(|(address, amount)| Ok((elements::Address::from_str(address)?, *amount)))
+            .map(|(address, amount)| {
+                let address = elements::Address::parse_with_params(address, params)?;
+                if address.blinding_pubkey.is_none() {
+                    return Err(Error::Protocol(
+                        "Additional output addresses must be confidential on Liquid.".to_string(),
+                    ));
+                }
+                Ok((address, *amount))
+            })
             .collect()
     }
 
@@ -657,7 +677,10 @@ impl SwapScript {
                     chain_client,
                     utxo,
                 )?
-                .with_additional_outputs(Self::additional_outputs_bitcoin(&additional_outputs)?);
+                .with_additional_outputs(Self::additional_outputs_bitcoin(
+                    &additional_outputs,
+                    chain_client.network().into(),
+                )?);
 
                 tx.sign_claim(&params.keys, preimage, params.fee, cooperative)
                     .await
@@ -699,7 +722,10 @@ impl SwapScript {
                     utxo,
                 )
                 .await?
-                .with_additional_outputs(Self::additional_outputs_liquid(&additional_outputs)?);
+                .with_additional_outputs(Self::additional_outputs_liquid(
+                    &additional_outputs,
+                    chain_client.network().into(),
+                )?);
 
                 tx.sign_claim(&params.keys, preimage, params.fee, cooperative, true)
                     .await
@@ -728,29 +754,37 @@ impl SwapScript {
 
         match self.script.clone() {
             SwapScriptImpl::Bitcoin(script) => {
+                let chain_client = params.chain_client.require_bitcoin_client()?;
                 let tx = BtcSwapTx::new_refund(
                     script.as_ref().clone(),
                     &params.output_address,
-                    params.chain_client.require_bitcoin_client()?,
+                    chain_client,
                     params.boltz_client,
                     params.swap_id.clone(),
                 )
                 .await?
-                .with_additional_outputs(Self::additional_outputs_bitcoin(&additional_outputs)?);
+                .with_additional_outputs(Self::additional_outputs_bitcoin(
+                    &additional_outputs,
+                    chain_client.network().into(),
+                )?);
                 tx.sign_refund(&params.keys, params.fee, cooperative)
                     .await
                     .map(BtcLikeTransaction::bitcoin)
             }
             SwapScriptImpl::Liquid(script) => {
+                let chain_client = params.chain_client.require_liquid_client()?;
                 let tx = LBtcSwapTx::new_refund(
                     script.as_ref().clone(),
                     &params.output_address,
-                    params.chain_client.require_liquid_client()?,
+                    chain_client,
                     params.boltz_client,
                     params.swap_id.clone(),
                 )
                 .await?
-                .with_additional_outputs(Self::additional_outputs_liquid(&additional_outputs)?);
+                .with_additional_outputs(Self::additional_outputs_liquid(
+                    &additional_outputs,
+                    chain_client.network().into(),
+                )?);
                 tx.sign_refund(&params.keys, params.fee, cooperative, true)
                     .await
                     .map(BtcLikeTransaction::liquid)

--- a/tests/regtest/chain_swaps.rs
+++ b/tests/regtest/chain_swaps.rs
@@ -176,15 +176,22 @@ async fn v2_chain(chain_client: &ChainClient, underpay: bool, from: Chain, to: C
 
         log::info!("Claiming!");
 
+        // Pay an extra fixed-amount output from the cooperative chain claim,
+        // so Boltz partial-signs a multi-output claim transaction.
+        let additional_outputs = vec![(utils::generate_address(to).await.unwrap(), 600)];
+        let absolute_fee = 1000;
+        let server_lock_amount = claim_details.amount;
+
         let swap_params = SwapTransactionParams {
             keys: our_claim_keys,
             output_address: claim_address.clone(),
-            fee: Fee::Absolute(1000),
+            fee: Fee::Absolute(absolute_fee),
             swap_id: swap_id.clone(),
             options: Some(
                 TransactionOptions::default()
                     .with_chain_claim(our_refund_keys, lockup_script.clone())
-                    .with_lockup_tx(lockup_tx),
+                    .with_lockup_tx(lockup_tx)
+                    .with_additional_outputs(additional_outputs.clone()),
             ),
             chain_client,
             boltz_client: &boltz_api_v2,
@@ -208,6 +215,17 @@ async fn v2_chain(chain_client: &ChainClient, underpay: bool, from: Chain, to: C
             .construct_claim(&preimage, swap_params.clone())
             .await
             .unwrap();
+
+        assert_multi_output_tx(
+            &tx,
+            to,
+            true,
+            &claim_address,
+            &additional_outputs,
+            server_lock_amount,
+            absolute_fee,
+        )
+        .await;
 
         chain_client.broadcast_tx(&tx).await.unwrap();
         log::info!("Successfully broadcasted claim tx!");

--- a/tests/regtest/common.rs
+++ b/tests/regtest/common.rs
@@ -1,9 +1,10 @@
-use boltz_client::swaps::ChainClient;
+use boltz_client::swaps::{BtcLikeTransaction, ChainClient};
 use boltz_client::util::sleep;
 use boltz_client::{
     boltz::{BoltzApiClientV2, SwapStatus, BOLTZ_REGTEST},
-    network::{BitcoinChain, LiquidChain},
+    network::{BitcoinChain, Chain, LiquidChain},
 };
+use std::str::FromStr;
 use std::time::Duration;
 use tokio::sync::broadcast::Receiver;
 
@@ -31,6 +32,92 @@ pub fn create_chain_client_esplora() -> ChainClient {
     ChainClient::new()
         .with_bitcoin(EsploraBitcoinClient::default(BTC_CHAIN, None))
         .with_liquid(EsploraLiquidClient::default(LBTC_CHAIN, None))
+}
+
+/// Assert the multi-output layout of a wrapper-built transaction: the primary
+/// output receives the remainder (input - fee - sum of additional outputs) and
+/// each additional output pays its fixed amount, in order. On Bitcoin the
+/// primary is output 0; on Liquid claims order [primary, additions.., fee] and
+/// refunds [fee, primary, additions..]. Liquid outputs are unblinded with the
+/// node's blinding keys and checked for value and asset.
+pub async fn assert_multi_output_tx(
+    tx: &BtcLikeTransaction,
+    chain: Chain,
+    is_claim: bool,
+    primary_address: &str,
+    additional: &[(String, u64)],
+    input_amount: u64,
+    absolute_fee: u64,
+) {
+    let total_additional: u64 = additional.iter().map(|(_, amount)| amount).sum();
+    let expected_primary = input_amount - absolute_fee - total_additional;
+
+    match chain {
+        Chain::Bitcoin(_) => {
+            let tx = tx.as_bitcoin().unwrap();
+            assert_eq!(tx.output.len(), 1 + additional.len());
+
+            let primary_spk = bitcoin::Address::from_str(primary_address)
+                .unwrap()
+                .assume_checked()
+                .script_pubkey();
+            assert_eq!(tx.output[0].script_pubkey, primary_spk);
+            assert_eq!(tx.output[0].value.to_sat(), expected_primary);
+
+            for (i, (address, amount)) in additional.iter().enumerate() {
+                let spk = bitcoin::Address::from_str(address)
+                    .unwrap()
+                    .assume_checked()
+                    .script_pubkey();
+                assert_eq!(tx.output[1 + i].script_pubkey, spk);
+                assert_eq!(tx.output[1 + i].value.to_sat(), *amount);
+            }
+        }
+        Chain::Liquid(liquid_chain) => {
+            let tx = tx.as_liquid().unwrap();
+            assert_eq!(tx.output.len(), 2 + additional.len());
+
+            let (fee_index, primary_index, additional_offset) = if is_claim {
+                (1 + additional.len(), 0, 1)
+            } else {
+                (0, 1, 2)
+            };
+            assert!(tx.output[fee_index].is_fee());
+            assert_eq!(tx.output[fee_index].value.explicit().unwrap(), absolute_fee);
+
+            let expected_asset = liquid_chain.bitcoin();
+            let primary = unblind_liquid_output(tx, primary_index, chain, primary_address).await;
+            assert_eq!(primary.value, expected_primary);
+            assert_eq!(primary.asset, expected_asset);
+
+            for (i, (address, amount)) in additional.iter().enumerate() {
+                let secrets =
+                    unblind_liquid_output(tx, additional_offset + i, chain, address).await;
+                assert_eq!(secrets.value, *amount);
+                assert_eq!(secrets.asset, expected_asset);
+            }
+        }
+    }
+}
+
+/// Check the output at `index` pays `address` and unblind it with the node
+/// wallet's blinding key.
+async fn unblind_liquid_output(
+    tx: &elements::Transaction,
+    index: usize,
+    chain: Chain,
+    address: &str,
+) -> elements::TxOutSecrets {
+    let addr = elements::Address::from_str(address).unwrap();
+    assert_eq!(tx.output[index].script_pubkey, addr.script_pubkey());
+
+    let blinding_key = crate::utils::get_blinding_key(chain, address)
+        .await
+        .unwrap();
+    let blinding_sk = elements::secp256k1_zkp::SecretKey::from_str(&blinding_key).unwrap();
+    tx.output[index]
+        .unblind(&elements::secp256k1_zkp::Secp256k1::new(), blinding_sk)
+        .unwrap()
 }
 
 pub async fn next_status(

--- a/tests/regtest/reverse.rs
+++ b/tests/regtest/reverse.rs
@@ -24,7 +24,7 @@ use crate::utils;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-async fn swap(chain: Chain, chain_client: &ChainClient) {
+async fn swap(chain: Chain, chain_client: &ChainClient, multi_output: bool) {
     let secp = Secp256k1::new();
     let preimage = Preimage::random();
     let our_keys = Keypair::new(&secp, &mut thread_rng());
@@ -96,14 +96,34 @@ async fn swap(chain: Chain, chain_client: &ChainClient) {
 
     let claim_address = utils::generate_address(chain).await.unwrap();
 
+    // A multi-output claim pays two extra fixed-amount outputs and spends
+    // non-cooperatively, so the additional-outputs wrapper path is exercised
+    // without Boltz involvement.
+    let additional_outputs = if multi_output {
+        vec![
+            (utils::generate_address(chain).await.unwrap(), 800),
+            (utils::generate_address(chain).await.unwrap(), 1_200),
+        ]
+    } else {
+        Vec::new()
+    };
+    let absolute_fee = if multi_output { 1_000 } else { 200 };
+    let mut options = TransactionOptions::default().with_lockup_tx(lockup_tx);
+    if multi_output {
+        options = options
+            .with_cooperative(false)
+            .with_additional_outputs(additional_outputs.clone());
+    }
+
+    let onchain_amount = reverse_resp.onchain_amount;
     let params = SwapTransactionParams {
         swap_id: swap_id.clone(),
         keys: our_keys,
-        fee: Fee::Absolute(200),
-        output_address: claim_address,
+        fee: Fee::Absolute(absolute_fee),
+        output_address: claim_address.clone(),
         chain_client,
         boltz_client: &boltz_api_v2,
-        options: Some(TransactionOptions::default().with_lockup_tx(lockup_tx)),
+        options: Some(options),
     };
 
     reverse_resp.onchain_amount += 10;
@@ -119,6 +139,19 @@ async fn swap(chain: Chain, chain_client: &ChainClient) {
         .construct_claim(&preimage, params)
         .await
         .unwrap();
+
+    if multi_output {
+        assert_multi_output_tx(
+            &tx,
+            chain,
+            true,
+            &claim_address,
+            &additional_outputs,
+            onchain_amount,
+            absolute_fee,
+        )
+        .await;
+    }
 
     chain_client.broadcast_tx(&tx).await.unwrap();
 
@@ -222,8 +255,8 @@ async fn swap_mrh(chain: Chain, chain_client: &ChainClient) {
 async fn bitcoin_v2_reverse_electrum() {
     setup_logger();
     let chain_client = create_chain_client_electrum();
-    swap(BTC_CHAIN.into(), &chain_client).await;
-    swap(BTC_CHAIN.into(), &chain_client).await;
+    swap(BTC_CHAIN.into(), &chain_client, false).await;
+    swap(BTC_CHAIN.into(), &chain_client, true).await;
 }
 
 #[macros::async_test_all]
@@ -232,8 +265,8 @@ async fn bitcoin_v2_reverse_electrum() {
 async fn bitcoin_v2_reverse_esplora() {
     setup_logger();
     let chain_client = create_chain_client_esplora();
-    swap(BTC_CHAIN.into(), &chain_client).await;
-    swap(BTC_CHAIN.into(), &chain_client).await;
+    swap(BTC_CHAIN.into(), &chain_client, false).await;
+    swap(BTC_CHAIN.into(), &chain_client, true).await;
 }
 
 #[macros::async_test]
@@ -242,8 +275,8 @@ async fn bitcoin_v2_reverse_esplora() {
 async fn liquid_v2_reverse_electrum() {
     setup_logger();
     let chain_client = create_chain_client_electrum();
-    swap(LBTC_CHAIN.into(), &chain_client).await;
-    swap(LBTC_CHAIN.into(), &chain_client).await;
+    swap(LBTC_CHAIN.into(), &chain_client, false).await;
+    swap(LBTC_CHAIN.into(), &chain_client, true).await;
 }
 
 #[macros::async_test_all]
@@ -252,8 +285,8 @@ async fn liquid_v2_reverse_electrum() {
 async fn liquid_v2_reverse_esplora() {
     setup_logger();
     let chain_client = create_chain_client_esplora();
-    swap(LBTC_CHAIN.into(), &chain_client).await;
-    swap(LBTC_CHAIN.into(), &chain_client).await;
+    swap(LBTC_CHAIN.into(), &chain_client, false).await;
+    swap(LBTC_CHAIN.into(), &chain_client, true).await;
 }
 
 #[macros::async_test_all]

--- a/tests/regtest/submarine.rs
+++ b/tests/regtest/submarine.rs
@@ -5,7 +5,10 @@ use boltz_client::network::electrum::{ElectrumBitcoinClient, ElectrumLiquidClien
 use boltz_client::network::esplora::{EsploraBitcoinClient, EsploraLiquidClient};
 use boltz_client::{
     network::Chain,
-    swaps::{boltz::CreateSubmarineRequest, ChainClient, SwapScript, SwapTransactionParams},
+    swaps::{
+        boltz::CreateSubmarineRequest, ChainClient, SwapScript, SwapTransactionParams,
+        TransactionOptions,
+    },
     util::{setup_logger, sleep},
 };
 use std::sync::Arc;
@@ -103,18 +106,38 @@ async fn v2_submarine(chain_client: &ChainClient, underpay: bool, chain: Chain) 
             .unwrap();
 
         sleep(WAIT_TIME).await;
+
+        // Refund through the wrapper with an extra fixed-amount output. The
+        // refund stays cooperative (a script-path refund would need the
+        // timelock matured), so Boltz partial-signs the multi-output refund.
+        let additional_outputs = vec![(utils::generate_address(chain).await.unwrap(), 700)];
+        let absolute_fee = 1000;
         let tx = swap_script
             .construct_refund(SwapTransactionParams {
                 keys: our_keys,
-                output_address: refund_address,
-                fee: Fee::Absolute(1000),
+                output_address: refund_address.clone(),
+                fee: Fee::Absolute(absolute_fee),
                 swap_id: swap_id.clone(),
                 chain_client,
                 boltz_client: &boltz_api_v2,
-                options: None,
+                options: Some(
+                    TransactionOptions::default()
+                        .with_additional_outputs(additional_outputs.clone()),
+                ),
             })
             .await
             .unwrap();
+
+        assert_multi_output_tx(
+            &tx,
+            chain,
+            false,
+            &refund_address,
+            &additional_outputs,
+            amount,
+            absolute_fee,
+        )
+        .await;
 
         let txid = chain_client.broadcast_tx(&tx).await.unwrap();
         log::info!("Cooperative Refund Successfully broadcasted: {txid}");

--- a/tests/txs.rs
+++ b/tests/txs.rs
@@ -98,6 +98,7 @@ fn prepare_btc_claim() -> (
         kind: SwapTxKind::Claim,
         swap_script,
         output_address: refund_addrs,
+        additional_outputs: Vec::new(),
         utxos: utxos.clone(),
     };
 
@@ -273,6 +274,7 @@ fn prepare_btc_refund() -> (
         kind: SwapTxKind::Refund,
         swap_script,
         output_address: refund_addrs,
+        additional_outputs: Vec::new(),
         utxos: utxos.clone(),
     };
 
@@ -431,6 +433,7 @@ fn prepare_lbtc_claim() -> (
         kind: SwapTxKind::Claim,
         swap_script,
         output_address: refund_addrs,
+        additional_outputs: Vec::new(),
         funding_outpoint: utxo.0,
         funding_utxo: utxo.1.clone(),
         genesis_hash,
@@ -583,6 +586,7 @@ fn prepare_lbtc_refund() -> (
         kind: SwapTxKind::Refund,
         swap_script,
         output_address: refund_addrs,
+        additional_outputs: Vec::new(),
         funding_outpoint: utxo.0,
         funding_utxo: utxo.1.clone(),
         genesis_hash,
@@ -664,4 +668,113 @@ async fn lbtc_submarine_refund_relative_fee() {
     test_framework.generate_blocks(1);
 
     assert!(test_framework.fetch_utxo(&swap_addrs).is_none());
+}
+
+#[tokio::test]
+async fn lbtc_reverse_claim_multi_output() {
+    let (test_framework, swap_tx, preimage, recvr_keypair, blinding_keypair, swap_addrs, utxo) =
+        prepare_lbtc_claim();
+
+    let secp = Secp256k1::new();
+
+    // Two extra confidential destinations with locally known blinders,
+    // so the broadcast outputs can be unblinded and checked exactly.
+    let extra_1_spend = Keypair::new(&secp, &mut thread_rng());
+    let extra_1_blinder = elements::secp256k1_zkp::Keypair::new(&secp, &mut thread_rng());
+    let extra_1 = Address::p2wpkh(
+        &bitcoin::PublicKey {
+            compressed: true,
+            inner: extra_1_spend.public_key(),
+        },
+        Some(extra_1_blinder.public_key()),
+        &elements::AddressParams::ELEMENTS,
+    );
+    let extra_2_spend = Keypair::new(&secp, &mut thread_rng());
+    let extra_2_blinder = elements::secp256k1_zkp::Keypair::new(&secp, &mut thread_rng());
+    let extra_2 = Address::p2wpkh(
+        &bitcoin::PublicKey {
+            compressed: true,
+            inner: extra_2_spend.public_key(),
+        },
+        Some(extra_2_blinder.public_key()),
+        &elements::AddressParams::ELEMENTS,
+    );
+
+    let swap_tx =
+        swap_tx.with_additional_outputs(vec![(extra_1.clone(), 800), (extra_2.clone(), 1_200)]);
+
+    let claim_tx = swap_tx
+        .sign_claim(&recvr_keypair, &preimage, Fee::Relative(0.1), None, false)
+        .await
+        .unwrap();
+
+    // primary, two additional, fee
+    assert_eq!(claim_tx.output.len(), 4);
+
+    let funding_secrets = utxo
+        .1
+        .unblind(&secp, blinding_keypair.secret_key())
+        .unwrap();
+    let fee = claim_tx.fee_in(funding_secrets.asset);
+
+    let extra_1_secrets = claim_tx.output[1]
+        .unblind(&secp, extra_1_blinder.secret_key())
+        .unwrap();
+    assert_eq!(extra_1_secrets.value, 800);
+    let extra_2_secrets = claim_tx.output[2]
+        .unblind(&secp, extra_2_blinder.secret_key())
+        .unwrap();
+    assert_eq!(extra_2_secrets.value, 1_200);
+
+    // The regtest node accepting the transaction proves the confidential
+    // proofs and the balance (primary = input - fee - 800 - 1200) are valid.
+    assert!(fee > 0);
+    test_framework.send_tx(&claim_tx);
+    test_framework.generate_blocks(1);
+
+    assert!(test_framework.fetch_utxo(&swap_addrs).is_none());
+}
+
+#[tokio::test]
+async fn btc_reverse_claim_multi_output() {
+    let (test_framework, scan_request, swap_tx, preimage, recvr_keypair, utxos) =
+        prepare_btc_claim();
+
+    let secp = Secp256k1::new();
+    let extra_keypair = Keypair::new(&secp, &mut thread_rng());
+    let extra_address = bitcoin::Address::p2wpkh(
+        &bitcoin::CompressedPublicKey(extra_keypair.public_key()),
+        bitcoin::Network::Regtest,
+    );
+
+    let swap_tx = swap_tx.with_additional_outputs(vec![(extra_address.clone(), 1_500)]);
+
+    let absolute_fee = 1_000;
+    let claim_tx = swap_tx
+        .sign_claim(&recvr_keypair, &preimage, Fee::Absolute(absolute_fee), None)
+        .await
+        .unwrap();
+
+    assert_eq!(claim_tx.output.len(), 2);
+    assert_eq!(claim_tx.output[1].value.to_sat(), 1_500);
+    assert_eq!(
+        claim_tx.output[1].script_pubkey,
+        extra_address.script_pubkey()
+    );
+    assert_eq!(
+        claim_tx.output[0].value.to_sat(),
+        utxos[0].1.value.to_sat() - absolute_fee - 1_500
+    );
+
+    test_framework
+        .as_ref()
+        .send_raw_transaction(&claim_tx)
+        .unwrap();
+    test_framework.generate_blocks(1);
+
+    let scan_result = test_framework
+        .as_ref()
+        .scan_tx_out_set_blocking(&[scan_request])
+        .unwrap();
+    assert_eq!(scan_result.unspents.len(), 0);
 }

--- a/tests/txs.rs
+++ b/tests/txs.rs
@@ -778,3 +778,154 @@ async fn btc_reverse_claim_multi_output() {
         .unwrap();
     assert_eq!(scan_result.unspents.len(), 0);
 }
+
+#[tokio::test]
+async fn btc_reverse_claim_multi_output_relative_fee() {
+    let (test_framework, scan_request, swap_tx, preimage, recvr_keypair, utxos) =
+        prepare_btc_claim();
+
+    let secp = Secp256k1::new();
+    let extra_keypair = Keypair::new(&secp, &mut thread_rng());
+    let extra_address = bitcoin::Address::p2wpkh(
+        &bitcoin::CompressedPublicKey(extra_keypair.public_key()),
+        bitcoin::Network::Regtest,
+    );
+
+    let swap_tx = swap_tx.with_additional_outputs(vec![(extra_address.clone(), 1_500)]);
+
+    let relative_fee = 1.0;
+    let claim_tx = swap_tx
+        .sign_claim(&recvr_keypair, &preimage, Fee::Relative(relative_fee), None)
+        .await
+        .unwrap();
+
+    let claim_tx_fee = utxos
+        .iter()
+        .fold(0, |acc, (_, out)| acc + out.value.to_sat())
+        - claim_tx
+            .output
+            .iter()
+            .map(|out| out.value.to_sat())
+            .sum::<u64>();
+    assert_eq!(relative_fee, claim_tx_fee as f64 / claim_tx.vsize() as f64);
+    // The additional output must be part of the weight the relative fee pays
+    // for: the single-output non-cooperative claim is 141 vB.
+    assert_eq!(claim_tx.output.len(), 2);
+    assert!(claim_tx_fee > 141);
+    assert_eq!(claim_tx.output[1].value.to_sat(), 1_500);
+
+    test_framework
+        .as_ref()
+        .send_raw_transaction(&claim_tx)
+        .unwrap();
+    test_framework.generate_blocks(1);
+
+    let scan_result = test_framework
+        .as_ref()
+        .scan_tx_out_set_blocking(&[scan_request])
+        .unwrap();
+    assert_eq!(scan_result.unspents.len(), 0);
+}
+
+#[tokio::test]
+async fn btc_submarine_refund_multi_output() {
+    let (test_framework, scan_request, swap_tx, sender_keypair, utxos) = prepare_btc_refund();
+
+    let secp = Secp256k1::new();
+    let extra_keypair = Keypair::new(&secp, &mut thread_rng());
+    let extra_address = bitcoin::Address::p2wpkh(
+        &bitcoin::CompressedPublicKey(extra_keypair.public_key()),
+        bitcoin::Network::Regtest,
+    );
+
+    let swap_tx = swap_tx.with_additional_outputs(vec![(extra_address.clone(), 2_000)]);
+
+    let absolute_fee = 1_000;
+    let refund_tx = swap_tx
+        .sign_refund(&sender_keypair, Fee::Absolute(absolute_fee), None)
+        .await
+        .unwrap();
+
+    // primary at index 0 with the remainder, additional output after it
+    assert_eq!(refund_tx.output.len(), 2);
+    assert_eq!(
+        refund_tx.output[0].value.to_sat(),
+        utxos[0].1.value.to_sat() - absolute_fee - 2_000
+    );
+    assert_eq!(refund_tx.output[1].value.to_sat(), 2_000);
+    assert_eq!(
+        refund_tx.output[1].script_pubkey,
+        extra_address.script_pubkey()
+    );
+
+    // Make the timelock matured and broadcast the spend
+    test_framework.generate_blocks(100);
+    test_framework
+        .as_ref()
+        .send_raw_transaction(&refund_tx)
+        .unwrap();
+    test_framework.generate_blocks(1);
+
+    let scan_result = test_framework
+        .as_ref()
+        .scan_tx_out_set_blocking(&[scan_request])
+        .unwrap();
+    assert_eq!(scan_result.unspents.len(), 0);
+}
+
+#[tokio::test]
+async fn lbtc_submarine_refund_multi_output() {
+    let (test_framework, swap_tx, sender_keypair, blinding_keypair, swap_addrs, utxo) =
+        prepare_lbtc_refund();
+
+    let secp = Secp256k1::new();
+
+    // An extra confidential destination with a locally known blinder, so the
+    // broadcast output can be unblinded and checked exactly.
+    let extra_spend = Keypair::new(&secp, &mut thread_rng());
+    let extra_blinder = elements::secp256k1_zkp::Keypair::new(&secp, &mut thread_rng());
+    let extra_address = Address::p2wpkh(
+        &bitcoin::PublicKey {
+            compressed: true,
+            inner: extra_spend.public_key(),
+        },
+        Some(extra_blinder.public_key()),
+        &elements::AddressParams::ELEMENTS,
+    );
+
+    let swap_tx = swap_tx.with_additional_outputs(vec![(extra_address.clone(), 900)]);
+
+    let absolute_fee = 1_000;
+    let refund_tx = swap_tx
+        .sign_refund(&sender_keypair, Fee::Absolute(absolute_fee), None, false)
+        .await
+        .unwrap();
+
+    // fee first, then primary and additional (refund output order)
+    assert_eq!(refund_tx.output.len(), 3);
+    assert!(refund_tx.output[0].is_fee());
+
+    let funding_secrets = utxo
+        .1
+        .unblind(&secp, blinding_keypair.secret_key())
+        .unwrap();
+    assert_eq!(refund_tx.fee_in(funding_secrets.asset), absolute_fee);
+
+    assert_eq!(
+        refund_tx.output[2].script_pubkey,
+        extra_address.script_pubkey()
+    );
+    let extra_secrets = refund_tx.output[2]
+        .unblind(&secp, extra_blinder.secret_key())
+        .unwrap();
+    assert_eq!(extra_secrets.value, 900);
+    assert_eq!(extra_secrets.asset, funding_secrets.asset);
+
+    // The regtest node accepting the transaction proves the confidential
+    // proofs and the balance (primary = input - fee - 900) are valid.
+    test_framework.generate_blocks(100);
+    test_framework.send_tx(&refund_tx);
+    test_framework.generate_blocks(1);
+
+    assert!(test_framework.fetch_utxo(&swap_addrs).is_none());
+}


### PR DESCRIPTION
## What

Adds the ability to pay **multiple outputs** from a swap claim or refund transaction, on both Liquid and Bitcoin.

- `LBtcSwapTx` / `BtcSwapTx` gain `additional_outputs: Vec<(Address, u64)>` and a `with_additional_outputs(...)` setter.
- The primary `output_address` receives the **remainder** (`input − fee − Σ additional`) and remains the **first payment output** (index 0 on claims; after the fee output on Liquid refunds, matching the existing refund output order). Additional outputs pay fixed amounts in the given order.
- `TransactionOptions::with_additional_outputs(Vec<(String, u64)>)` threads the destinations through `construct_claim` / `construct_refund` on both chains without breaking existing callers (new private field with `Default`).

## Validation policy

Construction enforces **balance, not policy**:

- Additional amounts are summed with `checked_add` (a wrapping sum cannot bypass the insufficient-funds guard) and must fit in `input − fee`.
- **Bitcoin** accepts zero-valued outputs and a zero primary remainder: zero outputs are consensus-valid, and dust/relay policy belongs to the broadcaster, not the constructor.
- **Liquid** rejects zero-valued outputs — including a zero primary — up front with a clear protocol error: every payment output is confidential and the rangeproof cannot prove less than 1 satoshi (`TxOut::RANGEPROOF_MIN_VALUE`).
- The wrapper conversions validate address strings before any signing: network match on Bitcoin (also fixes a pre-existing bug where `new_claim_with_utxo` computed but discarded its network check), address params + confidentiality on Liquid.

## Liquid CT details

`create_claim`/`create_refund` share a `create_payment_outputs` helper generalized to N blinded outputs:
- each output gets its own asset blinding factor, surjection proof and rangeproof;
- the **last** payment output balances the blinding equation via `ValueBlindingFactor::last` against the input and the explicit fee output;
- for a single output the arguments are identical to the previous code, so existing behavior is unchanged.

The cooperative (MuSig key-path) flows are untouched: they already sign whatever transaction was built and send the full serialized tx to Boltz for the partial signature, which commits to all outputs.

## Tests

- **Unit tests** fabricate a blinded funding utxo locally (no chain backend): multi-output Liquid claim and refund pass `verify_tx_amt_proofs` and every output unblinds to the expected value/asset/script_pubkey; boundary cases cover zero, one-satoshi, `[u64::MAX, 1]` overflow, zero-primary, insufficient funds and unblinded addresses on the appropriate chain.
- **Node-level broadcast tests** (`tests/txs.rs`): multi-output claims *and refunds* on both chains are broadcast to elementsd/bitcoind and accepted, including a Bitcoin multi-output claim with `Fee::Relative` proving the added output weight is paid for.
- **Boltz regtest suite** exercises the wrapper path end to end: reverse claims run a non-cooperative multi-output variant; submarine refunds and chain-swap claims pass additional outputs cooperatively, so **Boltz partial-signs complete multi-output transactions on both chains**. A shared helper asserts remainder math, output ordering, and unblinds Liquid outputs via the node's blinding keys.
- **Mainnet battle tests** against production Boltz (harness in `examples/multiout_battletest.rs`), all claimed cooperatively:
  - reverse swap `ZqxQ58hMEIxY` → Liquid claim [`0e845207…`](https://liquid.network/tx/0e8452074b12c1da65298ad75d8d5cc7f69b52733571ba26d346ecd414211345) (2 blinded outputs + explicit fee, confirmed)
  - chain swap L-BTC→BTC `FkNCgU6FJzfA` → Bitcoin claim [`7266da85…`](https://mempool.space/tx/7266da85a6e939adb19f49ac6de0507e16e9a564203edb4bef4a72e23de67c1d) (24,343 + 5,000 sat outputs)
  - chain swap BTC→L-BTC `5RHJIphzQrkN` → Liquid claim [`24a88229…`](https://liquid.network/tx/24a88229891a76044c5de985914fa7c629399007fffb0f81c78a4a6949511ba2)

All of `cargo fmt --check`, `make cargo-clippy`, `make wasm-clippy`, `make cargo-test` (73 passed), `make wasm-test`, `make cargo-regtest-test` (13/13 flows) and `make wasm-regtest-test` (7/7) pass.

## Compatibility notes

- **Must ship as 0.5.0** (changelog section included; version bump left to the release PR). Adding the struct field is source-breaking for code constructing `LBtcSwapTx`/`BtcSwapTx` with literal syntax; constructors initialize it to an empty vector and the wrapper API is backward compatible.
- Bitcoin single-output behavior with `input == fee` (zero primary) is unchanged; Liquid previously failed the same case deep inside blinding and now fails it with a clear protocol error.
- The insufficient-funds error strings changed slightly (they now mention additional outputs).
- FFI bindings (UniFFI/Python/Dart) intentionally do not expose `additional_outputs` yet — follow-up work.

